### PR TITLE
Continually set picam rotation in calib and driver mode pipes

### DIFF
--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -83,6 +83,7 @@ public class Calibrate3dPipeline
         this.minSnapshots = minSnapshots;
 
         if (PicamJNI.isSupported()) {
+            PicamJNI.setRotation(settings.inputImageRotationMode.value);
             PicamJNI.setShouldCopyColor(true);
         }
     }

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/DriverModePipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/DriverModePipeline.java
@@ -53,6 +53,7 @@ public class DriverModePipeline
         draw2dCrosshairPipe.setParams(draw2dCrosshairParams);
 
         if (PicamJNI.isSupported()) {
+            PicamJNI.setRotation(settings.inputImageRotationMode.value);
             PicamJNI.setShouldCopyColor(true);
         }
     }


### PR DESCRIPTION
This fixes rotation not getting set.