### PR TITLE
Deprecate hasTargets

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -190,6 +190,9 @@ public class PhotonCamera {
     /**
     * Returns whether the latest target result has targets.
     *
+    * <p>This method is deprecated; {@link PhotonPipelineResult#hasTargets()} should be used instead.
+    *
+    * @deprecated This method should be replaced with {@link PhotonPipelineResult#hasTargets()}
     * @return Whether the latest target result has targets.
     */
     public boolean hasTargets() {

--- a/photon-lib/src/main/native/include/photonlib/PhotonCamera.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonCamera.h
@@ -115,6 +115,10 @@ class PhotonCamera {
 
   /**
    * Returns whether the latest target result has targets.
+   * This method is deprecated; {@link PhotonPipelineResult#hasTargets()} should
+   * be used instead.
+   * @deprecated This method should be replaced with {@link
+   * PhotonPipelineResult#hasTargets()}
    * @return Whether the latest target result has targets.
    */
   bool HasTargets() const { return GetLatestResult().HasTargets(); }


### PR DESCRIPTION
hasTargets has the potential to allow users to inadvertantly create NPEs.