### PR TITLE
Websocket Stream Stats & Robustness Improvements

### DIFF
--- a/photon-client/src/components/common/cv-image.vue
+++ b/photon-client/src/components/common/cv-image.vue
@@ -1,25 +1,13 @@
 <template>
-  <div class="img_container">
-    <img
-      :id="id"
-      crossOrigin="anonymous"
-      :style="styleObject"
-      :src="src"
-      alt=""
-      @click="e => {this.openThinclientStream(e)}"
-    >
-  </div>
+  <img
+    :id="id"
+    crossOrigin="anonymous"
+    :style="styleObject"
+    :src="src"
+    alt=""
+    @click="e => {this.openThinclientStream(e)}"
+  >
 </template>
-
-<style scoped>
-.img_container {
-  position: relative;
-  text-align: center;
-  width: 100%;
-  height: 100%;
-}
-
-</style>
 
 
 <script>

--- a/photon-client/src/components/common/cv-image.vue
+++ b/photon-client/src/components/common/cv-image.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="img_container">
     <img
       :id="id"
       crossOrigin="anonymous"
@@ -10,6 +10,17 @@
     >
   </div>
 </template>
+
+<style scoped>
+.img_container {
+  position: relative;
+  text-align: center;
+  width: 100%;
+  height: 100%;
+}
+
+</style>
+
 
 <script>
     export default {

--- a/photon-client/src/components/common/cv-image.vue
+++ b/photon-client/src/components/common/cv-image.vue
@@ -1,12 +1,14 @@
 <template>
-  <img
-    :id="id"
-    crossOrigin="anonymous"
-    :style="styleObject"
-    :src="src"
-    alt=""
-    @click="e => {this.openThinclientStream(e)}"
-  >
+  <div class="container">
+    <img
+      :id="id"
+      crossOrigin="anonymous"
+      :style="styleObject"
+      :src="src"
+      alt=""
+      @click="e => {this.openThinclientStream(e)}"
+    >
+  </div>
 </template>
 
 <script>

--- a/photon-client/src/components/common/cv-input.vue
+++ b/photon-client/src/components/common/cv-input.vue
@@ -26,7 +26,7 @@
     </v-row>
   </div>
 </template>
-s
+
 <script>
     import TooltippedLabel from "./cv-tooltipped-label";
 

--- a/photon-client/src/plugins/WebsocketVideoStream.js
+++ b/photon-client/src/plugins/WebsocketVideoStream.js
@@ -11,7 +11,7 @@ class StatsHistoryBuffer{
         this.bitAvgAccum = 0;
         
         //calculated vals
-        this.bitRate_mbps = 0;
+        this.bitRate_kbps = 0;
         this.framerate_fps = 0;
     }
 
@@ -37,7 +37,7 @@ class StatsHistoryBuffer{
     
             this.bitAvgAccum -= oldFrameSize;
     
-            this.bitRate_mbps = ( (this.bitAvgAccum/this.windowLen) / deltaTime_s ) * (1.0/1048576.0);
+            this.bitRate_kbps = ( (this.bitAvgAccum/this.windowLen) / deltaTime_s ) * (1.0/1024.0);
             this.framerate_fps = (dispFrame_count - oldFrameCount) / deltaTime_s;
         }
 
@@ -45,7 +45,7 @@ class StatsHistoryBuffer{
     }
 
     getText(){
-        return "Streaming at " + this.framerate_fps.toFixed(1) + "FPS  " + this.bitRate_mbps.toFixed(2) + "Mbps";
+        return "Streaming at " + this.framerate_fps.toFixed(1) + "FPS  " + this.bitRate_kbps.toFixed(2) + "kbps";
     }
 
 }
@@ -311,7 +311,7 @@ export class WebsocketVideoStream{
                 this.frameRxCount++;
 
                 //keep the stats up to date
-                this.stats.addSample(msgTime_s,this.imgData.size,this.dispFrameCount);
+                this.stats.addSample(msgTime_s,this.imgData.size * 8,this.dispFrameCount);
             } else {
                 console.log("WS Stream Error: Server sent empty frame!");
             }

--- a/photon-client/src/plugins/WebsocketVideoStream.js
+++ b/photon-client/src/plugins/WebsocketVideoStream.js
@@ -3,13 +3,13 @@
 // will be returned if you try to get them, trying to set is an exception).
 // n represents the initial length of the array, not a maximum
 class StatsHistoryBuffer{
-    constructor (){ 
+    constructor (){
         this.windowLen = 10;
         this._array= new Array(this.windowLen);
         this.headPtr = 0;
         this.frameCount = 0;
         this.bitAvgAccum = 0;
-        
+
         //calculated vals
         this.bitRate_Mbps = 0;
         this.framerate_fps = 0;
@@ -32,11 +32,11 @@ class StatsHistoryBuffer{
             var oldTime = oldVal[0];
             var oldFrameSize = oldVal[1];
             var oldFrameCount = oldVal[2];
-    
+
             var deltaTime_s = (time - oldTime);
-    
+
             this.bitAvgAccum -= oldFrameSize;
-    
+
             //bitrate - total bits transferred over the time period, divided by the period length
             // converted to mbps
             this.bitRate_Mbps = ( this.bitAvgAccum / deltaTime_s ) * (1.0/1048576.0);

--- a/photon-client/src/views/PipelineView.vue
+++ b/photon-client/src/views/PipelineView.vue
@@ -33,7 +33,7 @@
                 :color="fpsTooLow ? 'error' : 'transparent'"
                 :text-color="fpsTooLow ? 'white' : 'grey'"
               >
-                <span class="pr-1">Processing at {{ Math.round($store.state.pipelineResults.fps) }}&nbsp;FPS &ndash;</span>
+                <span class="pr-1">Processing @ {{ Math.round($store.state.pipelineResults.fps) }}&nbsp;FPS &ndash;</span>
                 <span v-if="!fpsTooLow">{{ Math.min(Math.round($store.state.pipelineResults.latency), 9999) }} ms latency</span>
                 <span v-else-if="!$store.getters.currentPipelineSettings.inputShouldShow">HSV thresholds are too broad; narrow them for better performance</span>
                 <span v-else>stop viewing the raw stream for better performance</span>

--- a/photon-client/src/views/PipelineView.vue
+++ b/photon-client/src/views/PipelineView.vue
@@ -33,7 +33,7 @@
                 :color="fpsTooLow ? 'error' : 'transparent'"
                 :text-color="fpsTooLow ? 'white' : 'grey'"
               >
-                <span class="pr-1">{{ Math.round($store.state.pipelineResults.fps) }}&nbsp;FPS &ndash;</span>
+                <span class="pr-1">Processing at {{ Math.round($store.state.pipelineResults.fps) }}&nbsp;FPS &ndash;</span>
                 <span v-if="!fpsTooLow">{{ Math.min(Math.round($store.state.pipelineResults.latency), 9999) }} ms latency</span>
                 <span v-else-if="!$store.getters.currentPipelineSettings.inputShouldShow">HSV thresholds are too broad; narrow them for better performance</span>
                 <span v-else>stop viewing the raw stream for better performance</span>

--- a/photon-core/src/main/java/org/photonvision/vision/videoStream/SocketVideoStream.java
+++ b/photon-core/src/main/java/org/photonvision/vision/videoStream/SocketVideoStream.java
@@ -18,7 +18,6 @@
 package org.photonvision.vision.videoStream;
 
 import java.nio.ByteBuffer;
-import java.util.Base64;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -75,16 +74,6 @@ public class SocketVideoStream implements Consumer<Frame> {
             }
         }
         oldSchoolServer.accept(frame);
-    }
-
-    public String getJPEGBase64EncodedStr() {
-        String sendStr = null;
-        jpegBytesLock.lock();
-        if (jpegBytes != null) {
-            sendStr = Base64.getEncoder().encodeToString(jpegBytes.toArray());
-        }
-        jpegBytesLock.unlock();
-        return sendStr;
     }
 
     public ByteBuffer getJPEGByteBuffer() {

--- a/photon-server/src/main/java/org/photonvision/server/CameraSocketHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/CameraSocketHandler.java
@@ -51,7 +51,7 @@ public class CameraSocketHandler {
 
     private CameraSocketHandler() {
         cameraBroadcastThread = new Thread(this::broadcastFramesTask);
-        cameraBroadcastThread.setPriority(2); // fairly low priority
+        cameraBroadcastThread.setPriority(Thread.MAX_PRIORITY - 3); // fairly high priority
         cameraBroadcastThread.start();
     }
 


### PR DESCRIPTION
A collection of small tweaks meant to address some of the issues users have reported with stream robustness.

- Increased priority of the ws stream thread on the server side
- Added client-side stream stat tracking
- Added mouseover-driven overlay of the stats to each image in the main UI
  - skipped the thinclient, since it's fullscreen and likely to have a mouse over it anyway
- Reordered client-side temporary URL creation/revocation to ensure the browser can't reuse a URL. This is a plausable (but unproven) root cause of some "stuck stream" issues.