### PR TITLE
Never overwrite hardware config file

### DIFF
--- a/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -163,11 +163,6 @@ public class ConfigManager {
         FileUtils.deleteDirectory(camerasFolder.toPath());
 
         try {
-            JacksonUtils.serialize(hardwareConfigFile.toPath(), config.getHardwareConfig());
-        } catch (IOException e) {
-            logger.error("Could not save hardware config!", e);
-        }
-        try {
             JacksonUtils.serialize(networkConfigFile.toPath(), config.getNetworkConfig());
         } catch (IOException e) {
             logger.error("Could not save network config!", e);

--- a/photon-server/src/test/java/org/photonvision/common/configuration/ConfigTest.java
+++ b/photon-server/src/test/java/org/photonvision/common/configuration/ConfigTest.java
@@ -80,9 +80,6 @@ public class ConfigTest {
         Assertions.assertTrue(camConfDir.exists(), "TestCamera config folder not found!");
 
         Assertions.assertTrue(
-                Files.exists(Path.of(configMgr.configDirectoryFile.toString(), "hardwareConfig.json")),
-                "hardwareConfig.json file not found!");
-        Assertions.assertTrue(
                 Files.exists(Path.of(configMgr.configDirectoryFile.toString(), "networkSettings.json")),
                 "networkSettings.json file not found!");
     }


### PR DESCRIPTION
Because the hardware config should never be changed, we should never write to the file from within the program.