### PR TITLE
Delete native library if it already exists

### DIFF
--- a/photon-server/src/main/java/org/photonvision/raspi/PicamJNI.java
+++ b/photon-server/src/main/java/org/photonvision/raspi/PicamJNI.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
-import org.photonvision.common.util.file.FileUtils;
 
 public class PicamJNI {
 
@@ -46,7 +45,7 @@ public class PicamJNI {
             URL resourceURL = PicamJNI.class.getResource("/nativelibraries/libpicam.so");
             File libFile = Path.of("lib/libpicam.so").toFile();
             try (InputStream in = resourceURL.openStream()) {
-                if(libFile.exists()) Files.delete(libFile.toPath());
+                if (libFile.exists()) Files.delete(libFile.toPath());
                 Files.copy(in, libFile.toPath());
             } catch (Exception e) {
                 logger.error("Could not extract the native library!");

--- a/photon-server/src/main/java/org/photonvision/raspi/PicamJNI.java
+++ b/photon-server/src/main/java/org/photonvision/raspi/PicamJNI.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
+import org.photonvision.common.util.file.FileUtils;
 
 public class PicamJNI {
 
@@ -45,7 +46,10 @@ public class PicamJNI {
             URL resourceURL = PicamJNI.class.getResource("/nativelibraries/libpicam.so");
             File libFile = Path.of("lib/libpicam.so").toFile();
             try (InputStream in = resourceURL.openStream()) {
+                if(libFile.exists()) Files.delete(libFile.toPath());
                 Files.copy(in, libFile.toPath());
+            } catch (Exception e) {
+                logger.error("Could not extract the native library!");
             }
             System.load(libFile.getAbsolutePath());
 

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -188,7 +188,7 @@ public class RequestHandler {
 
         if (Platform.isRaspberryPi()) {
             try {
-                new ShellExec().executeBashCommand("systemctl restart photonvision");
+                new ShellExec().executeBashCommand("systemctl restart photonvision.service");
             } catch (IOException e) {
                 logger.error("Could not restart device!", e);
                 System.exit(0);


### PR DESCRIPTION
Prevents exceptions on runs after the first