### PR TITLE
Fix pipeline setting update not being sent if only autoexposure fails

### DIFF
--- a/photon-client/src/App.vue
+++ b/photon-client/src/App.vue
@@ -308,11 +308,7 @@ export default {
                 } else if (this.$store.state.settings.hasOwnProperty(key)) {
                     this.$store.commit('mutateSettings', {[key]: value});
                 } else {
-                    switch (key) {
-                        default: {
-                            console.error("Unknown message from backend: " + value);
-                        }
-                    }
+                    console.error("Unknown message from backend: " + value);
                 }
             },
             toggleCompactMode() {

--- a/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
@@ -181,17 +181,17 @@ public class PipelineManager {
             var desiredPipelineSettings = userPipelineSettings.get(currentPipelineIndex);
             switch (desiredPipelineSettings.pipelineType) {
                 case Reflective:
-                    logger.debug("Creatig Reflective pipeline");
+                    logger.debug("Creating Reflective pipeline");
                     currentUserPipeline =
                             new ReflectivePipeline((ReflectivePipelineSettings) desiredPipelineSettings);
                     break;
                 case ColoredShape:
-                    logger.debug("Creatig ColoredShape pipeline");
+                    logger.debug("Creating ColoredShape pipeline");
                     currentUserPipeline =
                             new ColoredShapePipeline((ColoredShapePipelineSettings) desiredPipelineSettings);
                     break;
                 case AprilTag:
-                    logger.debug("Creatig AprilTag pipeline");
+                    logger.debug("Creating AprilTag pipeline");
                     currentUserPipeline =
                             new AprilTagPipeline((AprilTagPipelineSettings) desiredPipelineSettings);
                     break;

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -17,6 +17,7 @@
 
 package org.photonvision.vision.processes;
 
+import edu.wpi.first.cscore.VideoException;
 import edu.wpi.first.math.util.Units;
 import io.javalin.websocket.WsContext;
 import java.util.*;
@@ -388,8 +389,12 @@ public class VisionModule {
         }
 
         visionSource.getSettables().setExposure(pipelineSettings.cameraExposure);
-        visionSource.getSettables().setAutoExposure(pipelineSettings.cameraAutoExposure);
-
+        try {
+            visionSource.getSettables().setAutoExposure(pipelineSettings.cameraAutoExposure);
+        } catch (VideoException e) {
+            logger.error("Unable to set camera auto exposure!");
+            logger.error(e.toString());
+        }
         if (cameraQuirks.hasQuirk(CameraQuirk.Gain)) {
             // If the gain is disabled for some reason, re-enable it
             if (pipelineSettings.cameraGain == -1) pipelineSettings.cameraGain = 20;


### PR DESCRIPTION
Closes #559 

The issue was due to `visionSource.getSettables().setAutoExposure(pipelineSettings.cameraAutoExposure);
` failing on my camera. Its failure caused an exception, which breaks the parent method preventing the data from being sent. The pipeline change happens before the camera auto exposure, so it follows that even if auto exposure fails, the client should be alerted of the pipeline change. This is accomplished by a simple catch.