### PR TITLE
Fix spelling on "set team #" popup

### DIFF
--- a/photon-client/src/App.vue
+++ b/photon-client/src/App.vue
@@ -201,7 +201,7 @@
             class="accent--text"
             @click="switchToSettingsTab"
           >
-            vist the settings tab
+            visit the settings tab
           </router-link>
           and set your team number.
         </v-card-text>


### PR DESCRIPTION
Minor spelling issue but this is the first thing people see, so it's worth fixing.