### PR TITLE
Fix uninitialized variables in PhotonPipelineResult

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 apply from: "versioningHelper.gradle"
 
 ext {
-    wpilibVersion = "2021.2.1"
+    wpilibVersion = "2021.3.1"
     opencvVersion = "3.4.7-5"
     joglVersion = "2.4.0-rc-20200307"
     pubVersion = versionString

--- a/photon-lib/src/main/java/org/photonvision/SimVisionTarget.java
+++ b/photon-lib/src/main/java/org/photonvision/SimVisionTarget.java
@@ -24,7 +24,6 @@ public class SimVisionTarget {
     double targetWidthMeters;
     double targetHeightMeters;
     double targetHeightAboveGroundMeters;
-    double targetInfill_pct;
     double tgtAreaMeters2;
 
     /**

--- a/photon-lib/src/main/native/include/photonlib/PhotonPipelineResult.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonPipelineResult.h
@@ -92,8 +92,8 @@ class PhotonPipelineResult {
   friend Packet& operator>>(Packet& packet, PhotonPipelineResult& result);
 
  private:
-  units::second_t latency;
-  bool hasTargets;
+  units::second_t latency = 0_s;
+  bool hasTargets = false;
   wpi::SmallVector<PhotonTrackedTarget, 10> targets;
   inline static bool HAS_WARNED = false;
 };

--- a/photon-lib/src/main/native/include/photonlib/SimVisionTarget.h
+++ b/photon-lib/src/main/native/include/photonlib/SimVisionTarget.h
@@ -38,7 +38,6 @@ class SimVisionTarget {
   units::meter_t targetHeightAboveGround;
   units::meter_t targetWidth;
   units::meter_t targetHeight;
-  double targetInfill_pct;
   units::square_meter_t tgtArea;
 };
 

--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile "edu.wpi.first.thirdparty.frc2021.opencv:opencv-jni:$opencvVersion:osxx86-64"
     compile "edu.wpi.first.thirdparty.frc2021.opencv:opencv-jni:$opencvVersion:windowsx86-64"
 
-    implementation "edu.wpi.first.wpimath:wpimath-java:2021.1.2-9-g26584ff"
+    implementation "edu.wpi.first.wpimath:wpimath-java:2021.3.1"
 
     // test stuff
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")


### PR DESCRIPTION
If the default constructor is used, some member variables weren't
properly initialized.