### PR TITLE
Update PhotonCamera.java

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -55,8 +55,6 @@ public class PhotonCamera {
         pipelineIndexEntry = rootTable.getEntry("pipelineIndex");
         ledModeEntry = mainTable.getEntry("ledMode");
         versionEntry = mainTable.getEntry("version");
-
-
     }
 
     /**
@@ -106,7 +104,7 @@ public class PhotonCamera {
     * @param driverMode Whether to set driver mode.
     */
     public void setDriverMode(boolean driverMode) {
-        if (getDriverMode() != driverMode){
+        if (getDriverMode() != driverMode) {
             driverModeEntry.setBoolean(driverMode);
         }
     }

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -37,8 +37,6 @@ public class PhotonCamera {
     final NetworkTable mainTable = NetworkTableInstance.getDefault().getTable("photonvision");
     private final String path;
 
-    boolean driverMode;
-    int pipelineIndex;
     VisionLEDMode mode;
 
     Packet packet = new Packet(1);
@@ -58,9 +56,7 @@ public class PhotonCamera {
         ledModeEntry = mainTable.getEntry("ledMode");
         versionEntry = mainTable.getEntry("version");
 
-        driverMode = driverModeEntry.getBoolean(false);
-        pipelineIndex = pipelineIndexEntry.getNumber(0).intValue();
-        getLEDMode();
+
     }
 
     /**
@@ -101,7 +97,7 @@ public class PhotonCamera {
     * @return Whether the camera is in driver mode.
     */
     public boolean getDriverMode() {
-        return driverMode;
+        return driverModeEntry.getBoolean(false);
     }
 
     /**
@@ -110,9 +106,8 @@ public class PhotonCamera {
     * @param driverMode Whether to set driver mode.
     */
     public void setDriverMode(boolean driverMode) {
-        if (this.driverMode != driverMode) {
-            this.driverMode = driverMode;
-            driverModeEntry.setBoolean(this.driverMode);
+        if (getDriverMode() != driverMode){
+            driverModeEntry.setBoolean(driverMode);
         }
     }
 
@@ -142,7 +137,7 @@ public class PhotonCamera {
     * @return The active pipeline index.
     */
     public int getPipelineIndex() {
-        return pipelineIndex;
+        return pipelineIndexEntry.getNumber(0).intValue();
     }
 
     /**
@@ -151,9 +146,8 @@ public class PhotonCamera {
     * @param index The active pipeline index.
     */
     public void setPipelineIndex(int index) {
-        if (pipelineIndex != index) {
-            pipelineIndex = index;
-            pipelineIndexEntry.setNumber(pipelineIndex);
+        if (getPipelineIndex() != index) {
+            pipelineIndexEntry.setNumber(index);
         }
     }
 
@@ -188,7 +182,7 @@ public class PhotonCamera {
     * @param led The mode to set to.
     */
     public void setLED(VisionLEDMode led) {
-        if (led != mode) {
+        if (led != getLEDMode()) {
             ledModeEntry.setNumber(led.value);
         }
     }

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -153,17 +153,13 @@ public class PhotonCamera {
         switch (value) {
             case 0:
                 return VisionLEDMode.kOff;
-                break;
             case 1:
                 return VisionLEDMode.kOn;
-                break;
             case 2:
                 return VisionLEDMode.kBlink;
-                break;
             case -1:
             default:
                 return VisionLEDMode.kDefault;
-                break;
         }
     }
 

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -37,8 +37,6 @@ public class PhotonCamera {
     final NetworkTable mainTable = NetworkTableInstance.getDefault().getTable("photonvision");
     private final String path;
 
-    VisionLEDMode mode;
-
     Packet packet = new Packet(1);
 
     /**
@@ -104,9 +102,7 @@ public class PhotonCamera {
     * @param driverMode Whether to set driver mode.
     */
     public void setDriverMode(boolean driverMode) {
-        if (getDriverMode() != driverMode) {
-            driverModeEntry.setBoolean(driverMode);
-        }
+        driverModeEntry.setBoolean(driverMode);
     }
 
     /**
@@ -144,9 +140,7 @@ public class PhotonCamera {
     * @param index The active pipeline index.
     */
     public void setPipelineIndex(int index) {
-        if (getPipelineIndex() != index) {
-            pipelineIndexEntry.setNumber(index);
-        }
+        pipelineIndexEntry.setNumber(index);
     }
 
     /**
@@ -158,20 +152,19 @@ public class PhotonCamera {
         int value = ledModeEntry.getNumber(-1).intValue();
         switch (value) {
             case 0:
-                mode = VisionLEDMode.kOff;
+                return VisionLEDMode.kOff;
                 break;
             case 1:
-                mode = VisionLEDMode.kOn;
+                return VisionLEDMode.kOn;
                 break;
             case 2:
-                mode = VisionLEDMode.kBlink;
+                return VisionLEDMode.kBlink;
                 break;
             case -1:
             default:
-                mode = VisionLEDMode.kDefault;
+                return VisionLEDMode.kDefault;
                 break;
         }
-        return mode;
     }
 
     /**
@@ -180,9 +173,7 @@ public class PhotonCamera {
     * @param led The mode to set to.
     */
     public void setLED(VisionLEDMode led) {
-        if (led != getLEDMode()) {
-            ledModeEntry.setNumber(led.value);
-        }
+        ledModeEntry.setNumber(led.value);
     }
 
     /**

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -26,8 +26,7 @@ PhotonCamera::PhotonCamera(std::shared_ptr<nt::NetworkTable> rootTable)
       inputSaveImgEntry(rootTable->GetEntry("inputSaveImgCmd")),
       outputSaveImgEntry(rootTable->GetEntry("outputSaveImgCmd")),
       pipelineIndexEntry(rootTable->GetEntry("pipelineIndex")),
-      ledModeEntry(mainTable->GetEntry("ledMode")) {
-}
+      ledModeEntry(mainTable->GetEntry("ledMode")) {}
 
 PhotonCamera::PhotonCamera(const std::string& cameraName)
     : PhotonCamera(nt::NetworkTableInstance::GetDefault()

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -61,13 +61,17 @@ void PhotonCamera::TakeInputSnapshot() { inputSaveImgEntry.SetBoolean(true); }
 
 void PhotonCamera::TakeOutputSnapshot() { outputSaveImgEntry.SetBoolean(true); }
 
-bool PhotonCamera::GetDriverMode() const { return driverModeEntry.GetBoolean(false); }
+bool PhotonCamera::GetDriverMode() const {
+  return driverModeEntry.GetBoolean(false);
+  }
 
 void PhotonCamera::SetPipelineIndex(int index) {
   pipelineIndexEntry.SetDouble(static_cast<double>(index));
 }
 
-int PhotonCamera::GetPipelineIndex() const { return static_cast<int>(pipelineIndexEntry.GetDouble(0)); }
+int PhotonCamera::GetPipelineIndex() const {
+  return static_cast<int>(pipelineIndexEntry.GetDouble(0));
+}
 
 LEDMode PhotonCamera::GetLEDMode() const {
   return static_cast<LEDMode>(static_cast<int>(ledModeEntry.GetDouble(-1.0)));

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -67,7 +67,7 @@ void PhotonCamera::SetPipelineIndex(int index) {
   pipelineIndexEntry.SetDouble(static_cast<double>(index));
 }
 
-int PhotonCamera::GetPipelineIndex() const { return (int) pipelineIndexEntry.GetDouble(0); }
+int PhotonCamera::GetPipelineIndex() const { return static_cast<int>(pipelineIndexEntry.GetDouble(0)); }
 
 LEDMode PhotonCamera::GetLEDMode() const {
   return static_cast<LEDMode>(static_cast<int>(ledModeEntry.GetDouble(-1.0)));

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -61,13 +61,13 @@ void PhotonCamera::TakeInputSnapshot() { inputSaveImgEntry.SetBoolean(true); }
 
 void PhotonCamera::TakeOutputSnapshot() { outputSaveImgEntry.SetBoolean(true); }
 
-bool PhotonCamera::GetDriverMode() const { return driverMode; }
+bool PhotonCamera::GetDriverMode() const { return driverModeEntry.GetBoolean(false); }
 
 void PhotonCamera::SetPipelineIndex(int index) {
   pipelineIndexEntry.SetDouble(static_cast<double>(index));
 }
 
-int PhotonCamera::GetPipelineIndex() const { return pipelineIndex; }
+int PhotonCamera::GetPipelineIndex() const { return (int) pipelineIndexEntry.GetDouble(0); }
 
 LEDMode PhotonCamera::GetLEDMode() const {
   return static_cast<LEDMode>(static_cast<int>(ledModeEntry.GetDouble(-1.0)));

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -27,9 +27,6 @@ PhotonCamera::PhotonCamera(std::shared_ptr<nt::NetworkTable> rootTable)
       outputSaveImgEntry(rootTable->GetEntry("outputSaveImgCmd")),
       pipelineIndexEntry(rootTable->GetEntry("pipelineIndex")),
       ledModeEntry(mainTable->GetEntry("ledMode")) {
-  driverMode = driverModeEntry.GetBoolean(false);
-  pipelineIndex = static_cast<int>(pipelineIndexEntry.GetDouble(0.0));
-  mode = GetLEDMode();
 }
 
 PhotonCamera::PhotonCamera(const std::string& cameraName)
@@ -58,10 +55,7 @@ PhotonPipelineResult PhotonCamera::GetLatestResult() const {
 }
 
 void PhotonCamera::SetDriverMode(bool driverMode) {
-  if (this->driverMode != driverMode) {
-    this->driverMode = driverMode;
-    driverModeEntry.SetBoolean(this->driverMode);
-  }
+  driverModeEntry.SetBoolean(driverMode);
 }
 
 void PhotonCamera::TakeInputSnapshot() { inputSaveImgEntry.SetBoolean(true); }
@@ -71,23 +65,16 @@ void PhotonCamera::TakeOutputSnapshot() { outputSaveImgEntry.SetBoolean(true); }
 bool PhotonCamera::GetDriverMode() const { return driverMode; }
 
 void PhotonCamera::SetPipelineIndex(int index) {
-  if (index != pipelineIndex) {
-    pipelineIndex = index;
-    pipelineIndexEntry.SetDouble(static_cast<double>(pipelineIndex));
-  }
+  pipelineIndexEntry.SetDouble(static_cast<double>(index));
 }
 
 int PhotonCamera::GetPipelineIndex() const { return pipelineIndex; }
 
 LEDMode PhotonCamera::GetLEDMode() const {
-  mode = static_cast<LEDMode>(static_cast<int>(ledModeEntry.GetDouble(-1.0)));
-  return mode;
+  return static_cast<LEDMode>(static_cast<int>(ledModeEntry.GetDouble(-1.0)));
 }
 
-void PhotonCamera::SetLEDMode(LEDMode led) {
-  if (led != mode) {
-    mode = led;
-    ledModeEntry.SetDouble(static_cast<double>(static_cast<int>(mode)));
-  }
+void PhotonCamera::SetLEDMode(LEDMode mode) {
+  ledModeEntry.SetDouble(static_cast<double>(static_cast<int>(mode)));
 }
 }  // namespace photonlib

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -63,7 +63,7 @@ void PhotonCamera::TakeOutputSnapshot() { outputSaveImgEntry.SetBoolean(true); }
 
 bool PhotonCamera::GetDriverMode() const {
   return driverModeEntry.GetBoolean(false);
-  }
+}
 
 void PhotonCamera::SetPipelineIndex(int index) {
   pipelineIndexEntry.SetDouble(static_cast<double>(index));

--- a/photon-lib/src/main/native/include/photonlib/PhotonCamera.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonCamera.h
@@ -139,8 +139,6 @@ class PhotonCamera {
   nt::NetworkTableEntry ledModeEntry;
 
   mutable Packet packet;
-
-  mutable LEDMode mode;
 };
 
 }  // namespace photonlib

--- a/photon-lib/src/main/native/include/photonlib/PhotonCamera.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonCamera.h
@@ -140,8 +140,6 @@ class PhotonCamera {
 
   mutable Packet packet;
 
-  bool driverMode;
-  double pipelineIndex;
   mutable LEDMode mode;
 };
 


### PR DESCRIPTION
The get and set driverMode and pipelineIndex methods were not functioning because they were linked to the network table through variables which were not being updated. The getLedMode method was changed in the same manner.
The variables were deleted and the network table entries were used directly in the methods.
