### PR TITLE
Calibration3D Pipeline Memory Leak

### DIFF
--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -34,8 +34,10 @@ import org.photonvision.common.util.TestUtils;
 import org.photonvision.raspi.PicamJNI;
 import org.photonvision.server.Server;
 import org.photonvision.vision.camera.FileVisionSource;
+import org.photonvision.vision.opencv.CVMat;
 import org.photonvision.vision.opencv.ContourGroupingMode;
 import org.photonvision.vision.pipeline.CVPipelineSettings;
+import org.photonvision.vision.pipeline.PipelineProfiler;
 import org.photonvision.vision.pipeline.ReflectivePipelineSettings;
 import org.photonvision.vision.processes.VisionModule;
 import org.photonvision.vision.processes.VisionModuleManager;
@@ -138,7 +140,10 @@ public class Main {
             logger.error("Failed to parse command-line options!", e);
         }
 
-        var logLevel = LogLevel.DEBUG;
+        CVMat.enablePrint(true);
+        PipelineProfiler.enablePrint(false);
+
+        var logLevel = printDebugLogs ? LogLevel.TRACE : LogLevel.DEBUG;
         Logger.setLevel(LogGroup.Camera, logLevel);
         Logger.setLevel(LogGroup.WebServer, logLevel);
         Logger.setLevel(LogGroup.VisionModule, logLevel);

--- a/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
+++ b/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
@@ -70,8 +70,10 @@ public class CVMat implements Releasable {
         int matNo = allMats.get(mat);
         allMats.remove(mat);
         mat.release();
-        logger.trace(() -> "CVMat" + matNo + " de-alloc - new count: " + allMats.size());
-        logStackTrace();
+        if (shouldPrint) {
+            logger.trace(() -> "CVMat" + matNo + " de-alloc - new count: " + allMats.size());
+            logStackTrace();
+        }
     }
 
     public Mat getMat() {

--- a/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
+++ b/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
@@ -44,7 +44,7 @@ public class CVMat implements Releasable {
         srcMat.copyTo(mat);
     }
 
-    public void logStackTrace(){
+    public void logStackTrace() {
         var trace = Thread.currentThread().getStackTrace();
 
         final var traceStr = new StringBuilder();

--- a/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
+++ b/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
@@ -47,10 +47,12 @@ public class CVMat implements Releasable {
     private StringBuilder getStackTraceBuilder() {
         var trace = Thread.currentThread().getStackTrace();
 
+        final int STACK_FRAMES_TO_SKIP = 4;
         final var traceStr = new StringBuilder();
-        for (int idx = 3; idx < trace.length; idx++) {
+        for (int idx = STACK_FRAMES_TO_SKIP; idx < trace.length; idx++) {
             traceStr.append("\t\n").append(trace[idx]);
         }
+        traceStr.append("\n");
         return traceStr;
     }
 

--- a/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
+++ b/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
@@ -44,6 +44,16 @@ public class CVMat implements Releasable {
         srcMat.copyTo(mat);
     }
 
+    public void logStackTrace(){
+        var trace = Thread.currentThread().getStackTrace();
+
+        final var traceStr = new StringBuilder();
+        for (int idx = 3; idx < trace.length; idx++) {
+            traceStr.append("\t\n").append(trace[idx]);
+        }
+        logger.trace("\n" + traceStr.toString() + "\n");
+    }
+
     public CVMat(Mat mat) {
         this.mat = mat;
         allMatCounter++;
@@ -51,13 +61,7 @@ public class CVMat implements Releasable {
 
         if (shouldPrint) {
             logger.trace(() -> "CVMat" + allMatCounter + " alloc - new count: " + allMats.size());
-            var trace = Thread.currentThread().getStackTrace();
-
-            final var traceStr = new StringBuilder();
-            for (var elem : trace) {
-                traceStr.append("\t\n").append(elem);
-            }
-            logger.trace(traceStr::toString);
+            logStackTrace();
         }
     }
 
@@ -67,6 +71,7 @@ public class CVMat implements Releasable {
         allMats.remove(mat);
         mat.release();
         logger.trace(() -> "CVMat" + matNo + " de-alloc - new count: " + allMats.size());
+        logStackTrace();
     }
 
     public Mat getMat() {

--- a/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
+++ b/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
@@ -51,7 +51,6 @@ public class CVMat implements Releasable {
         for (int idx = 3; idx < trace.length; idx++) {
             traceStr.append("\t\n").append(trace[idx]);
         }
-        logger.trace("\n" + traceStr.toString() + "\n");
         return traceStr;
     }
 

--- a/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
+++ b/photon-server/src/main/java/org/photonvision/vision/opencv/CVMat.java
@@ -44,7 +44,7 @@ public class CVMat implements Releasable {
         srcMat.copyTo(mat);
     }
 
-    public void logStackTrace() {
+    private StringBuilder getStackTraceBuilder() {
         var trace = Thread.currentThread().getStackTrace();
 
         final var traceStr = new StringBuilder();
@@ -52,6 +52,7 @@ public class CVMat implements Releasable {
             traceStr.append("\t\n").append(trace[idx]);
         }
         logger.trace("\n" + traceStr.toString() + "\n");
+        return traceStr;
     }
 
     public CVMat(Mat mat) {
@@ -61,7 +62,7 @@ public class CVMat implements Releasable {
 
         if (shouldPrint) {
             logger.trace(() -> "CVMat" + allMatCounter + " alloc - new count: " + allMats.size());
-            logStackTrace();
+            logger.trace(getStackTraceBuilder()::toString);
         }
     }
 
@@ -72,7 +73,7 @@ public class CVMat implements Releasable {
         mat.release();
         if (shouldPrint) {
             logger.trace(() -> "CVMat" + matNo + " de-alloc - new count: " + allMats.size());
-            logStackTrace();
+            logger.trace(getStackTraceBuilder()::toString);
         }
     }
 

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -124,7 +124,8 @@ public class Calibrate3dPipeline
         // Check if the frame has chessboard corners
         var outputColorCVMat = new CVMat();
         inputColorMat.copyTo(outputColorCVMat.getMat());
-        var findBoardResult = findBoardCornersPipe.run(Pair.of(inputColorMat, outputColorCVMat.getMat())).output;
+        var findBoardResult =
+                findBoardCornersPipe.run(Pair.of(inputColorMat, outputColorCVMat.getMat())).output;
 
         var fpsResult = calculateFPSPipe.run(null);
         var fps = fpsResult.output;

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -122,9 +122,9 @@ public class Calibrate3dPipeline
         long sumPipeNanosElapsed = 0L;
 
         // Check if the frame has chessboard corners
-        var outputColorMat = new Mat();
-        inputColorMat.copyTo(outputColorMat);
-        var findBoardResult = findBoardCornersPipe.run(Pair.of(inputColorMat, outputColorMat)).output;
+        var outputColorCVMat = new CVMat();
+        inputColorMat.copyTo(outputColorCVMat.getMat());
+        var findBoardResult = findBoardCornersPipe.run(Pair.of(inputColorMat, outputColorCVMat.getMat())).output;
 
         var fpsResult = calculateFPSPipe.run(null);
         var fps = fpsResult.output;
@@ -142,6 +142,7 @@ public class Calibrate3dPipeline
                 // update the UI
                 broadcastState();
 
+                outputColorCVMat.release();
                 return new CVPipelineResult(
                         MathUtils.nanosToMillis(sumPipeNanosElapsed),
                         fps,
@@ -150,12 +151,14 @@ public class Calibrate3dPipeline
             }
         }
 
+        frame.image.release();
+
         // Return the drawn chessboard if corners are found, if not, then return the input image.
         return new CVPipelineResult(
                 MathUtils.nanosToMillis(sumPipeNanosElapsed),
                 fps, // Unused but here in case
                 null,
-                new Frame(new CVMat(outputColorMat), frame.frameStaticProperties));
+                new Frame(outputColorCVMat, frame.frameStaticProperties));
     }
 
     public void deleteSavedImages() {

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/DriverModePipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/DriverModePipeline.java
@@ -65,7 +65,7 @@ public class DriverModePipeline
         if (inputMat.channels() == 1 && PicamJNI.isSupported()) {
             long colorMatPtr = PicamJNI.grabFrame(true);
             if (colorMatPtr == 0) throw new RuntimeException("Got null Mat from GPU Picam driver");
-            inputMat.release();
+            frame.image.release();
             inputMat = new Mat(colorMatPtr);
         }
 

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/PipelineProfiler.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/PipelineProfiler.java
@@ -22,6 +22,9 @@ import org.photonvision.common.logging.Logger;
 import org.photonvision.common.util.math.MathUtils;
 
 public class PipelineProfiler {
+
+    private static boolean shouldLog;
+
     private static final Logger reflectiveLogger =
             new Logger(ReflectivePipeline.class, LogGroup.VisionModule);
     private static final Logger coloredShapeLogger =
@@ -85,6 +88,12 @@ public class PipelineProfiler {
     }
 
     public static void printReflectiveProfile(long[] nanos) {
-        reflectiveLogger.trace(() -> getReflectiveProfileString(nanos));
+        if (shouldLog) {
+            reflectiveLogger.trace(() -> getReflectiveProfileString(nanos));
+        }
+    }
+
+    public static void enablePrint(boolean enable) {
+        shouldLog = enable;
     }
 }


### PR DESCRIPTION
Applied patches from Banks to increase visibility of CVMat allocation & de-allocation.

Revised Calibration3D pipeline to release the unneded mat prior to returning.

Changed a few instances of using `opencv.Mat` to photon's `CVMat` for better traceability.