### PR TITLE
[Calibration] Reduce minimum snapshots to 12

### DIFF
--- a/photon-client/src/store/index.js
+++ b/photon-client/src/store/index.js
@@ -119,7 +119,7 @@ export default new Vuex.Store({
         calibrationData: {
             count: 0,
             videoModeIndex: 0,
-            minCount: 25,
+            minCount: 12, // Gets set by backend anyways, but we need a sane default
             hasEnough: false,
             squareSizeIn: 1.0,
             patternWidth: 8,

--- a/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-server/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -74,7 +74,7 @@ public class Calibrate3dPipeline
     private final Path imageDir = ConfigManager.getInstance().getCalibDir();
 
     public Calibrate3dPipeline() {
-        this(25);
+        this(12);
     }
 
     public Calibrate3dPipeline(int minSnapshots) {


### PR DESCRIPTION
This prevents OOMs on Gloworm, without sacrificing too much accuracy