### PR TITLE
Leds active without vendor fov

### DIFF
--- a/photon-server/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
+++ b/photon-server/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
@@ -102,7 +102,7 @@ public class PhotonConfiguration {
 
         var lightingConfig = new UILightingConfig();
         lightingConfig.brightness = hardwareSettings.ledBrightnessPercentage;
-        lightingConfig.supported = Platform.isRaspberryPi(); // TODO check non pi??
+        lightingConfig.supported = (hardwareConfig.ledPins.size() != 0);
         settingsSubmap.put("lighting", SerializationUtils.objectToHashMap(lightingConfig));
 
         var generalSubmap = new HashMap<String, Object>();

--- a/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -274,7 +274,8 @@ public class VisionModule {
     }
 
     private void setVisionLEDs(boolean on) {
-        if (HardwareManager.getInstance().visionLED != null) HardwareManager.getInstance().visionLED.setState(on);
+        if (HardwareManager.getInstance().visionLED != null)
+            HardwareManager.getInstance().visionLED.setState(on);
     }
 
     public void saveModule() {

--- a/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -131,7 +131,10 @@ public class VisionModule {
             var fov = ConfigManager.getInstance().getConfig().getHardwareConfig().vendorFOV;
             logger.info("Setting FOV of vendor camera to " + fov);
             visionSource.getSettables().setFOV(fov);
+        }
 
+        // Configure LED's if supported by the underlying hardware
+        if (HardwareManager.getInstance().visionLED != null) {
             HardwareManager.getInstance()
                     .visionLED
                     .setPipelineModeSupplier(() -> pipelineManager.getCurrentPipelineSettings().ledMode);
@@ -271,7 +274,7 @@ public class VisionModule {
     }
 
     private void setVisionLEDs(boolean on) {
-        if (isVendorCamera()) HardwareManager.getInstance().visionLED.setState(on);
+        if (HardwareManager.getInstance().visionLED != null) HardwareManager.getInstance().visionLED.setState(on);
     }
 
     public void saveModule() {


### PR DESCRIPTION
Updated lighting configuration and `setVisionLED` logic to rely on LED-related hardware configuration items alone. This should remove the need to configure a FOV to activate LED functionality.

Commentary: I propose that this is probably less hacky then before, but possibly might not be the optimal solution yet. To get there, I think the best path would be to first more-fully define what the hardware support "model" looks like: What sorts of hardware permutations are supported, how they get configured, etc. Which, not knowing what the full future landscape of this is going to be (nor desiring to limit it), will be a difficult task. 