### PR TITLE
Added Support for 3D tracking of the 2022 Cargo Balls

### DIFF
--- a/photon-client/src/views/PipelineViews/PnPTab.vue
+++ b/photon-client/src/views/PipelineViews/PnPTab.vue
@@ -60,7 +60,7 @@
         },
         data() {
             return {
-                targetList: ['2020 High Goal Outer', '2020 High Goal Inner', '2019 Dual Target', 'Power Cell (7in)','2022 Cargo Ball (9.5)', '2016 High Goal'], //Keep in sync with TargetModel.java
+                targetList: ['2020 High Goal Outer', '2020 High Goal Inner', '2019 Dual Target', '2020 Power Cell (7in)','2022 Cargo Ball (9.5in)', '2016 High Goal'], //Keep in sync with TargetModel.java
                 snackbar: {
                     color: "Success",
                     text: ""

--- a/photon-client/src/views/PipelineViews/PnPTab.vue
+++ b/photon-client/src/views/PipelineViews/PnPTab.vue
@@ -60,7 +60,7 @@
         },
         data() {
             return {
-                targetList: ['2020 High Goal Outer', '2020 High Goal Inner', '2019 Dual Target', 'Power Cell (7in)', '2016 High Goal'], //Keep in sync with TargetModel.java
+                targetList: ['2020 High Goal Outer', '2020 High Goal Inner', '2019 Dual Target', 'Power Cell (7in)','2022 Cargo Ball (9.5)', '2016 High Goal'], //Keep in sync with TargetModel.java
                 snackbar: {
                     color: "Success",
                     text: ""

--- a/photon-core/src/main/java/org/photonvision/vision/target/TargetModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/target/TargetModel.java
@@ -73,6 +73,25 @@ public enum TargetModel implements Releasable {
                             -Units.inchesToMeters(7) / 2,
                             -Units.inchesToMeters(7) / 2)),
             0),
+            k2022CircularCargoBall(
+                List.of(
+                        new Point3(
+                                -Units.inchesToMeters(9.5) / 2,
+                                -Units.inchesToMeters(9.5) / 2,
+                                -Units.inchesToMeters(9.5) / 2),
+                        new Point3(
+                                -Units.inchesToMeters(9.5) / 2,
+                                Units.inchesToMeters(9.5) / 2,
+                                -Units.inchesToMeters(9.5) / 2),
+                        new Point3(
+                                Units.inchesToMeters(9.5) / 2,
+                                Units.inchesToMeters(9.5) / 2,
+                                -Units.inchesToMeters(9.5) / 2),
+                        new Point3(
+                                Units.inchesToMeters(9.5) / 2,
+                                -Units.inchesToMeters(9.5) / 2,
+                                -Units.inchesToMeters(9.5) / 2)),
+                0),
     k2016HighGoal(
             List.of(
                     new Point3(Units.inchesToMeters(-10), Units.inchesToMeters(12), 0),

--- a/photon-core/src/main/java/org/photonvision/vision/target/TargetModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/target/TargetModel.java
@@ -73,25 +73,25 @@ public enum TargetModel implements Releasable {
                             -Units.inchesToMeters(7) / 2,
                             -Units.inchesToMeters(7) / 2)),
             0),
-            k2022CircularCargoBall(
-                List.of(
-                        new Point3(
-                                -Units.inchesToMeters(9.5) / 2,
-                                -Units.inchesToMeters(9.5) / 2,
-                                -Units.inchesToMeters(9.5) / 2),
-                        new Point3(
-                                -Units.inchesToMeters(9.5) / 2,
-                                Units.inchesToMeters(9.5) / 2,
-                                -Units.inchesToMeters(9.5) / 2),
-                        new Point3(
-                                Units.inchesToMeters(9.5) / 2,
-                                Units.inchesToMeters(9.5) / 2,
-                                -Units.inchesToMeters(9.5) / 2),
-                        new Point3(
-                                Units.inchesToMeters(9.5) / 2,
-                                -Units.inchesToMeters(9.5) / 2,
-                                -Units.inchesToMeters(9.5) / 2)),
-                0),
+    k2022CircularCargoBall(
+            List.of(
+                    new Point3(
+                            -Units.inchesToMeters(9.5) / 2,
+                            -Units.inchesToMeters(9.5) / 2,
+                            -Units.inchesToMeters(9.5) / 2),
+                    new Point3(
+                            -Units.inchesToMeters(9.5) / 2,
+                            Units.inchesToMeters(9.5) / 2,
+                            -Units.inchesToMeters(9.5) / 2),
+                    new Point3(
+                            Units.inchesToMeters(9.5) / 2,
+                            Units.inchesToMeters(9.5) / 2,
+                            -Units.inchesToMeters(9.5) / 2),
+                    new Point3(
+                            Units.inchesToMeters(9.5) / 2,
+                            -Units.inchesToMeters(9.5) / 2,
+                            -Units.inchesToMeters(9.5) / 2)),
+            0),
     k2016HighGoal(
             List.of(
                     new Point3(Units.inchesToMeters(-10), Units.inchesToMeters(12), 0),


### PR DESCRIPTION
I have added the ability to accurately get positions of the 2022 Cargo Balls from the 3D mode. I did test this on a Raspberry Pi 4B and it did work in accurately getting positions.