### PR TITLE
Implement mjpeg server connected clients query - issue #416

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -50,6 +50,7 @@ import org.photonvision.vision.pipeline.result.CVPipelineResult;
 import org.photonvision.vision.target.TargetModel;
 import org.photonvision.vision.target.TrackedTarget;
 
+//=======================================================================================
 /**
  * This is the God Class
  *
@@ -190,18 +191,25 @@ public class VisionModule {
         rawResultConsumers.add((in, out, tgts) -> inputFrameSaver.accept(in));
         fpsLimitedResultConsumers.add(result -> outputFrameSaver.accept(result.outputFrame));
 
+        //--------only send the video frame to the mjpeg server if there are connected clients
+        //--------The check for pipelinesettings inputShouldShow is reudundant since these
+        //--------clients act like any other streaming client and thus will show up as a 
+        //--------connected client.
         fpsLimitedResultConsumers.add(
                 result -> {
-                    if (this.pipelineManager.getCurrentPipelineSettings().inputShouldShow)
+                    //----if (this.pipelineManager.getCurrentPipelineSettings().inputShouldShow)
+                    if ( dashboardInputStreamer.anyClientConnections())
                         dashboardInputStreamer.accept(result.inputFrame);
-                    else dashboardInputStreamer.disabledTick();
+                    else 
+                        dashboardInputStreamer.disabledTick();
                 });
         fpsLimitedResultConsumers.add(
                 result -> {
-                    if (this.pipelineManager.getCurrentPipelineSettings().outputShouldShow)
+                    //----if (this.pipelineManager.getCurrentPipelineSettings().outputShouldShow)
+                    if ( dashboardOutputStreamer.anyClientConnections())
                         dashboardOutputStreamer.accept(result.outputFrame);
-                    else dashboardInputStreamer.disabledTick();
-                    ;
+                    else
+                        dashboardOutputStreamer.disabledTick();
                 });
     }
 


### PR DESCRIPTION
Added method to MJPGFrameConsumer to determine if there are any connected clients.   This is used by VisionModule to determine if the frame is sent to the MJPGFrameConsumer.  Also implemented logging in MJPGFrameConsumer.  Also corrected bug in VisionModule where inputStream was used where outputStream should have been used.  This is for issue #416 

Do with this what you want...