### PR TITLE
Update which-cam-controls-LEDs logic

### DIFF
--- a/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -141,7 +141,7 @@ public class VisionModule {
         }
 
         // Configure LED's if supported by the underlying hardware
-        if (HardwareManager.getInstance().visionLED != null) {
+        if (HardwareManager.getInstance().visionLED != null && this.camShouldControlLEDs()) {
             HardwareManager.getInstance()
                     .visionLED
                     .setPipelineModeSupplier(() -> pipelineManager.getCurrentPipelineSettings().ledMode);
@@ -277,7 +277,7 @@ public class VisionModule {
 
     void setDriverMode(boolean isDriverMode) {
         pipelineManager.setDriverMode(isDriverMode);
-        if (isVendorCamera()) setVisionLEDs(!isDriverMode);
+        setVisionLEDs(!isDriverMode);
         saveAndBroadcastAll();
     }
 
@@ -375,14 +375,21 @@ public class VisionModule {
             visionSource.getSettables().setGain(Math.max(0, config.cameraGain));
         }
 
-        if (isVendorCamera()) setVisionLEDs(config.ledMode);
+        setVisionLEDs(config.ledMode);
 
         visionSource.getSettables().getConfiguration().currentPipelineIndex =
                 pipelineManager.getCurrentPipelineIndex();
     }
 
+    private boolean camShouldControlLEDs(){
+        //Heuristic - if the camera has a known FOV or is a piCam, assume it's in use for
+        // vision processing, and should command stuff to the LED's. 
+        // TODO: Make LED control a property of the camera itself and controllable in the UI.
+        return isVendorCamera() || cameraQuirks.hasQuirk(CameraQuirk.PiCam);
+    }
+
     private void setVisionLEDs(boolean on) {
-        if (HardwareManager.getInstance().visionLED != null)
+        if (camShouldControlLEDs() && HardwareManager.getInstance().visionLED != null)
             HardwareManager.getInstance().visionLED.setState(on);
     }
 

--- a/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-server/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -381,9 +381,9 @@ public class VisionModule {
                 pipelineManager.getCurrentPipelineIndex();
     }
 
-    private boolean camShouldControlLEDs(){
-        //Heuristic - if the camera has a known FOV or is a piCam, assume it's in use for
-        // vision processing, and should command stuff to the LED's. 
+    private boolean camShouldControlLEDs() {
+        // Heuristic - if the camera has a known FOV or is a piCam, assume it's in use for
+        // vision processing, and should command stuff to the LED's.
         // TODO: Make LED control a property of the camera itself and controllable in the UI.
         return isVendorCamera() || cameraQuirks.hasQuirk(CameraQuirk.PiCam);
     }


### PR DESCRIPTION
Modified `VisionModule.java` to cause any camera the either has a vendor-defined FOV or the PiCam quirks to control the LED state. 

This is a bit of a patch, and directly assumes that piCam's are the devices primarily used for vision processing.

This fixes a tiny bit of pain experienced with a pi3b + picam v1 + usb Cam where not having the USB cam causes the LED's to be working normally, but plugging in the USB cam causes them to be always off.

[Parallel issue entered in documentation](https://github.com/PhotonVision/photonvision-docs/issues/62) to add this to known limitations of photon - if you had a set of all usb cameras, we wouldn't know which one is being used for vision processing, and would not be able to control the LED's accordingly. The ultimate solution is just to have teams control the NT entry themselves, which is easy enough. But, docs shouild be updated to reflect that.