### PR TITLE
Correct image capture time

### DIFF
--- a/photonlib-java-examples/src/main/java/org/photonlib/examples/simposeest/robot/DrivetrainPoseEstimator.java
+++ b/photonlib-java-examples/src/main/java/org/photonlib/examples/simposeest/robot/DrivetrainPoseEstimator.java
@@ -86,7 +86,7 @@ public class DrivetrainPoseEstimator {
 
         var res = cam.getLatestResult();
         if (res.hasTargets()) {
-            double imageCaptureTime = Timer.getFPGATimestamp() - res.getLatencyMillis();
+            double imageCaptureTime = Timer.getFPGATimestamp() - res.getLatencyMillis() - 1000;
             Transform3d camToTargetTrans = res.getBestTarget().getCameraToTarget();
             var transform =
                     new Transform2d(

--- a/photonlib-java-examples/src/main/java/org/photonlib/examples/simposeest/robot/DrivetrainPoseEstimator.java
+++ b/photonlib-java-examples/src/main/java/org/photonlib/examples/simposeest/robot/DrivetrainPoseEstimator.java
@@ -86,7 +86,7 @@ public class DrivetrainPoseEstimator {
 
         var res = cam.getLatestResult();
         if (res.hasTargets()) {
-            double imageCaptureTime = Timer.getFPGATimestamp() - res.getLatencyMillis() / 1000d;
+            double imageCaptureTime = Timer.getFPGATimestamp() - res.getLatencyMillis() / 1000.0;
             Transform3d camToTargetTrans = res.getBestTarget().getCameraToTarget();
             var transform =
                     new Transform2d(

--- a/photonlib-java-examples/src/main/java/org/photonlib/examples/simposeest/robot/DrivetrainPoseEstimator.java
+++ b/photonlib-java-examples/src/main/java/org/photonlib/examples/simposeest/robot/DrivetrainPoseEstimator.java
@@ -86,7 +86,7 @@ public class DrivetrainPoseEstimator {
 
         var res = cam.getLatestResult();
         if (res.hasTargets()) {
-            double imageCaptureTime = Timer.getFPGATimestamp() - res.getLatencyMillis() - 1000;
+            double imageCaptureTime = Timer.getFPGATimestamp() - res.getLatencyMillis() / 1000d;
             Transform3d camToTargetTrans = res.getBestTarget().getCameraToTarget();
             var transform =
                     new Transform2d(


### PR DESCRIPTION
`Timer.getFPGATimesptamp()` returns the current time in _seconds_, but `res.getLatencyMillis()` is in _miliseconds_.

Fixes #498 