### PR TITLE
Limit PS3Eye to 100FPS

### DIFF
--- a/photon-server/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
+++ b/photon-server/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
@@ -21,5 +21,7 @@ public enum CameraQuirk {
     /** Camera settable for controllable image gain */
     Gain,
     /** For the Raspberry Pi Camera */
-    PiCam
+    PiCam,
+    /** Cap at 100FPS for high-bandwidth cameras */
+    FPSCap100
 }

--- a/photon-server/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
+++ b/photon-server/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
@@ -25,7 +25,7 @@ public class QuirkyCamera {
 
     private static final List<QuirkyCamera> quirkyCameras =
             List.of(
-                    new QuirkyCamera(0x2000, 0x1415, CameraQuirk.Gain), // PS3Eye
+                    new QuirkyCamera(0x2000, 0x1415, CameraQuirk.Gain, CameraQuirk.FPSCap100), // PS3Eye
                     new QuirkyCamera(-1, -1, "mmal service 16.1", CameraQuirk.PiCam) // PiCam (via V4L2)
                     );
 

--- a/photon-server/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-server/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -194,6 +194,12 @@ public class USBCameraSource implements VisionSource {
                             }
                         }
 
+                        if (cameraQuirks.hasQuirk(CameraQuirk.FPSCap100)) {
+                            if (videoMode.fps > 100) {
+                                continue;
+                            }
+                        }
+
                         videoModesList.add(videoMode);
 
                         // We look for modes with the same height/width/pixelformat as this mode

--- a/photon-server/src/test/java/org/photonvision/vision/QuirkyCameraTest.java
+++ b/photon-server/src/test/java/org/photonvision/vision/QuirkyCameraTest.java
@@ -28,6 +28,7 @@ public class QuirkyCameraTest {
     public void ps3EyeTest() {
         HashMap<CameraQuirk, Boolean> ps3EyeQuirks = new HashMap<>();
         ps3EyeQuirks.put(CameraQuirk.Gain, true);
+        ps3EyeQuirks.put(CameraQuirk.FPSCap100, true);
         for (var q : CameraQuirk.values()) {
             ps3EyeQuirks.putIfAbsent(q, false);
         }


### PR DESCRIPTION
This helps prevent running in to USB bandwidth issues with multiple PS3Eyes