### PR TITLE
Disable auto focus on USB cameras by default

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
@@ -27,5 +27,7 @@ public enum CameraQuirk {
     /** Separate red/blue gain controls available */
     AWBGain,
     /** Will not work with photonvision - Logitec C270 at least */
-    CompletelyBroken
+    CompletelyBroken,
+    /** Has adjustable focus and autofocus switch */
+    AdjustableFocus,
 }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
@@ -31,8 +31,10 @@ public class QuirkyCamera {
                     new QuirkyCamera(0x825, 0x46D, CameraQuirk.CompletelyBroken), // Logitec C270
                     new QuirkyCamera(0x2000, 0x1415, CameraQuirk.Gain, CameraQuirk.FPSCap100), // PS3Eye
                     new QuirkyCamera(
-                            -1, -1, "mmal service 16.1", CameraQuirk.PiCam) // PiCam (via V4L2, not zerocopy)
-                    );
+                            -1, -1, "mmal service 16.1", CameraQuirk.PiCam), // PiCam (via V4L2, not zerocopy)
+                    new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus) // Logitech C925-e
+            );
+
 
     public static final QuirkyCamera DefaultCamera = new QuirkyCamera(0, 0, "");
     public static final QuirkyCamera ZeroCopyPiCamera =

--- a/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
@@ -33,8 +33,7 @@ public class QuirkyCamera {
                     new QuirkyCamera(
                             -1, -1, "mmal service 16.1", CameraQuirk.PiCam), // PiCam (via V4L2, not zerocopy)
                     new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus) // Logitech C925-e
-            );
-
+                    );
 
     public static final QuirkyCamera DefaultCamera = new QuirkyCamera(0, 0, "");
     public static final QuirkyCamera ZeroCopyPiCamera =

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -19,7 +19,6 @@ package org.photonvision.vision.camera;
 
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.cscore.*;
-
 import java.util.*;
 import java.util.stream.Collectors;
 import org.photonvision.common.configuration.CameraConfiguration;

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -18,10 +18,8 @@
 package org.photonvision.vision.camera;
 
 import edu.wpi.first.cameraserver.CameraServer;
-import edu.wpi.first.cscore.CvSink;
-import edu.wpi.first.cscore.UsbCamera;
-import edu.wpi.first.cscore.VideoException;
-import edu.wpi.first.cscore.VideoMode;
+import edu.wpi.first.cscore.*;
+
 import java.util.*;
 import java.util.stream.Collectors;
 import org.photonvision.common.configuration.CameraConfiguration;
@@ -65,8 +63,21 @@ public class USBCameraSource extends VisionSource {
         } else {
             // Normal init
             setLowExposureOptimizationImpl(false);
+            disableAutoFocus();
             usbCameraSettables = new USBCameraSettables(config);
             usbFrameProvider = new USBFrameProvider(cvSink, usbCameraSettables);
+        }
+    }
+
+    void disableAutoFocus() {
+        VideoProperty autoFocus = camera.getProperty("focus_auto");
+        VideoProperty focusValue = camera.getProperty("focus_absolute");
+
+        // These values are from a Logitech C925-e
+        if (autoFocus.isBoolean() && focusValue.isInteger()) {
+            logger.info("Disabling Auto Focus on USB Camera");
+            autoFocus.set(0);
+            focusValue.set(0); // Focus into infinity
         }
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -73,9 +73,7 @@ public class USBCameraSource extends VisionSource {
         VideoProperty autoFocus = camera.getProperty("focus_auto");
         VideoProperty focusValue = camera.getProperty("focus_absolute");
 
-        // These values are from a Logitech C925-e
         if (autoFocus.isBoolean() && focusValue.isInteger()) {
-            logger.info("Disabling Auto Focus on USB Camera");
             autoFocus.set(0);
             focusValue.set(0); // Focus into infinity
         }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -70,12 +70,13 @@ public class USBCameraSource extends VisionSource {
     }
 
     void disableAutoFocus() {
-        VideoProperty autoFocus = camera.getProperty("focus_auto");
-        VideoProperty focusValue = camera.getProperty("focus_absolute");
-
-        if (autoFocus.isBoolean() && focusValue.isInteger()) {
-            autoFocus.set(0);
-            focusValue.set(0); // Focus into infinity
+        if (cameraQuirks.hasQuirk(CameraQuirk.AdjustableFocus)) {
+            try {
+                camera.getProperty("focus_auto").set(0);
+                camera.getProperty("focus_absolute").set(0); // Focus into infinity
+            } catch (VideoException e) {
+                logger.error("Unable to disable autofocus!", e);
+            }
         }
     }
 


### PR DESCRIPTION
My Logitech C925-e has auto focus enabled by default, which causes issues with the camera calibration. This PR disables auto focus, though I'm not sure how universal the two properties I used are. I tested this on my Raspberry Pi 3b.