### PR TITLE
Calibration and metrics clean up.

### DIFF
--- a/photon-server/src/main/java/org/photonvision/common/configuration/HardwareConfig.java
+++ b/photon-server/src/main/java/org/photonvision/common/configuration/HardwareConfig.java
@@ -35,6 +35,7 @@ public class HardwareConfig {
     public final boolean ledsCanDim;
     public final ArrayList<Integer> ledPWMRange;
     public final String ledPWMSetRange;
+    public final int ledPWMFrequency;
     public final String ledDimCommand;
     public final String ledBlinkCommand;
 
@@ -54,6 +55,7 @@ public class HardwareConfig {
         ledSetCommand = "";
         ledsCanDim = false;
         ledPWMRange = new ArrayList<>();
+        ledPWMFrequency = 0;
         ledPWMSetRange = "";
         ledDimCommand = "";
 
@@ -81,6 +83,7 @@ public class HardwareConfig {
         this.ledsCanDim = (Boolean) hardware.get("ledsCanDim");
         this.ledPWMRange = (ArrayList<Integer>) hardware.get("ledPWMRange");
         this.ledPWMSetRange = (String) hardware.get("ledPWMSetRange");
+        this.ledPWMFrequency = (Integer) hardware.get("ledPWMFrequency");
         this.ledDimCommand = (String) hardware.get("ledDimCommand");
         this.ledBlinkCommand = (String) hardware.get("ledBlinkCommand");
 

--- a/photon-server/src/main/java/org/photonvision/common/hardware/GPIO/PiGPIO.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/GPIO/PiGPIO.java
@@ -35,10 +35,10 @@ public class PiGPIO extends GPIOBase {
         return Singleton.INSTANCE;
     }
 
-    public PiGPIO(int address, int value, int range) {
+    public PiGPIO(int address, int frequency, int range) {
         this.pin = address;
         try {
-            getPigpioDaemon().setPWMFrequency(this.pin, value);
+            getPigpioDaemon().setPWMFrequency(this.pin, frequency);
             getPigpioDaemon().setPWMRange(this.pin, range);
         } catch (PigpioException e) {
             logger.error("Could not set PWM settings on port " + this.pin);

--- a/photon-server/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -41,7 +41,9 @@ public class HardwareManager {
         hardwareConfig.ledPins.forEach(
                 pin -> {
                     if (Platform.isRaspberryPi()) {
-                        LEDs.put(pin, new PiGPIO(pin, 0, hardwareConfig.ledPWMRange.get(1)));
+                        LEDs.put(
+                                pin,
+                                new PiGPIO(pin, hardwareConfig.ledPWMFrequency, hardwareConfig.ledPWMRange.get(1)));
                     } else {
                         LEDs.put(pin, new CustomGPIO(pin));
                     }

--- a/photon-server/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -48,7 +48,7 @@ public class HardwareManager {
                 });
 
         // Start hardware metrics thread
-        MetricsPublisher.getInstance().startThread();
+        MetricsPublisher.getInstance().startTask();
     }
     /** Example: HardwareManager.getInstance().getPWM(port).dimLEDs(int dimValue); */
     public GPIOBase getGPIO(int pin) {

--- a/photon-server/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -24,12 +24,9 @@ import org.photonvision.common.hardware.GPIO.GPIOBase;
 import org.photonvision.common.hardware.GPIO.PiGPIO;
 import org.photonvision.common.hardware.metrics.MetricsBase;
 import org.photonvision.common.hardware.metrics.MetricsPublisher;
-import org.photonvision.common.logging.LogGroup;
-import org.photonvision.common.logging.Logger;
 
 public class HardwareManager {
     HardwareConfig hardwareConfig;
-    private static final Logger logger = new Logger(HardwareManager.class, LogGroup.General);
     private static final HashMap<Integer, GPIOBase> LEDs = new HashMap<>();
 
     public static HardwareManager getInstance() {

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -75,8 +75,8 @@ public abstract class MetricsBase {
                             + runCommand.getExitCode());
             return Double.NaN;
         } catch (IOException e) {
-            MetricsPublisher.getInstance().stopThread();
-            return Double.NaN;
+            MetricsPublisher.getInstance().stopTask();
+            return -1;
         }
     }
 }

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -62,9 +62,12 @@ public abstract class MetricsBase {
             logger.error(
                     "Command: \""
                             + command
-                            + "\" returned a non-double output \""
+                            + "\" returned a non-double output!"
+                            + "Output Received: "
                             + runCommand.getOutput()
-                            + "\"");
+                            + "\n"
+                            + "Standard Error: "
+                            + runCommand.getError());
             return Double.NaN;
         } catch (IOException e) {
             MetricsPublisher.getInstance().stopThread();

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -63,11 +63,16 @@ public abstract class MetricsBase {
                     "Command: \""
                             + command
                             + "\" returned a non-double output!"
-                            + "Output Received: "
+                            + "\nOutput Received: "
                             + runCommand.getOutput()
-                            + "\n"
-                            + "Standard Error: "
-                            + runCommand.getError());
+                            + "\nStandard Error: "
+                            + runCommand.getError()
+                            + "\nCommand completed: "
+                            + runCommand.isOutputCompleted()
+                            + "\nError completed: "
+                            + runCommand.isErrorCompleted()
+                            + "\nExit code: "
+                            + runCommand.getExitCode());
             return Double.NaN;
         } catch (IOException e) {
             MetricsPublisher.getInstance().stopThread();

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -17,7 +17,6 @@
 
 package org.photonvision.common.hardware.metrics;
 
-import java.util.Arrays;
 import org.photonvision.common.configuration.HardwareConfig;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -56,7 +56,7 @@ public abstract class MetricsBase {
 
     public static double execute(String command) {
         try {
-            runCommand.execute(command);
+            runCommand.executeBashCommand(command);
             return Double.parseDouble(runCommand.getOutput());
         } catch (NumberFormatException e) {
             logger.error(

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -59,7 +59,12 @@ public abstract class MetricsBase {
             runCommand.executeBashCommand(command);
             return Double.parseDouble(runCommand.getOutput());
         } catch (NumberFormatException e) {
-            logger.error("Command: " + command + " returned a non-double output!");
+            logger.error(
+                    "Command: \""
+                            + command
+                            + "\" returned a non-double output \""
+                            + runCommand.getOutput()
+                            + "\"");
             return Double.NaN;
         } catch (IOException e) {
             MetricsPublisher.getInstance().stopThread();

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -56,7 +56,7 @@ public abstract class MetricsBase {
 
     public static double execute(String command) {
         try {
-            runCommand.executeBashCommand(command);
+            runCommand.execute(command);
             return Double.parseDouble(runCommand.getOutput());
         } catch (NumberFormatException e) {
             logger.error(

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -17,6 +17,7 @@
 
 package org.photonvision.common.hardware.metrics;
 
+import java.io.IOException;
 import org.photonvision.common.configuration.HardwareConfig;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
@@ -57,10 +58,11 @@ public abstract class MetricsBase {
         try {
             runCommand.executeBashCommand(command);
             return Double.parseDouble(runCommand.getOutput());
-        } catch (Exception e) {
-            logger.info("This device does not support running bash commands.");
+        } catch (NumberFormatException e) {
+            logger.error("Command: " + command + " returned a non-double output!");
+            return Double.NaN;
+        } catch (IOException e) {
             MetricsPublisher.getInstance().stopThread();
-            logger.info("Stopped metrics thread.");
             return Double.NaN;
         }
     }

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -59,7 +59,9 @@ public abstract class MetricsBase {
             runCommand.executeBashCommand(command);
             return Double.parseDouble(runCommand.getOutput());
         } catch (Exception e) {
-            logger.error(Arrays.toString(e.getStackTrace()));
+            logger.info("This device does not support running bash commands.");
+            MetricsPublisher.getInstance().stopThread();
+            logger.info("Stopped metrics thread.");
             return Double.NaN;
         }
     }

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsPublisher.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsPublisher.java
@@ -22,12 +22,15 @@ import java.util.Timer;
 import java.util.TimerTask;
 import org.photonvision.common.dataflow.DataChangeService;
 import org.photonvision.common.dataflow.events.OutgoingUIEvent;
+import org.photonvision.common.logging.LogGroup;
+import org.photonvision.common.logging.Logger;
 import org.photonvision.server.UIUpdateType;
 
 public class MetricsPublisher {
     private final HashMap<String, Double> metrics;
     private final Thread metricsThread;
     private final Timer timer;
+    private static final Logger logger = new Logger(MetricsPublisher.class, LogGroup.General);
 
     public static MetricsPublisher getInstance() {
         return Singleton.INSTANCE;
@@ -43,26 +46,25 @@ public class MetricsPublisher {
 
         this.metricsThread =
                 new Thread(
-                        () -> {
-                            timer.schedule(
-                                    new TimerTask() {
-                                        public void run() {
-                                            metrics.put("cpuTemp", cpu.getTemp());
-                                            metrics.put("cpuUtil", cpu.getUtilization());
-                                            metrics.put("cpuMem", cpu.getMemory());
-                                            metrics.put("gpuTemp", gpu.getTemp());
-                                            metrics.put("gpuMem", gpu.getMemory());
-                                            metrics.put("ramUtil", ram.getUsedRam());
+                        () ->
+                                timer.schedule(
+                                        new TimerTask() {
+                                            public void run() {
+                                                metrics.put("cpuTemp", cpu.getTemp());
+                                                metrics.put("cpuUtil", cpu.getUtilization());
+                                                metrics.put("cpuMem", cpu.getMemory());
+                                                metrics.put("gpuTemp", gpu.getTemp());
+                                                metrics.put("gpuMem", gpu.getMemory());
+                                                metrics.put("ramUtil", ram.getUsedRam());
 
-                                            DataChangeService.getInstance()
-                                                    .publishEvent(
-                                                            new OutgoingUIEvent<>(
-                                                                    UIUpdateType.BROADCAST, "metrics", metrics, null));
-                                        }
-                                    },
-                                    0,
-                                    1000);
-                        });
+                                                DataChangeService.getInstance()
+                                                        .publishEvent(
+                                                                new OutgoingUIEvent<>(
+                                                                        UIUpdateType.BROADCAST, "metrics", metrics, null));
+                                            }
+                                        },
+                                        0,
+                                        1000));
     }
 
     public void startThread() {
@@ -71,6 +73,9 @@ public class MetricsPublisher {
 
     public void stopThread() {
         timer.cancel();
+        timer.purge();
+        metricsThread.interrupt();
+        logger.info("This device does not support running bash commands. Stopped metrics thread.");
     }
 
     private static class Singleton {

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsPublisher.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsPublisher.java
@@ -44,24 +44,24 @@ public class MetricsPublisher {
         this.metricsThread =
                 new Thread(
                         () -> {
-                                timer.schedule(
-                                        new TimerTask() {
-                                            public void run() {
-                                                metrics.put("cpuTemp", cpu.getTemp());
-                                                metrics.put("cpuUtil", cpu.getUtilization());
-                                                metrics.put("cpuMem", cpu.getMemory());
-                                                metrics.put("gpuTemp", gpu.getTemp());
-                                                metrics.put("gpuMem", gpu.getMemory());
-                                                metrics.put("ramUtil", ram.getUsedRam());
+                            timer.schedule(
+                                    new TimerTask() {
+                                        public void run() {
+                                            metrics.put("cpuTemp", cpu.getTemp());
+                                            metrics.put("cpuUtil", cpu.getUtilization());
+                                            metrics.put("cpuMem", cpu.getMemory());
+                                            metrics.put("gpuTemp", gpu.getTemp());
+                                            metrics.put("gpuMem", gpu.getMemory());
+                                            metrics.put("ramUtil", ram.getUsedRam());
 
-                                                DataChangeService.getInstance()
-                                                        .publishEvent(
-                                                                new OutgoingUIEvent<>(
-                                                                        UIUpdateType.BROADCAST, "metrics", metrics, null));
-                                            }
-                                        },
-                                        0,
-                                        1000);
+                                            DataChangeService.getInstance()
+                                                    .publishEvent(
+                                                            new OutgoingUIEvent<>(
+                                                                    UIUpdateType.BROADCAST, "metrics", metrics, null));
+                                        }
+                                    },
+                                    0,
+                                    1000);
                         });
     }
 
@@ -69,7 +69,7 @@ public class MetricsPublisher {
         metricsThread.start();
     }
 
-    public void stopThread(){
+    public void stopThread() {
         timer.cancel();
     }
 

--- a/photon-server/src/main/java/org/photonvision/vision/calibration/CameraCalibrationCoefficients.java
+++ b/photon-server/src/main/java/org/photonvision/vision/calibration/CameraCalibrationCoefficients.java
@@ -71,7 +71,9 @@ public class CameraCalibrationCoefficients implements Releasable {
     }
 
     @JsonIgnore
-    public double getStandardDeviation(){return standardDeviation;}
+    public double getStandardDeviation() {
+        return standardDeviation;
+    }
 
     @Override
     public void release() {

--- a/photon-server/src/main/java/org/photonvision/vision/calibration/CameraCalibrationCoefficients.java
+++ b/photon-server/src/main/java/org/photonvision/vision/calibration/CameraCalibrationCoefficients.java
@@ -38,16 +38,21 @@ public class CameraCalibrationCoefficients implements Releasable {
     @JsonProperty("perViewErrors")
     public final double[] perViewErrors;
 
+    @JsonProperty("standardDeviation")
+    public final double standardDeviation;
+
     @JsonCreator
     public CameraCalibrationCoefficients(
             @JsonProperty("resolution") Size resolution,
             @JsonProperty("cameraIntrinsics") JsonMat cameraIntrinsics,
             @JsonProperty("cameraExtrinsics") JsonMat cameraExtrinsics,
-            @JsonProperty("perViewErrors") double[] perViewErrors) {
+            @JsonProperty("perViewErrors") double[] perViewErrors,
+            @JsonProperty("standardDeviation") double standardDeviation) {
         this.resolution = resolution;
         this.cameraIntrinsics = cameraIntrinsics;
         this.cameraExtrinsics = cameraExtrinsics;
         this.perViewErrors = perViewErrors;
+        this.standardDeviation = standardDeviation;
     }
 
     @JsonIgnore
@@ -64,6 +69,9 @@ public class CameraCalibrationCoefficients implements Releasable {
     public double[] getPerViewErrors() {
         return perViewErrors;
     }
+
+    @JsonIgnore
+    public double getStandardDeviation(){return standardDeviation;}
 
     @Override
     public void release() {

--- a/photon-server/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
@@ -90,7 +90,7 @@ public class Calibrate3dPipe
                 new double[(int) perViewErrors.total() * perViewErrors.channels()];
         perViewErrors.get(0, 0, perViewErrorsArray);
 
-        //Standard deviation of results
+        // Standard deviation of results
         double stdDev = calculateSD(perViewErrorsArray);
         try {
             // Print calibration successful
@@ -111,23 +111,22 @@ public class Calibrate3dPipe
                 params.resolution, cameraMatrixMat, distortionCoefficientsMat, perViewErrorsArray, stdDev);
     }
 
-    //Calculate standard deviation of the RMS error of the snapshots
-    private static double calculateSD(double numArray[])
-    {
+    // Calculate standard deviation of the RMS error of the snapshots
+    private static double calculateSD(double numArray[]) {
         double sum = 0.0, standardDeviation = 0.0;
         int length = numArray.length;
 
-        for(double num : numArray) {
+        for (double num : numArray) {
             sum += num;
         }
 
-        double mean = sum/length;
+        double mean = sum / length;
 
-        for(double num: numArray) {
+        for (double num : numArray) {
             standardDeviation += Math.pow(num - mean, 2);
         }
 
-        return Math.sqrt(standardDeviation/length);
+        return Math.sqrt(standardDeviation / length);
     }
 
     public static class CalibratePipeParams {

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibration3dPipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibration3dPipeline.java
@@ -136,16 +136,16 @@ public class Calibration3dPipeline
         return calibrationOutput.output.perViewErrors;
     }
 
-    public void finishCalibration(){
+    public void finishCalibration() {
         numSnapshots = 0;
         boardSnapshots.clear();
     }
 
-    public boolean removeSnapshot(int index){
-        try{
+    public boolean removeSnapshot(int index) {
+        try {
             boardSnapshots.remove(index);
             return true;
-        }catch (ArrayIndexOutOfBoundsException e){
+        } catch (ArrayIndexOutOfBoundsException e) {
             logger.error("Could not remove snapshot at index " + index, e);
             return false;
         }

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibration3dPipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibration3dPipeline.java
@@ -20,6 +20,8 @@ package org.photonvision.vision.pipeline;
 import java.util.ArrayList;
 import java.util.List;
 import org.opencv.core.Mat;
+import org.photonvision.common.logging.LogGroup;
+import org.photonvision.common.logging.Logger;
 import org.photonvision.common.util.math.MathUtils;
 import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
 import org.photonvision.vision.frame.Frame;
@@ -32,6 +34,9 @@ import org.photonvision.vision.pipeline.result.CVPipelineResult;
 
 public class Calibration3dPipeline
         extends CVPipeline<CVPipelineResult, Calibration3dPipelineSettings> {
+
+    // For loggging
+    private static final Logger logger = new Logger(Calibration3dPipeline.class, LogGroup.General);
 
     // Only 2 pipes needed, one for finding the board corners and one for actually calibrating
     private final FindBoardCornersPipe findBoardCornersPipe = new FindBoardCornersPipe();
@@ -94,9 +99,6 @@ public class Calibration3dPipeline
             sumPipeNanosElapsed += calibrationOutput.nanosElapsed;
 
             calibrate = false;
-            numSnapshots = 0;
-            boardSnapshots.clear();
-
         } else if (takeSnapshot) {
             var hasBoard = findBoardCornersPipe.findBoardCorners(frame.image.getMat());
             if (hasBoard.getLeft()) {
@@ -132,6 +134,21 @@ public class Calibration3dPipeline
 
     public double[] perViewErrors() {
         return calibrationOutput.output.perViewErrors;
+    }
+
+    public void finishCalibration(){
+        numSnapshots = 0;
+        boardSnapshots.clear();
+    }
+
+    public boolean removeSnapshot(int index){
+        try{
+            boardSnapshots.remove(index);
+            return true;
+        }catch (ArrayIndexOutOfBoundsException e){
+            logger.error("Could not remove snapshot at index " + index, e);
+            return false;
+        }
     }
 
     public CameraCalibrationCoefficients cameraCalibrationCoefficients() {

--- a/photon-server/src/test/java/org/photonvision/hardware/HardwareConfigTest.java
+++ b/photon-server/src/test/java/org/photonvision/hardware/HardwareConfigTest.java
@@ -42,6 +42,7 @@ public class HardwareConfigTest {
                     config.ledPins.stream().mapToInt(i -> i).toArray(), new int[] {2, 13});
             Assertions.assertArrayEquals(
                     config.ledPWMRange.stream().mapToInt(i -> i).toArray(), new int[] {0, 100});
+            Assertions.assertEquals(config.ledPWMFrequency, 800);
 
             CustomGPIO.setConfig(config);
 

--- a/photon-server/src/test/java/org/photonvision/hardware/HardwareTest.java
+++ b/photon-server/src/test/java/org/photonvision/hardware/HardwareTest.java
@@ -36,6 +36,8 @@ public class HardwareTest {
         RAM ram = RAM.getInstance();
         GPU gpu = GPU.getInstance();
 
+        if (!Platform.isRaspberryPi()) return;
+
         System.out.println("Testing on platform: " + Platform.CurrentPlatform);
 
         System.out.println("Printing CPU Info:");

--- a/photon-server/src/test/java/org/photonvision/hardware/HardwareTest.java
+++ b/photon-server/src/test/java/org/photonvision/hardware/HardwareTest.java
@@ -36,8 +36,6 @@ public class HardwareTest {
         RAM ram = RAM.getInstance();
         GPU gpu = GPU.getInstance();
 
-        if (!Platform.isRaspberryPi()) return;
-
         System.out.println("Testing on platform: " + Platform.CurrentPlatform);
 
         System.out.println("Printing CPU Info:");

--- a/photon-server/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
+++ b/photon-server/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opencv.core.Mat;
 import org.opencv.core.Size;
-import org.opencv.highgui.HighGui;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.photonvision.common.util.TestUtils;
 import org.photonvision.vision.frame.Frame;
@@ -86,7 +85,7 @@ public class Calibrate3dPipeTest {
                             new Frame(
                                     new CVMat(Imgcodecs.imread(file.getAbsolutePath())),
                                     new FrameStaticProperties(640, 480, 60)));
-            HighGui.imshow("Calibration Output Frame", output.outputFrame.image.getMat());
+            TestUtils.showImage(output.outputFrame.image.getMat());
         }
 
         calibration3dPipeline.removeSnapshot(0);

--- a/photon-server/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
+++ b/photon-server/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
@@ -89,11 +89,13 @@ public class Calibrate3dPipeTest {
             HighGui.imshow("Calibration Output Frame", output.outputFrame.image.getMat());
         }
 
+        calibration3dPipeline.removeSnapshot(0);
         calibration3dPipeline.startCalibration();
         calibration3dPipeline.run(
                 new Frame(
                         new CVMat(Imgcodecs.imread(directoryListing[0].getAbsolutePath())),
                         new FrameStaticProperties(640, 480, 60)));
+        calibration3dPipeline.finishCalibration();
         System.out.println(
                 "Per View Errors: " + Arrays.toString(calibration3dPipeline.perViewErrors()));
         System.out.println(
@@ -102,5 +104,9 @@ public class Calibrate3dPipeTest {
         System.out.println(
                 "Camera Extrinsics : "
                         + calibration3dPipeline.cameraCalibrationCoefficients().cameraExtrinsics.toString());
+        System.out.println(
+                "Standard Deviation: " + calibration3dPipeline.cameraCalibrationCoefficients().standardDeviation);
+        System.out.println(
+                "Mean: " + Arrays.stream(calibration3dPipeline.perViewErrors()).average().toString());
     }
 }

--- a/photon-server/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
+++ b/photon-server/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
@@ -105,7 +105,8 @@ public class Calibrate3dPipeTest {
                 "Camera Extrinsics : "
                         + calibration3dPipeline.cameraCalibrationCoefficients().cameraExtrinsics.toString());
         System.out.println(
-                "Standard Deviation: " + calibration3dPipeline.cameraCalibrationCoefficients().standardDeviation);
+                "Standard Deviation: "
+                        + calibration3dPipeline.cameraCalibrationCoefficients().standardDeviation);
         System.out.println(
                 "Mean: " + Arrays.stream(calibration3dPipeline.perViewErrors()).average().toString());
     }

--- a/photon-server/src/test/resources/hardware/HardwareConfig.json
+++ b/photon-server/src/test/resources/hardware/HardwareConfig.json
@@ -7,6 +7,7 @@
     "ledSetCommand": "",
     "ledsCanDim": true,
     "ledPWMRange": [0, 100],
+    "ledPWMFrequency" : 800,
     "ledPWMSetRange": "",
     "ledDimCommand": "",
     "ledBlinkCommand": ""


### PR DESCRIPTION
This PR addresses a few things:
- Metrics thread now stops if running bash commands throws errors, this prevents logger from spamming errors
- Calibration pipeline now allows you to remove snapshots
- Calibration stores stdDeviation of the per view errors
- Snapshots are not cleared until ``finishCalibration()`` is called