### PR TITLE
Add Disk Usage Percentage Stat

### DIFF
--- a/photon-client/src/views/SettingsViews/General.vue
+++ b/photon-client/src/views/SettingsViews/General.vue
@@ -13,6 +13,8 @@
         <span>CPU Memory Usage: {{ metrics.ramUtil.replace(" ", "") }}MB of {{ metrics.cpuMem }}MB</span>
         &ndash;
         <span>GPU Memory Usage: {{ metrics.gpuMemUtil }}MB of {{ metrics.gpuMem }}MB</span>
+        &ndash;
+        <span>Disk Usage: {{ metrics.diskUtilPct }}</span>
       </v-row>
     </div>
       

--- a/photon-client/src/views/SettingsViews/General.vue
+++ b/photon-client/src/views/SettingsViews/General.vue
@@ -131,9 +131,6 @@
 </template>
 
 <script>
-
-var metricsGetter = null;
-
 export default {
     name: 'General',
     data() {

--- a/photon-client/src/views/SettingsViews/General.vue
+++ b/photon-client/src/views/SettingsViews/General.vue
@@ -1,23 +1,47 @@
 <template>
   <div>
     <v-row class="pa-4">
-      <span>{{ infoTabs.join('  —  ') }}</span>
+      <table class="infoTable">
+        <tr>
+          <th class="infoElem"> Version </th>
+          <th class="infoElem"> Hardware Model </th>
+          <th class="infoElem"> Platform </th>
+          <th class="infoElem"> GPU Acceleration </th>
+        </tr>
+        <tr>
+          <td class="infoElem">{{ version.replace(" ", "") }}</td>
+          <td class="infoElem">{{ hwModel.replace(" ", "") }}</td>
+          <td class="infoElem">{{ platform.replace(" ", "") }}</td>
+          <td class="infoElem">{{ gpuAccel.replace(" ", "") }}</td>
+        </tr>
+      </table>
+
+      <table class="infoTable">
+        <tr>
+          <th class="infoElem"> CPU Usage </th>
+          <th class="infoElem"> CPU Temp </th>
+          <th class="infoElem"> CPU Memory Usage </th>
+          <th class="infoElem"> GPU Memory Usage </th>
+          <th class="infoElem"> Disk Usage </th>
+        </tr>
+        <tr v-if="metrics.cpuUtil !== 'N/A'">
+          <td class="infoElem">{{ metrics.cpuUtil.replace(" ", "") }}%</td>
+          <td class="infoElem">{{ parseInt(metrics.cpuTemp) }}&deg;&nbsp;C</td>
+          <td class="infoElem">{{ metrics.ramUtil.replace(" ", "") }}MB of {{ metrics.cpuMem }}MB</td>
+          <td class="infoElem">{{ metrics.gpuMemUtil.replace(" ", "") }}MB of {{ metrics.gpuMem }}MB</td>
+          <td class="infoElem">{{ metrics.diskUtilPct.replace(" ", "") }}</td>
+        </tr>
+        <tr v-if="metrics.cpuUtil === 'N/A'">
+          <td class="infoElem">---</td>
+          <td class="infoElem">---</td>
+          <td class="infoElem">---</td>
+          <td class="infoElem">---</td>
+          <td class="infoElem">---</td>
+        </tr>
+      </table>
+
     </v-row>
 
-    <div v-if="metrics.cpuUtil !== 'N/A'">
-      <v-row class="pa-4">
-        <span>CPU Usage: {{ metrics.cpuUtil.replace(" ", "") }}%</span>
-        &nbsp;&ndash;&nbsp;
-        <span>CPU Temp: {{ parseInt(metrics.cpuTemp) }}&deg;&nbsp;C</span>
-        &nbsp;&ndash;&nbsp;
-        <span>CPU Memory Usage: {{ metrics.ramUtil.replace(" ", "") }}MB of {{ metrics.cpuMem }}MB</span>
-        &ndash;
-        <span>GPU Memory Usage: {{ metrics.gpuMemUtil }}MB of {{ metrics.gpuMem }}MB</span>
-        &ndash;
-        <span>Disk Usage: {{ metrics.diskUtilPct }}</span>
-      </v-row>
-    </div>
-      
     <v-row>
       <v-col
         cols="12"
@@ -107,6 +131,9 @@
 </template>
 
 <script>
+
+var metricsGetter = null;
+
 export default {
     name: 'General',
     data() {
@@ -118,23 +145,47 @@ export default {
             },
         }
     },
+    created() {
+      console.log("On Created hit!");
+      
+      //Periodically update hardware metrics
+      metricsGetter = setInterval(function () {
+        this.axios.post('http://' + this.$address + '/api/sendMetrics', {});
+      }.bind(this), 4000); 
+
+    },
+    beforeDestroy() {
+      console.log("On Destroy!");
+
+      //Stop periodic metrics getter
+      if(metricsGetter != null){
+        clearInterval(metricsGetter);
+        console.log("Cleared periodc getter!");
+      }
+
+    },
     computed: {
         settings() {
             return this.$store.state.settings.general;
         },
-        infoTabs() {
-            let ret = [];
-            let idx = 0;
-            ret[idx++] = `Version: ${this.settings.version}`;
+        version() {
+          return `${this.settings.version}`;
+        },
+        hwModel() {
             if (this.settings.hardwareModel !== '') {
-                ret[idx++] = `Hardware model: ${this.settings.hardwareModel}`;
+                return `${this.settings.hardwareModel}`;
+            } else {
+              return `Unknown`;
             }
-            ret[idx++] = `Platform: ${this.settings.hardwarePlatform}`;
-            ret[idx++] = `GPU Acceleration: ${this.settings.gpuAcceleration ? "Enabled" : "Unsupported"}${this.settings.gpuAcceleration ? " (" + this.settings.gpuAcceleration + " mode)" : ""}`
-
-            return ret;
+        },
+        platform() {
+          return `${this.settings.hardwarePlatform}`;
+        },
+        gpuAccel() {
+          return  `${this.settings.gpuAcceleration ? "Enabled" : "Unsupported"}${this.settings.gpuAcceleration ? " (" + this.settings.gpuAcceleration + " mode)" : ""}`
         },
         metrics() {
+          console.log(this.$store.state.metrics);
             return this.$store.state.metrics;
         }
     },
@@ -171,4 +222,23 @@ export default {
 .v-btn {
     width: 100%;
 }
+
+.infoTable{
+  border: 1px solid;
+  border-collapse: separate;
+  border-spacing: 0px;
+  border-radius: 5px;
+  text-align: left;
+  margin-bottom: 10px;
+  width: 100%;
+}
+
+.infoElem {
+  padding-right: 15px;
+  padding-bottom: 1px;
+  padding-top: 1px;
+  padding-left: 10px;
+  border-right: 1px solid;
+}
+
 </style>

--- a/photon-client/src/views/SettingsViews/General.vue
+++ b/photon-client/src/views/SettingsViews/General.vue
@@ -145,25 +145,6 @@ export default {
             },
         }
     },
-    created() {
-      console.log("On Created hit!");
-      
-      //Periodically update hardware metrics
-      metricsGetter = setInterval(function () {
-        this.axios.post('http://' + this.$address + '/api/sendMetrics', {});
-      }.bind(this), 4000); 
-
-    },
-    beforeDestroy() {
-      console.log("On Destroy!");
-
-      //Stop periodic metrics getter
-      if(metricsGetter != null){
-        clearInterval(metricsGetter);
-        console.log("Cleared periodc getter!");
-      }
-
-    },
     computed: {
         settings() {
             return this.$store.state.settings.general;

--- a/photon-server/src/main/java/org/photonvision/common/configuration/HardwareConfig.java
+++ b/photon-server/src/main/java/org/photonvision/common/configuration/HardwareConfig.java
@@ -43,6 +43,7 @@ public class HardwareConfig {
     public final String gpuMemoryCommand;
     public final String ramUtilCommand;
     public final String gpuMemUsageCommand;
+    public final String diskUsageCommand;
 
     // Device stuff
     public final String restartHardwareCommand;
@@ -67,6 +68,7 @@ public class HardwareConfig {
         ramUtilCommand = "";
         ledBlinkCommand = "";
         gpuMemUsageCommand = "";
+        diskUsageCommand = "";
 
         restartHardwareCommand = "";
         vendorFOV = -1;
@@ -91,6 +93,7 @@ public class HardwareConfig {
             String gpuMemoryCommand,
             String ramUtilCommand,
             String gpuMemUsageCommand,
+            String diskUsageCommand,
             String restartHardwareCommand,
             double vendorFOV,
             List<Integer> blacklistedResIndices) {
@@ -110,6 +113,7 @@ public class HardwareConfig {
         this.gpuMemoryCommand = gpuMemoryCommand;
         this.ramUtilCommand = ramUtilCommand;
         this.gpuMemUsageCommand = gpuMemUsageCommand;
+        this.diskUsageCommand = diskUsageCommand;
         this.restartHardwareCommand = restartHardwareCommand;
         this.vendorFOV = vendorFOV;
         this.blacklistedResIndices = blacklistedResIndices;

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/DiskMetrics.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/DiskMetrics.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.common.hardware.metrics;
+
+public class DiskMetrics extends MetricsBase {
+    public String getUsedDiskPct() {
+        if (diskUsageCommand.isEmpty()) return "";
+        return execute(diskUsageCommand);
+    }
+}

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -55,6 +55,8 @@ public abstract class MetricsBase {
         gpuMemoryCommand = config.gpuMemoryCommand;
         gpuMemUsageCommand = config.gpuMemUsageCommand;
 
+        diskUsageCommand = config.diskUsageCommand;
+
         ramUsageCommand = config.ramUtilCommand;
     }
 

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -39,6 +39,10 @@ public abstract class MetricsBase {
     // RAM
     public static String ramUsageCommand = "free --mega | awk -v i=2 -v j=3 'FNR == i {print $j}'";
 
+    //Disk
+    public static String diskUsageCommand = "df ./ --output=pcent | tail -n +2";
+
+
     private static ShellExec runCommand = new ShellExec(true, true);
 
     public static void setConfig(HardwareConfig config) {

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -17,6 +17,9 @@
 
 package org.photonvision.common.hardware.metrics;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.photonvision.common.configuration.HardwareConfig;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
@@ -57,11 +60,15 @@ public abstract class MetricsBase {
         ramUsageCommand = config.ramUtilCommand;
     }
 
-    public static String execute(String command) {
+    public static synchronized String execute(String command) {
         try {
             runCommand.executeBashCommand(command);
             return runCommand.getOutput();
         } catch (Exception e) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            
             logger.error(
                     "Command: \""
                             + command
@@ -75,7 +82,10 @@ public abstract class MetricsBase {
                             + "\nError completed: "
                             + runCommand.isErrorCompleted()
                             + "\nExit code: "
-                            + runCommand.getExitCode());
+                            + runCommand.getExitCode()
+                            + "\n Exception: "
+                            + e.toString()
+                            + sw.toString());
             return "";
         }
     }

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsBase.java
@@ -19,7 +19,6 @@ package org.photonvision.common.hardware.metrics;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-
 import org.photonvision.common.configuration.HardwareConfig;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
@@ -42,9 +41,8 @@ public abstract class MetricsBase {
     // RAM
     public static String ramUsageCommand = "free --mega | awk -v i=2 -v j=3 'FNR == i {print $j}'";
 
-    //Disk
+    // Disk
     public static String diskUsageCommand = "df ./ --output=pcent | tail -n +2";
-
 
     private static ShellExec runCommand = new ShellExec(true, true);
 
@@ -68,7 +66,7 @@ public abstract class MetricsBase {
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
             e.printStackTrace(pw);
-            
+
             logger.error(
                     "Command: \""
                             + command

--- a/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsPublisher.java
+++ b/photon-server/src/main/java/org/photonvision/common/hardware/metrics/MetricsPublisher.java
@@ -30,6 +30,7 @@ public class MetricsPublisher {
     private static CPUMetrics cpuMetrics;
     private static GPUMetrics gpuMetrics;
     private static RAMMetrics ramMetrics;
+    private static DiskMetrics diskMetrics;
 
     public static MetricsPublisher getInstance() {
         return Singleton.INSTANCE;
@@ -39,6 +40,7 @@ public class MetricsPublisher {
         cpuMetrics = new CPUMetrics();
         gpuMetrics = new GPUMetrics();
         ramMetrics = new RAMMetrics();
+        diskMetrics = new DiskMetrics();
     }
 
     public void stopTask() {
@@ -61,6 +63,7 @@ public class MetricsPublisher {
         metrics.put("gpuMem", gpuMetrics.getGPUMemorySplit());
         metrics.put("ramUtil", ramMetrics.getUsedRam());
         metrics.put("gpuMemUtil", gpuMetrics.getMallocedMemory());
+        metrics.put("diskUtilPct", diskMetrics.getUsedDiskPct());
 
         var retMap = new HashMap<String, Object>();
         retMap.put("metrics", metrics);


### PR DESCRIPTION
Updated Settings-General UI to have table-layout for metrics and other info. Added `df`-based command to read disk percent utilization for whatever volume has the working directory of the photonvision process (since, presumably, that's where the log and image storage location will be, which are photon's main dynamic disk usage contributions)

Added a `synchronized` modifier to the command runner due to some `InterruptedThreadExceptions` that were spuriously showing up while getting stats. Added additional stack trace logging when issues arise. Probably needs more work.

![image](https://user-images.githubusercontent.com/4583662/97790026-38156200-1b93-11eb-9d55-ddc5cbc7dbea.png)

Submitting as draft for now - lemme know if we want to split this into two or three smaller ones... the changes are all related, not sure how granular we want to get though.
