### PR TITLE
Fix crash in logging when log files are not writable

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
@@ -344,7 +344,7 @@ public class Logger {
                 wantsFlush = true;
             } catch (IOException e) {
                 e.printStackTrace();
-            } catch (NullPointerException e){
+            } catch (NullPointerException e) {
                 // Nothing to do - no stream available for writing
             }
         }

--- a/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
@@ -344,6 +344,8 @@ public class Logger {
                 wantsFlush = true;
             } catch (IOException e) {
                 e.printStackTrace();
+            } catch (NullPointerException e){
+                // Nothing to do - no stream available for writing
             }
         }
     }


### PR DESCRIPTION
Addresses null pointer crash in logging when log files are not writable. Should allow photon to run on the Romi image (or without `sudo`), though settings won't persist over power cycle.