### PR TITLE
Single Config-file Upload Support

### DIFF
--- a/photon-client/src/views/SettingsViews/General.vue
+++ b/photon-client/src/views/SettingsViews/General.vue
@@ -89,7 +89,7 @@
     <input
       ref="importSettings"
       type="file"
-      accept=".zip"
+      accept=".zip, .json"
       style="display: none;"
 
       @change="readImportedSettings"
@@ -153,11 +153,23 @@ export default {
                     text: "Settings imported successfully! Program will now exit...",
                 };
                 this.snack = true;
-            }).catch(() => {
-                this.snackbar = {
-                    color: "success",
-                    text: "Settings imported successfully! Program will now exit...",
-                };
+            }).catch(err => {
+                if (err.response) {
+                  this.snackbar = {
+                      color: "error",
+                      text: "Error while uploading settings file! Could not process provided file.",
+                  };               
+                } else if (err.request) {
+                  this.snackbar = {
+                      color: "error",
+                      text: "Error while uploading settings file! No respond to upload attempt.",
+                  };
+                } else {
+                  this.snackbar = {
+                      color: "error",
+                      text: "Error while uploading settings file!",
+                  };
+                }
                 this.snack = true;
             });
         },

--- a/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -71,6 +71,8 @@ public class ConfigManager {
         }
     }
 
+    //TODO: Make more things like saveUploadedSettingsZip, but specific to the different config files.
+
     public PhotonConfiguration getConfig() {
         return config;
     }

--- a/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -395,7 +395,6 @@ public class ConfigManager {
         FileUtils.copyFile(uploadPath, this.getNetworkConfigFile());
     }
 
-
     public void requestSave() {
         logger.trace("Requesting save...");
         saveRequestTimestamp = System.currentTimeMillis();

--- a/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-server/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -40,6 +40,10 @@ public class ConfigManager {
     private static final Logger logger = new Logger(ConfigManager.class, LogGroup.General);
     private static ConfigManager INSTANCE;
 
+    public static final String HW_CFG_FNAME = "hardwareConfig.json";
+    public static final String HW_SET_FNAME = "hardwareSettings.json";
+    public static final String NET_SET_FNAME = "networkSettings.json";
+
     private PhotonConfiguration config;
     private final File hardwareConfigFile;
     private final File hardwareSettingsFile;
@@ -71,8 +75,6 @@ public class ConfigManager {
         }
     }
 
-    //TODO: Make more things like saveUploadedSettingsZip, but specific to the different config files.
-
     public PhotonConfiguration getConfig() {
         return config;
     }
@@ -84,11 +86,11 @@ public class ConfigManager {
     ConfigManager(Path configDirectoryFile) {
         this.configDirectoryFile = new File(configDirectoryFile.toUri());
         this.hardwareConfigFile =
-                new File(Path.of(configDirectoryFile.toString(), "hardwareConfig.json").toUri());
+                new File(Path.of(configDirectoryFile.toString(), HW_CFG_FNAME).toUri());
         this.hardwareSettingsFile =
-                new File(Path.of(configDirectoryFile.toString(), "hardwareSettings.json").toUri());
+                new File(Path.of(configDirectoryFile.toString(), HW_SET_FNAME).toUri());
         this.networkConfigFile =
-                new File(Path.of(configDirectoryFile.toString(), "networkSettings.json").toUri());
+                new File(Path.of(configDirectoryFile.toString(), NET_SET_FNAME).toUri());
         this.camerasFolder = new File(Path.of(configDirectoryFile.toString(), "cameras").toUri());
 
         TimedTaskManager.getInstance().addTask("ConfigManager", this::checkSaveAndWrite, 1000);
@@ -365,6 +367,34 @@ public class ConfigManager {
         if (!imgFilePath.exists()) imgFilePath.mkdirs();
         return imgFilePath.toPath();
     }
+
+    public Path getHardwareConfigFile() {
+        return this.hardwareConfigFile.toPath();
+    }
+
+    public Path getHardwareSettingsFile() {
+        return this.hardwareSettingsFile.toPath();
+    }
+
+    public Path getNetworkConfigFile() {
+        return this.networkConfigFile.toPath();
+    }
+
+    public void saveUploadedHardwareConfig(Path uploadPath) {
+        FileUtils.deleteFile(this.getHardwareConfigFile());
+        FileUtils.copyFile(uploadPath, this.getHardwareConfigFile());
+    }
+
+    public void saveUploadedHardwareSettings(Path uploadPath) {
+        FileUtils.deleteFile(this.getHardwareSettingsFile());
+        FileUtils.copyFile(uploadPath, this.getHardwareSettingsFile());
+    }
+
+    public void saveUploadedNetworkConfig(Path uploadPath) {
+        FileUtils.deleteFile(this.getNetworkConfigFile());
+        FileUtils.copyFile(uploadPath, this.getNetworkConfigFile());
+    }
+
 
     public void requestSave() {
         logger.trace("Requesting save...");

--- a/photon-server/src/main/java/org/photonvision/common/util/file/FileUtils.java
+++ b/photon-server/src/main/java/org/photonvision/common/util/file/FileUtils.java
@@ -58,7 +58,7 @@ public class FileUtils {
         }
     }
 
-    public static void deleteFile(Path path){
+    public static void deleteFile(Path path) {
         try {
             Files.delete(path);
         } catch (IOException e) {
@@ -66,7 +66,7 @@ public class FileUtils {
         }
     }
 
-    public static void copyFile(Path src, Path dst){
+    public static void copyFile(Path src, Path dst) {
         try {
             Files.copy(src, dst);
         } catch (IOException e) {

--- a/photon-server/src/main/java/org/photonvision/common/util/file/FileUtils.java
+++ b/photon-server/src/main/java/org/photonvision/common/util/file/FileUtils.java
@@ -58,6 +58,22 @@ public class FileUtils {
         }
     }
 
+    public static void deleteFile(Path path){
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            logger.error("Exception deleting file " + path + "!", e);
+        }
+    }
+
+    public static void copyFile(Path src, Path dst){
+        try {
+            Files.copy(src, dst);
+        } catch (IOException e) {
+            logger.error("Exception copying file " + src + " to " + dst + "!", e);
+        }
+    }
+
     public static void setFilePerms(Path path) throws IOException {
         if (!Platform.CurrentPlatform.isWindows()) {
             File thisFile = path.toFile();

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -57,12 +57,23 @@ public class RequestHandler {
             } catch (IOException e) {
                 logger.error("Exception uploading settings file!");
                 e.printStackTrace();
+                return;
             }
-            ConfigManager.saveUploadedSettingsZip(tempZipPath);
+
+            if(file.getExtension().contains("zip")){
+                ConfigManager.saveUploadedSettingsZip(tempZipPath);
+            } else if(file.getFilename() == "hardwareConfig.json") {
+                
+            } else {
+                logger.error("Couldn't apply provided settings file!");
+                ctx.status(500);
+                return;
+            }
+
             ctx.status(200);
             logger.info("Settings uploaded, going down for restart.");
-
             restartProgram(ctx);
+
         } else {
             logger.error("Couldn't read uploaded settings ZIP! Ignoring.");
             ctx.status(500);

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.photonvision.common.configuration.ConfigManager;
-import org.photonvision.common.configuration.HardwareConfig;
 import org.photonvision.common.configuration.NetworkConfig;
 import org.photonvision.common.dataflow.networktables.NetworkTablesManager;
 import org.photonvision.common.hardware.HardwareManager;
@@ -51,7 +50,7 @@ public class RequestHandler {
         var file = ctx.uploadedFile("zipData");
         if (file != null) {
 
-            //Copy the file from the client to a temporary location
+            // Copy the file from the client to a temporary location
             var tempFilePath =
                     new File(Path.of(System.getProperty("java.io.tmpdir"), file.getFilename()).toString());
             tempFilePath.getParentFile().mkdirs();
@@ -64,28 +63,34 @@ public class RequestHandler {
             }
 
             // Process the file by its extension
-            if(file.getExtension().contains("zip")){
-                //.zip files are assumed to be full packages of configuration files
+            if (file.getExtension().contains("zip")) {
+                // .zip files are assumed to be full packages of configuration files
                 logger.debug("Processing uploaded settings zip " + file.getFilename());
                 ConfigManager.saveUploadedSettingsZip(tempFilePath);
 
-            } else if(file.getFilename().equals(ConfigManager.HW_CFG_FNAME)) {
-                //Filenames matching the hardware config .json file are assumed to be hardware config .json's
+            } else if (file.getFilename().equals(ConfigManager.HW_CFG_FNAME)) {
+                // Filenames matching the hardware config .json file are assumed to be
+                // hardware config .json's
                 logger.debug("Processing uploaded hardware config " + file.getFilename());
                 ConfigManager.getInstance().saveUploadedHardwareConfig(tempFilePath.toPath());
 
-            } else if(file.getFilename().equals(ConfigManager.HW_SET_FNAME)) {
-                //Filenames matching the hardware settings .json file are assumed to be hardware settings .json's
+            } else if (file.getFilename().equals(ConfigManager.HW_SET_FNAME)) {
+                // Filenames matching the hardware settings .json file are assumed to be
+                // hardware settings.json's
                 logger.debug("Processing uploaded hardware settings" + file.getFilename());
                 ConfigManager.getInstance().saveUploadedHardwareSettings(tempFilePath.toPath());
 
-            } else if(file.getFilename().equals(ConfigManager.NET_SET_FNAME)) {
-                //Filenames matching the network config .json file are assumed to be network config .json's
+            } else if (file.getFilename().equals(ConfigManager.NET_SET_FNAME)) {
+                // Filenames matching the network config .json file are assumed to be
+                // network config .json's
                 logger.debug("Processing uploaded network config " + file.getFilename());
                 ConfigManager.getInstance().saveUploadedNetworkConfig(tempFilePath.toPath());
 
             } else {
-                logger.error("Couldn't apply provided settings file - did not recognize " + file.getFilename() + " as a supported file.");
+                logger.error(
+                        "Couldn't apply provided settings file - did not recognize "
+                                + file.getFilename()
+                                + " as a supported file.");
                 ctx.status(500);
                 return;
             }


### PR DESCRIPTION
Added logic which allows uploading some individual .json hardware config files.

Done primarily to allow me to manipulate the LED hardware settings without needing to SSH into the board and edit manually. Backward compatible, previous zip functionality has been preserved.

For now, I think I'm gonna punt on allowing specific subsets of files (ex: for a camera) - for larger sets, the zip file methodology is probably better.