### PR TITLE
Set a compression level to better optimize the latency of the stream

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/frame/consumer/MJPGFrameConsumer.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/consumer/MJPGFrameConsumer.java
@@ -119,6 +119,7 @@ public class MJPGFrameConsumer {
 
         this.mjpegServer = new MjpegServer("serve_" + cvSource.getName(), port);
         mjpegServer.setSource(cvSource);
+        mjpegServer.setCompression(75);
 
         listener =
                 new VideoListener(


### PR DESCRIPTION
Reduces bytes sent, which allows for less latency in the image that's actually shown in a browser

`75` pulled from experiments done while testing websocket streaming.