### PR TITLE
Remove Erode/Dilate from backend and UI

### DIFF
--- a/photon-client/src/store/index.js
+++ b/photon-client/src/store/index.js
@@ -58,8 +58,6 @@ export default new Vuex.Store({
                     hsvHue: [0, 15],
                     hsvSaturation: [0, 15],
                     hsvValue: [0, 25],
-                    erode: false,
-                    dilate: false,
                     contourArea: [0, 12],
                     contourRatio: [0, 12],
                     contourFullness: [0, 12],

--- a/photon-client/src/views/PipelineViews/ThresholdTab.vue
+++ b/photon-client/src/views/PipelineViews/ThresholdTab.vue
@@ -84,33 +84,16 @@
         </v-btn>
       </template>
     </v-row>
-    <v-divider class="mb-3" />
-    <CVswitch
-      v-model="erode"
-      name="Erode"
-      tooltip="Removes pixels around the edges of white areas in the thresholded image"
-      @input="handlePipelineData('erode')"
-      @rollback="e => rollback('erode',e)"
-    />
-    <CVswitch
-      v-model="dilate"
-      name="Dilate"
-      tooltip="Adds pixels around the edges of white areas in the thresholded image"
-      @input="handlePipelineData('dilate')"
-      @rollback="e => rollback('dilate',e)"
-    />
   </div>
 </template>
 
 <script>
     import CVrangeSlider from '../../components/common/cv-range-slider'
-    import CVswitch from '../../components/common/cv-switch'
-
+    
     export default {
         name: 'Threshold',
         components: {
-            CVrangeSlider,
-            CVswitch
+            CVrangeSlider
         },
         // eslint-disable-next-line vue/require-prop-types
         props: ['value'],
@@ -145,23 +128,7 @@
                 set(val) {
                     this.$store.commit("mutatePipeline", {"hsvValue": val})
                 }
-            },
-            erode: {
-                get() {
-                    return this.$store.getters.currentPipelineSettings.erode
-                },
-                set(val) {
-                    this.$store.commit("mutatePipeline", {"erode": val});
-                }
-            },
-            dilate: {
-                get() {
-                    return this.$store.getters.currentPipelineSettings.dilate
-                },
-                set(val) {
-                    this.$store.commit("mutatePipeline", {"dilate": val});
-                }
-            },
+            }
         },
         mounted: function () {
             const self = this;

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/AdvancedPipelineSettings.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/AdvancedPipelineSettings.java
@@ -39,9 +39,6 @@ public class AdvancedPipelineSettings extends CVPipelineSettings {
     public boolean outputShouldDraw = true;
     public boolean outputShowMultipleTargets = false;
 
-    public boolean erode = false;
-    public boolean dilate = false;
-
     public DoubleCouple contourArea = new DoubleCouple(0.0, 100.0);
     public DoubleCouple contourRatio = new DoubleCouple(0.0, 20.0);
     public DoubleCouple contourFullness = new DoubleCouple(0.0, 100.0);
@@ -79,8 +76,6 @@ public class AdvancedPipelineSettings extends CVPipelineSettings {
         AdvancedPipelineSettings that = (AdvancedPipelineSettings) o;
         return outputShouldDraw == that.outputShouldDraw
                 && outputShowMultipleTargets == that.outputShowMultipleTargets
-                && erode == that.erode
-                && dilate == that.dilate
                 && contourSpecklePercentage == that.contourSpecklePercentage
                 && Double.compare(that.offsetDualPointA.x, offsetDualPointA.x) == 0
                 && Double.compare(that.offsetDualPointA.y, offsetDualPointA.y) == 0
@@ -110,8 +105,6 @@ public class AdvancedPipelineSettings extends CVPipelineSettings {
                 hsvValue,
                 outputShouldDraw,
                 outputShowMultipleTargets,
-                erode,
-                dilate,
                 contourArea,
                 contourRatio,
                 contourFullness,

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipelineSettings.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipelineSettings.java
@@ -62,6 +62,9 @@ public class ColoredShapePipelineSettings extends AdvancedPipelineSettings {
     public int cornerDetectionSideCount = 4;
     public double cornerDetectionAccuracyPercentage = 10;
 
+    public boolean erode = false;
+    public boolean dilate = false;
+
     public ColoredShapePipelineSettings() {
         super();
         pipelineType = PipelineType.ColoredShape;
@@ -96,7 +99,9 @@ public class ColoredShapePipelineSettings extends AdvancedPipelineSettings {
                 && Objects.equals(cameraCalibration, that.cameraCalibration)
                 && Objects.equals(targetModel, that.targetModel)
                 && Objects.equals(cameraPitch, that.cameraPitch)
-                && cornerDetectionStrategy == that.cornerDetectionStrategy;
+                && cornerDetectionStrategy == that.cornerDetectionStrategy
+                && erode == that.erode
+                && dilate == that.dilate;
     }
 
     @Override
@@ -125,6 +130,8 @@ public class ColoredShapePipelineSettings extends AdvancedPipelineSettings {
                 cornerDetectionUseConvexHulls,
                 cornerDetectionExactSideCount,
                 cornerDetectionSideCount,
-                cornerDetectionAccuracyPercentage);
+                cornerDetectionAccuracyPercentage,
+                erode,
+                dilate);
     }
 }

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/PipelineProfiler.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/PipelineProfiler.java
@@ -28,25 +28,12 @@ public class PipelineProfiler {
             new Logger(ColoredShapePipeline.class, LogGroup.VisionModule);
 
     /**
-    * Indices for Reflective profiling 
-    * 0  - rotateImagePipe 
-    * 1  - inputCopy (not a pipe) 
-    * 2  - hsvPipe 
-    * 3  - findContoursPipe  
-    * 4  - speckleRejectPipe  
-    * 5  - filterContoursPipe  
-    * 6  - groupContoursPipe  
-    * 7  - sortContoursPipe  
-    * 8  - collect2dTargetsPipe  
-    * 9  - cornerDetectionPipe 
-    * 10 - solvePNPPipe (OPTIONAL) 
-    * 11 - outputMatPipe (OPTIONAL) 
-    * 12 - draw2dCrosshairPipe (on input)
-    * 13 - draw2dCrosshairPipe (on output) 
-    * 14 - draw2dTargetsPipe (on input) 
-    * 15 - draw2dTargetsPipe (on output) 
-    * 16 - draw3dTargetsPipe (OPTIONAL, on input) 
-    * 17 - draw3dTargetsPipe (OPTIONAL, on output)
+    * Indices for Reflective profiling 0 - rotateImagePipe 1 - inputCopy (not a pipe) 2 - hsvPipe 3 -
+    * findContoursPipe 4 - speckleRejectPipe 5 - filterContoursPipe 6 - groupContoursPipe 7 -
+    * sortContoursPipe 8 - collect2dTargetsPipe 9 - cornerDetectionPipe 10 - solvePNPPipe (OPTIONAL)
+    * 11 - outputMatPipe (OPTIONAL) 12 - draw2dCrosshairPipe (on input) 13 - draw2dCrosshairPipe (on
+    * output) 14 - draw2dTargetsPipe (on input) 15 - draw2dTargetsPipe (on output) 16 -
+    * draw3dTargetsPipe (OPTIONAL, on input) 17 - draw3dTargetsPipe (OPTIONAL, on output)
     */
     private static final String[] ReflectivePipeNames =
             new String[] {
@@ -71,7 +58,6 @@ public class PipelineProfiler {
             };
 
     public static final int ReflectivePipeCount = ReflectivePipeNames.length;
-
 
     protected static String getReflectiveProfileString(long[] nanos) {
         if (nanos.length != ReflectivePipeCount) {

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/PipelineProfiler.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/PipelineProfiler.java
@@ -27,22 +27,31 @@ public class PipelineProfiler {
     private static final Logger coloredShapeLogger =
             new Logger(ColoredShapePipeline.class, LogGroup.VisionModule);
 
-    public static final int ReflectivePipeCount = 19;
-
     /**
-    * Indices for Reflective profiling 0 - rotateImagePipe 1 - inputCopy (not a pipe) 2 -
-    * erodeDilatePipe 3 - hsvPipe 4 - findContoursPipe 5 - speckleRejectPipe 6 - filterContoursPipe 7
-    * - groupContoursPipe 8 - sortContoursPipe 9 - collect2dTargetsPipe 10 - cornerDetectionPipe
-    * (OPTIONAL) 11 - solvePNPPipe (OPTIONAL) 12 - outputMatPipe 13 - draw2dCrosshairPipe (on input)
-    * 14 - draw2dCrosshairPipe (on output) 15 - draw2dTargetsPipe (on input) 16 - draw2dTargetsPipe
-    * (on output) 17 - draw3dTargetsPipe (OPTIONAL, on input) 18 - draw3dTargetsPipe (OPTIONAL, on
-    * output)
+    * Indices for Reflective profiling 
+    * 0  - rotateImagePipe 
+    * 1  - inputCopy (not a pipe) 
+    * 2  - hsvPipe 
+    * 3  - findContoursPipe  
+    * 4  - speckleRejectPipe  
+    * 5  - filterContoursPipe  
+    * 6  - groupContoursPipe  
+    * 7  - sortContoursPipe  
+    * 8  - collect2dTargetsPipe  
+    * 9  - cornerDetectionPipe 
+    * 10 - solvePNPPipe (OPTIONAL) 
+    * 11 - outputMatPipe (OPTIONAL) 
+    * 12 - draw2dCrosshairPipe (on input)
+    * 13 - draw2dCrosshairPipe (on output) 
+    * 14 - draw2dTargetsPipe (on input) 
+    * 15 - draw2dTargetsPipe (on output) 
+    * 16 - draw3dTargetsPipe (OPTIONAL, on input) 
+    * 17 - draw3dTargetsPipe (OPTIONAL, on output)
     */
     private static final String[] ReflectivePipeNames =
             new String[] {
                 "RotateImage",
                 "InputCopy",
-                "ErodeDilate",
                 "HSV",
                 "FindContours",
                 "SpeckleReject",
@@ -60,6 +69,9 @@ public class PipelineProfiler {
                 "Draw3dTargetsInput",
                 "Draw3dTargetsOutput",
             };
+
+    public static final int ReflectivePipeCount = ReflectivePipeNames.length;
+
 
     protected static String getReflectiveProfileString(long[] nanos) {
         if (nanos.length != ReflectivePipeCount) {

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/ReflectivePipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/ReflectivePipeline.java
@@ -55,6 +55,7 @@ public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectiveP
     private final CalculateFPSPipe calculateFPSPipe = new CalculateFPSPipe();
 
     private final Mat rawInputMat = new Mat();
+    private final Mat preProcInputMat = new Mat();
     private final long[] pipeProfileNanos = new long[PipelineProfiler.ReflectivePipeCount];
 
     public ReflectivePipeline() {
@@ -177,14 +178,16 @@ public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectiveP
         // TODO: make this a pipe?
         long inputCopyStartNanos = System.nanoTime();
         rawInputMat.release();
+        preProcInputMat.release();
         frame.image.getMat().copyTo(rawInputMat);
+        frame.image.getMat().copyTo(preProcInputMat);
         long inputCopyElapsedNanos = System.nanoTime() - inputCopyStartNanos;
         sumPipeNanosElapsed += pipeProfileNanos[1] = inputCopyElapsedNanos;
 
-        var erodeDilateResult = erodeDilatePipe.run(rawInputMat);
+        var erodeDilateResult = erodeDilatePipe.run(preProcInputMat);
         sumPipeNanosElapsed += pipeProfileNanos[2] = erodeDilateResult.nanosElapsed;
 
-        CVPipeResult<Mat> hsvPipeResult = hsvPipe.run(rawInputMat);
+        CVPipeResult<Mat> hsvPipeResult = hsvPipe.run(preProcInputMat);
         sumPipeNanosElapsed += hsvPipeResult.nanosElapsed;
         pipeProfileNanos[3] = pipeProfileNanos[3] = hsvPipeResult.nanosElapsed;
 

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/ReflectivePipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/ReflectivePipeline.java
@@ -38,7 +38,6 @@ import org.photonvision.vision.target.TrackedTarget;
 public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectivePipelineSettings> {
 
     private final RotateImagePipe rotateImagePipe = new RotateImagePipe();
-    private final ErodeDilatePipe erodeDilatePipe = new ErodeDilatePipe();
     private final HSVPipe hsvPipe = new HSVPipe();
     private final FindContoursPipe findContoursPipe = new FindContoursPipe();
     private final SpeckleRejectPipe speckleRejectPipe = new SpeckleRejectPipe();
@@ -55,7 +54,6 @@ public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectiveP
     private final CalculateFPSPipe calculateFPSPipe = new CalculateFPSPipe();
 
     private final Mat rawInputMat = new Mat();
-    private final Mat preProcInputMat = new Mat();
     private final long[] pipeProfileNanos = new long[PipelineProfiler.ReflectivePipeCount];
 
     public ReflectivePipeline() {
@@ -80,11 +78,6 @@ public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectiveP
         RotateImagePipe.RotateImageParams rotateImageParams =
                 new RotateImagePipe.RotateImageParams(settings.inputImageRotationMode);
         rotateImagePipe.setParams(rotateImageParams);
-
-        ErodeDilatePipe.ErodeDilateParams erodeDilateParams =
-                new ErodeDilatePipe.ErodeDilateParams(settings.erode, settings.dilate, 5);
-        // TODO: add kernel size to pipeline settings
-        erodeDilatePipe.setParams(erodeDilateParams);
 
         HSVPipe.HSVParams hsvParams =
                 new HSVPipe.HSVParams(settings.hsvHue, settings.hsvSaturation, settings.hsvValue);
@@ -178,56 +171,51 @@ public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectiveP
         // TODO: make this a pipe?
         long inputCopyStartNanos = System.nanoTime();
         rawInputMat.release();
-        preProcInputMat.release();
         frame.image.getMat().copyTo(rawInputMat);
-        frame.image.getMat().copyTo(preProcInputMat);
         long inputCopyElapsedNanos = System.nanoTime() - inputCopyStartNanos;
         sumPipeNanosElapsed += pipeProfileNanos[1] = inputCopyElapsedNanos;
 
-        var erodeDilateResult = erodeDilatePipe.run(preProcInputMat);
-        sumPipeNanosElapsed += pipeProfileNanos[2] = erodeDilateResult.nanosElapsed;
-
-        CVPipeResult<Mat> hsvPipeResult = hsvPipe.run(preProcInputMat);
+        CVPipeResult<Mat> hsvPipeResult = hsvPipe.run(rawInputMat);
         sumPipeNanosElapsed += hsvPipeResult.nanosElapsed;
-        pipeProfileNanos[3] = pipeProfileNanos[3] = hsvPipeResult.nanosElapsed;
+        pipeProfileNanos[2] = pipeProfileNanos[2] = hsvPipeResult.nanosElapsed;
 
         CVPipeResult<List<Contour>> findContoursResult = findContoursPipe.run(hsvPipeResult.output);
-        sumPipeNanosElapsed += pipeProfileNanos[4] = findContoursResult.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[3] = findContoursResult.nanosElapsed;
 
         CVPipeResult<List<Contour>> speckleRejectResult =
                 speckleRejectPipe.run(findContoursResult.output);
-        sumPipeNanosElapsed += pipeProfileNanos[5] = speckleRejectResult.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[4] = speckleRejectResult.nanosElapsed;
 
         CVPipeResult<List<Contour>> filterContoursResult =
                 filterContoursPipe.run(speckleRejectResult.output);
-        sumPipeNanosElapsed += pipeProfileNanos[6] = filterContoursResult.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[5] = filterContoursResult.nanosElapsed;
 
         CVPipeResult<List<PotentialTarget>> groupContoursResult =
                 groupContoursPipe.run(filterContoursResult.output);
-        sumPipeNanosElapsed += pipeProfileNanos[7] = groupContoursResult.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[6] = groupContoursResult.nanosElapsed;
 
         CVPipeResult<List<PotentialTarget>> sortContoursResult =
                 sortContoursPipe.run(groupContoursResult.output);
-        sumPipeNanosElapsed += pipeProfileNanos[8] = sortContoursResult.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[7] = sortContoursResult.nanosElapsed;
 
         CVPipeResult<List<TrackedTarget>> collect2dTargetsResult =
                 collect2dTargetsPipe.run(sortContoursResult.output);
-        sumPipeNanosElapsed += pipeProfileNanos[9] = collect2dTargetsResult.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[8] = collect2dTargetsResult.nanosElapsed;
 
         List<TrackedTarget> targetList;
 
         // 3d stuff
         if (settings.solvePNPEnabled) {
             var cornerDetectionResult = cornerDetectionPipe.run(collect2dTargetsResult.output);
-            sumPipeNanosElapsed += pipeProfileNanos[10] = cornerDetectionResult.nanosElapsed;
+            sumPipeNanosElapsed += pipeProfileNanos[9] = cornerDetectionResult.nanosElapsed;
 
             var solvePNPResult = solvePNPPipe.run(cornerDetectionResult.output);
-            sumPipeNanosElapsed += pipeProfileNanos[11] = solvePNPResult.nanosElapsed;
+            sumPipeNanosElapsed += pipeProfileNanos[10] = solvePNPResult.nanosElapsed;
 
             targetList = solvePNPResult.output;
         } else {
+            pipeProfileNanos[9] = 0;
             pipeProfileNanos[10] = 0;
-            pipeProfileNanos[11] = 0;
             targetList = collect2dTargetsResult.output;
         }
 
@@ -237,37 +225,37 @@ public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectiveP
 
         // Convert single-channel HSV output mat to 3-channel BGR in preparation for streaming
         var outputMatPipeResult = outputMatPipe.run(hsvPipeResult.output);
-        sumPipeNanosElapsed += pipeProfileNanos[12] = outputMatPipeResult.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[11] = outputMatPipeResult.nanosElapsed;
 
         // Draw 2D Crosshair on input and output
         var draw2dCrosshairResultOnInput = draw2dCrosshairPipe.run(Pair.of(rawInputMat, targetList));
-        sumPipeNanosElapsed += pipeProfileNanos[13] = draw2dCrosshairResultOnInput.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[12] = draw2dCrosshairResultOnInput.nanosElapsed;
 
         var draw2dCrosshairResultOnOutput =
                 draw2dCrosshairPipe.run(Pair.of(hsvPipeResult.output, targetList));
-        sumPipeNanosElapsed += pipeProfileNanos[14] = draw2dCrosshairResultOnOutput.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[13] = draw2dCrosshairResultOnOutput.nanosElapsed;
 
         // Draw 2D contours on input and output
         var draw2dTargetsOnInput =
                 draw2dTargetsPipe.run(Triple.of(rawInputMat, collect2dTargetsResult.output, fps));
-        sumPipeNanosElapsed += pipeProfileNanos[15] = draw2dTargetsOnInput.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[14] = draw2dTargetsOnInput.nanosElapsed;
 
         var draw2dTargetsOnOutput =
                 draw2dTargetsPipe.run(Triple.of(hsvPipeResult.output, collect2dTargetsResult.output, fps));
-        sumPipeNanosElapsed += pipeProfileNanos[16] = draw2dTargetsOnOutput.nanosElapsed;
+        sumPipeNanosElapsed += pipeProfileNanos[15] = draw2dTargetsOnOutput.nanosElapsed;
 
         // Draw 3D Targets on input and output if necessary
         if (settings.solvePNPEnabled) {
             var drawOnInputResult =
                     draw3dTargetsPipe.run(Pair.of(rawInputMat, collect2dTargetsResult.output));
-            sumPipeNanosElapsed += pipeProfileNanos[17] = drawOnInputResult.nanosElapsed;
+            sumPipeNanosElapsed += pipeProfileNanos[16] = drawOnInputResult.nanosElapsed;
 
             var drawOnOutputResult =
                     draw3dTargetsPipe.run(Pair.of(hsvPipeResult.output, collect2dTargetsResult.output));
-            sumPipeNanosElapsed += pipeProfileNanos[18] = drawOnOutputResult.nanosElapsed;
+            sumPipeNanosElapsed += pipeProfileNanos[17] = drawOnOutputResult.nanosElapsed;
         } else {
+            pipeProfileNanos[16] = 0;
             pipeProfileNanos[17] = 0;
-            pipeProfileNanos[18] = 0;
         }
 
         PipelineProfiler.printReflectiveProfile(pipeProfileNanos);

--- a/photon-server/src/test/java/org/photonvision/vision/pipeline/PipelineProfilerTest.java
+++ b/photon-server/src/test/java/org/photonvision/vision/pipeline/PipelineProfilerTest.java
@@ -35,7 +35,7 @@ public class PipelineProfilerTest {
         var validResult = PipelineProfiler.getReflectiveProfileString(validNanos);
 
         Assertions.assertEquals("Invalid data", invalidResult);
-        Assertions.assertTrue(validResult.contains("Total: 171.0ms"));
+        Assertions.assertTrue(validResult.contains("Total: 153.0ms"));
         System.out.println(validResult);
     }
 }


### PR DESCRIPTION
In main vision pipeline, added new preProcInputMat

The new one compliments rawInputMat: rawInput retains its previous meaning (camera image with target/fps annotations overlaid). preProcInput now is the working mat which gets erode/dilate manipulations applied prior to passing into the hsv chain.

Should cover https://github.com/PhotonVision/photonvision/issues/132 