### PR TITLE
Fix mismatched doc building python version that prevents package install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
       # Install Python.
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The AprilTag documentation PR required a package only available with Python 3.9 (furo 2022.9^). The CI for /photonvision uses Python 3.6. This PR fixes the CI for /photonvision: