### PR TITLE
Made pipeline menu button color match other icons

### DIFF
--- a/photon-client/src/components/pipeline/CameraAndPipelineSelect.vue
+++ b/photon-client/src/components/pipeline/CameraAndPipelineSelect.vue
@@ -74,7 +74,7 @@
         >
           <template v-slot:activator="{ on }">
             <v-icon
-              color="white"
+              color="#c5c5c5"
               v-on="on"
             >
               menu


### PR DESCRIPTION
The pipeline menu icon was #ffffff, while the other icons were not. This PR makes it match all other icons.

Before
![before](https://i.imgur.com/6R6Bbfe.jpg)

After
![after](https://i.imgur.com/Deu1nmZ.jpg)