### PR TITLE
OV9281 exposure quirk 

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
@@ -30,4 +30,6 @@ public enum CameraQuirk {
     CompletelyBroken,
     /** Has adjustable focus and autofocus switch */
     AdjustableFocus,
+    /** Limits useful exposure to the first ~2% of the range, so we scale our UI slider differently.*/
+    LimitedExposure,
 }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
@@ -30,6 +30,8 @@ public enum CameraQuirk {
     CompletelyBroken,
     /** Has adjustable focus and autofocus switch */
     AdjustableFocus,
-    /** Limits useful exposure to the first ~2% of the range, so we scale our UI slider differently.*/
+    /**
+     * Limits useful exposure to the first ~2% of the range, so we scale our UI slider differently.
+     */
     LimitedExposure,
 }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
@@ -43,7 +43,12 @@ public class QuirkyCamera {
                     new QuirkyCamera(0x2000, 0x1415, CameraQuirk.Gain, CameraQuirk.FPSCap100), // PS3Eye
                     new QuirkyCamera(
                             -1, -1, "mmal service 16.1", CameraQuirk.PiCam), // PiCam (via V4L2, not zerocopy)
-                    new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus) // Logitech C925-e
+                    new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus), // Logitech C925-e
+                    new QuirkyCamera(
+                        0x0,
+                        0x0,
+                        "Arducam OV9281 USB Camera",
+                        CameraQuirk.LimitedExposure) //OV9281 global shutter
                     );
 
     public static final QuirkyCamera DefaultCamera = new QuirkyCamera(0, 0, "");

--- a/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
@@ -45,10 +45,10 @@ public class QuirkyCamera {
                             -1, -1, "mmal service 16.1", CameraQuirk.PiCam), // PiCam (via V4L2, not zerocopy)
                     new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus), // Logitech C925-e
                     new QuirkyCamera(
-                        0x0,
-                        0x0,
-                        "Arducam OV9281 USB Camera",
-                        CameraQuirk.LimitedExposure) //OV9281 global shutter
+                            0x0,
+                            0x0,
+                            "Arducam OV9281 USB Camera",
+                            CameraQuirk.LimitedExposure) // OV9281 global shutter
                     );
 
     public static final QuirkyCamera DefaultCamera = new QuirkyCamera(0, 0, "");

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -179,21 +179,20 @@ public class USBCameraSource extends VisionSource {
                 try {
                     int scaledExposure = 1;
                     if (cameraQuirks.hasQuirk(CameraQuirk.PiCam)) {
-                        //Pi Camera
+                        // Pi Camera
                         scaledExposure =
                                 (int) Math.round(timeToPiCamRawExposure(pctToExposureTimeUs(exposure)));
                         logger.debug("Setting camera raw exposure to " + Integer.toString(scaledExposure));
                         camera.getProperty("raw_exposure_time_absolute").set(scaledExposure);
                         camera.getProperty("raw_exposure_time_absolute").set(scaledExposure);
                     } else if (cameraQuirks.hasQuirk(CameraQuirk.LimitedExposure)) {
-                        //"Special" USB cameras that need some love and care to get the exposure range right
-                        scaledExposure = 1 +
-                                (int) Math.round( exposure * 69/100.0 );
+                        // "Special" USB cameras that need some love and care to get the exposure range right
+                        scaledExposure = 1 + (int) Math.round(exposure * 69 / 100.0);
                         logger.debug("Setting camera raw exposure to " + Integer.toString(scaledExposure));
                         camera.getProperty("exposure_absolute").set(scaledExposure);
                         camera.getProperty("exposure_absolute").set(scaledExposure);
                     } else {
-                        //Normal cameras
+                        // Normal cameras
                         scaledExposure = (int) Math.round(exposure);
                         logger.debug("Setting camera exposure to " + Integer.toString(scaledExposure));
                         camera.setExposureManual(scaledExposure);

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -179,13 +179,21 @@ public class USBCameraSource extends VisionSource {
                 try {
                     int scaledExposure = 1;
                     if (cameraQuirks.hasQuirk(CameraQuirk.PiCam)) {
+                        //Pi Camera
                         scaledExposure =
                                 (int) Math.round(timeToPiCamRawExposure(pctToExposureTimeUs(exposure)));
                         logger.debug("Setting camera raw exposure to " + Integer.toString(scaledExposure));
                         camera.getProperty("raw_exposure_time_absolute").set(scaledExposure);
                         camera.getProperty("raw_exposure_time_absolute").set(scaledExposure);
-
+                    } else if (cameraQuirks.hasQuirk(CameraQuirk.LimitedExposure)) {
+                        //"Special" USB cameras that need some love and care to get the exposure range right
+                        scaledExposure = 1 +
+                                (int) Math.round( exposure * 69/100.0 );
+                        logger.debug("Setting camera raw exposure to " + Integer.toString(scaledExposure));
+                        camera.getProperty("exposure_absolute").set(scaledExposure);
+                        camera.getProperty("exposure_absolute").set(scaledExposure);
                     } else {
+                        //Normal cameras
                         scaledExposure = (int) Math.round(exposure);
                         logger.debug("Setting camera exposure to " + Integer.toString(scaledExposure));
                         camera.setExposureManual(scaledExposure);


### PR DESCRIPTION
Adds camera quirk to handle USB cameras with a limited useful exposure range.

Closes #599 