### PR TITLE
Stop camera gain from throwing errors

### DIFF
--- a/photon-client/src/views/PipelineViews/InputTab.vue
+++ b/photon-client/src/views/PipelineViews/InputTab.vue
@@ -31,13 +31,13 @@
     <CVslider
       v-if="cameraGain >= 0"
       v-model="cameraGain"
-      name="Camera gain"
+      name="Camera Gain"
       min="0"
       max="100"
       tooltip="Controls camera gain, similar to brightness"
       :slider-cols="largeBox"
-      @input="handlePipelineData('cameraRedGain')"
-      @rollback="e => rollback('cameraRedGain', e)"
+      @input="handlePipelineData('cameraGain')"
+      @rollback="e => rollback('cameraGain', e)"
     />
     <CVslider
       v-if="cameraRedGain !== -1"
@@ -142,6 +142,14 @@
                 },
                 set(val) {
                     this.$store.commit("mutatePipeline", {"cameraBrightness": parseInt(val)});
+                }
+            },
+            cameraGain: {
+                get() {
+                    return parseInt(this.$store.getters.currentPipelineSettings.cameraGain)
+                },
+                set(val) {
+                    this.$store.commit("mutatePipeline", {"cameraGain": parseInt(val)});
                 }
             },
             cameraRedGain: {


### PR DESCRIPTION
The "camera gain" slider is not connected to Vue and throws console exceptions constantly.
![image](https://user-images.githubusercontent.com/31329139/195156592-0bc1fc45-bec9-43ee-8e62-c0a0b79ddbed.png)
This PR adds the data getter/setter to fix it. It does send it to store, but I didn't add it with a default value in store/index.js as I'm not sure of the endgoal.