### PR TITLE
Improve Pi Non-GPU-accel exposure

### DIFF
--- a/photon-client/src/views/PipelineViews/InputTab.vue
+++ b/photon-client/src/views/PipelineViews/InputTab.vue
@@ -5,6 +5,7 @@
       name="Exposure"
       min="0"
       max="100"
+      step="0.1"
       tooltip="Directly controls how much light is allowed to fall onto the sensor, which affects brightness"
       :slider-cols="largeBox"
       @input="handlePipelineData('cameraExposure')"
@@ -87,10 +88,10 @@
             },
             cameraExposure: {
                 get() {
-                    return parseInt(this.$store.getters.currentPipelineSettings.cameraExposure);
+                    return parseFloat(this.$store.getters.currentPipelineSettings.cameraExposure);
                 },
                 set(val) {
-                    this.$store.commit("mutatePipeline", {"cameraExposure": parseInt(val)});
+                    this.$store.commit("mutatePipeline", {"cameraExposure": parseFloat(val)});
                 }
             },
             cameraBrightness: {

--- a/photon-server/src/main/java/org/photonvision/vision/camera/FileVisionSource.java
+++ b/photon-server/src/main/java/org/photonvision/vision/camera/FileVisionSource.java
@@ -89,7 +89,7 @@ public class FileVisionSource implements VisionSource {
         }
 
         @Override
-        public void setExposure(int exposure) {}
+        public void setExposure(double exposure) {}
 
         @Override
         public void setBrightness(int brightness) {}

--- a/photon-server/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-server/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -122,7 +122,7 @@ public class USBCameraSource implements VisionSource {
 
                 } else {
                     scaledExposure = (int) Math.round(exposure);
-                    logger.info("Setting camera exposure to " + Integer.toString(scaledExposure));
+                    logger.debug("Setting camera exposure to " + Integer.toString(scaledExposure));
                     camera.setExposureManual(scaledExposure);
                     camera.setExposureManual(scaledExposure);
                 }

--- a/photon-server/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-server/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -116,7 +116,7 @@ public class USBCameraSource implements VisionSource {
 
                     scaledExposure =
                             (int) Math.round(timeToPiCamV2RawExposure(pctToExposureTimeUs(exposure)));
-                    logger.info("Setting camera raw exposure to " + Integer.toString(scaledExposure));
+                    logger.debug("Setting camera raw exposure to " + Integer.toString(scaledExposure));
                     camera.getProperty("raw_exposure_time_absolute").set(scaledExposure);
                     camera.getProperty("raw_exposure_time_absolute").set(scaledExposure);
 

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/CVPipelineSettings.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/CVPipelineSettings.java
@@ -39,7 +39,7 @@ public class CVPipelineSettings implements Cloneable {
     public ImageFlipMode inputImageFlipMode = ImageFlipMode.NONE;
     public ImageRotationMode inputImageRotationMode = ImageRotationMode.DEG_0;
     public String pipelineNickname = "New Pipeline";
-    public int cameraExposure = 50;
+    public double cameraExposure = 50;
     public int cameraBrightness = 50;
     public int cameraGain = 50;
     public int cameraVideoModeIndex = 0;

--- a/photon-server/src/main/java/org/photonvision/vision/processes/VisionSourceSettables.java
+++ b/photon-server/src/main/java/org/photonvision/vision/processes/VisionSourceSettables.java
@@ -42,7 +42,7 @@ public abstract class VisionSourceSettables {
         return configuration;
     }
 
-    public abstract void setExposure(int exposure);
+    public abstract void setExposure(double exposure);
 
     public abstract void setBrightness(int brightness);
 

--- a/photon-server/src/test/java/org/photonvision/vision/processes/VisionModuleManagerTest.java
+++ b/photon-server/src/test/java/org/photonvision/vision/processes/VisionModuleManagerTest.java
@@ -69,7 +69,7 @@ public class VisionModuleManagerTest {
         }
 
         @Override
-        public void setExposure(int exposure) {}
+        public void setExposure(double exposure) {}
 
         @Override
         public void setBrightness(int brightness) {}


### PR DESCRIPTION
Change exposure setters to accept a floating point input (rather than integer)
Update the UI to change exposure in increments of 0.1 (rather than 1.0)
Update quirky PI camera logic to use the raw_ interface with scaling/offset logic matching the GPU-accelerated pi3 camera logic from Delcan.
Added logic to disable auto-white-balance in the PI camera, which should yeild more consistent vision processing results.


Split out from https://github.com/PhotonVision/photonvision/pull/146