### PR TITLE
Fix Camera Calibration Frontend

### DIFF
--- a/photon-client/src/views/CamerasView.vue
+++ b/photon-client/src/views/CamerasView.vue
@@ -432,13 +432,11 @@ export default {
                 return filtered
             }
         },
-
         stringResolutionList: {
             get() {
                 return this.filteredResolutionList.map(res => `${res['width']} X ${res['height']}`);
             }
         },
-
         cameraSettings: {
             get() {
                 return this.$store.getters.currentCameraSettings;
@@ -447,7 +445,6 @@ export default {
                 this.$store.commit('cameraSettings', value);
             }
         },
-
         boardType: {
             get() {
                 return this.calibrationData.boardType
@@ -503,6 +500,17 @@ export default {
         isCalibrating: {
             get() {
                 return this.$store.getters.currentPipelineIndex === -2;
+            }
+        },
+        resolutionList: {
+            get() {
+                let temp_dict = {};
+                let videoFormatList = this.$store.getters.videoFormatList;
+                for(let i = 0; i < videoFormatList.length; i++) {
+                  let videoFormat = videoFormatList[i];
+                  temp_dict[videoFormat["width"]+" X "+videoFormat["height"]] = i;
+                }
+                return temp_dict;
             }
         },
         selectedFilteredResIndex: {
@@ -647,17 +655,15 @@ export default {
                 ['cameraIndex']: this.$store.state.currentCameraIndex
             };
 
-            this.$store.commit('currentPipelineIndex', -2);
             if (this.isCalibrating === true) {
                 data['takeCalibrationSnapshot'] = true
             } else {
                 const calData = this.calibrationData;
                 calData.isCalibrating = true;
                 data['startPnpCalibration'] = calData;
-
                 console.log("starting calibration with index " + calData.videoModeIndex);
             }
-
+            this.$store.commit('currentPipelineIndex', -2);
             this.$socket.send(this.$msgPack.encode(data));
         },
         sendCalibrationFinish() {

--- a/photon-client/src/views/CamerasView.vue
+++ b/photon-client/src/views/CamerasView.vue
@@ -647,6 +647,7 @@ export default {
                 ['cameraIndex']: this.$store.state.currentCameraIndex
             };
 
+            this.$store.commit('currentPipelineIndex', -2);
             if (this.isCalibrating === true) {
                 data['takeCalibrationSnapshot'] = true
             } else {

--- a/photon-client/src/views/CamerasView.vue
+++ b/photon-client/src/views/CamerasView.vue
@@ -502,17 +502,6 @@ export default {
                 return this.$store.getters.currentPipelineIndex === -2;
             }
         },
-        resolutionList: {
-            get() {
-                let temp_dict = {};
-                let videoFormatList = this.$store.getters.videoFormatList;
-                for(let i = 0; i < videoFormatList.length; i++) {
-                  let videoFormat = videoFormatList[i];
-                  temp_dict[videoFormat["width"]+" X "+videoFormat["height"]] = i;
-                }
-                return temp_dict;
-            }
-        },
         selectedFilteredResIndex: {
             get() {
                 return this.filteredVideomodeIndex
@@ -658,6 +647,8 @@ export default {
             if (this.isCalibrating === true) {
                 data['takeCalibrationSnapshot'] = true
             } else {
+                // This store prevents an edge case of a user not selecting a different resolution, which causes the set logic to not be called
+                this.$store.commit('mutateCalibrationState', {['videoModeIndex']: this.filteredResolutionList[this.selectedFilteredResIndex].index});
                 const calData = this.calibrationData;
                 calData.isCalibrating = true;
                 data['startPnpCalibration'] = calData;

--- a/photon-client/src/views/PipelineViews/TargetsTab.vue
+++ b/photon-client/src/views/PipelineViews/TargetsTab.vue
@@ -50,7 +50,7 @@
                 </th>
               </template>
               <template v-if="$store.getters.pipelineType === 4 && $store.getters.currentPipelineSettings.solvePNPEnabled">
-                <th class="text-center" >
+                <th class="text-center">
                   Ambiguity
                 </th>
               </template>
@@ -82,9 +82,9 @@
                 <td>{{ (parseFloat(value.pose.angle_z) * 180 / Math.PI).toFixed(2) }}&deg;</td>
               </template>
               <template v-if="$store.getters.pipelineType === 4 && $store.getters.currentPipelineSettings.solvePNPEnabled">
-              <td>
-                {{ parseFloat(value.ambiguity).toFixed(2) }}
-              </td>
+                <td>
+                  {{ parseFloat(value.ambiguity).toFixed(2) }}
+                </td>
               </template>
             </tr>
           </tbody>


### PR DESCRIPTION
This PR fixes two issues with the camera calibration frontend.

1. The start calibration button now works without having to refresh the page. This issue was caused by the pipeline index not being updated.
2. The video calibration resolution selection works correctly. The original issue was an incorrect mapping of resolutions to VideoMode indices. I chose to keep it only dependent on resolution, and my algorithm chooses the last of each resolution (which always has the highest FPS) to calibrate with.