### PR TITLE
Upgrade athena Docker container from 2021 to 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: wpilib/roborio-cross-ubuntu:2021-18.04
+          - container: wpilib/roborio-cross-ubuntu:2022-18.04
             artifact-name: Athena
           - container: wpilib/raspbian-cross-ubuntu:10-18.04
             artifact-name: Raspbian


### PR DESCRIPTION
The proper compiler wasn't available for 2022 native-utils, so
linuxathena artifact builds were silently skipped.