### PR TITLE
Expand PhotonLib and PhotonTracking functionalities

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -46,8 +46,15 @@ public class PhotonCamera {
     protected final NetworkTable cameraTable;
 
     // NetworkTables entries
+    // Used
     RawSubscriber rawBytesEntry;
     BooleanEntry driverModeEntry;
+    StringSubscriber versionEntry;
+    BooleanPublisher inputSaveImgEntry, outputSaveImgEntry;
+    IntegerEntry pipelineIndexEntry, ledModeEntry;
+    IntegerSubscriber heartbeatEntry;
+
+    // Unused TODO: why are these here?
     BooleanPublisher driverModePublisher;
     BooleanSubscriber driverModeSubscriber;
     DoublePublisher latencyMillisEntry;
@@ -57,10 +64,6 @@ public class PhotonCamera {
     DoublePublisher targetAreaEntry;
     DoubleArrayPublisher targetPoseEntry;
     DoublePublisher targetSkewEntry;
-    StringSubscriber versionEntry;
-    BooleanPublisher inputSaveImgEntry, outputSaveImgEntry;
-    IntegerEntry pipelineIndexEntry, ledModeEntry;
-    IntegerSubscriber heartbeatEntry;
 
     /**
      * Close out the NetworkTables entries used to communicate with the camera and releases their resources.

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -66,9 +66,12 @@ public class PhotonCamera {
     DoublePublisher targetSkewEntry;
 
     /**
-     * Close out the NetworkTables entries used to communicate with the camera and releases their resources.
+     * Close out the NetworkTables entries used to communicate with the camera and releases their
+     * resources.
      */
     public void close() {
+        // TODO: what is the point of this method, most teams create the object in RobotInit then leave
+        // the object for the lifecycle of the robot, this serves no purpose.
         rawBytesEntry.close();
         driverModeEntry.close();
         driverModePublisher.close();
@@ -160,7 +163,8 @@ public class PhotonCamera {
 
         // Set the timestamp of the result.
         // getLatestChange returns in microseconds; divide by 1e6 to convert it to seconds.
-        pipelineResult.setTimestampSeconds((rawBytesEntry.getLastChange() / 1e6) - pipelineResult.getLatencyMillis() / 1e3);
+        pipelineResult.setTimestampSeconds(
+                (rawBytesEntry.getLastChange() / 1e6) - pipelineResult.getLatencyMillis() / 1e3);
 
         // Return result.
         return pipelineResult;
@@ -183,7 +187,6 @@ public class PhotonCamera {
     public void setCamMode(VisionCamMode mode) {
         driverModeEntry.set(mode == VisionCamMode.kDriver);
     }
-
 
     /**
      * Returns whether the camera is in driver mode.
@@ -307,7 +310,6 @@ public class PhotonCamera {
         long curHeartbeat = heartbeatEntry.get();
         double now = Timer.getFPGATimestamp();
 
-
         if (curHeartbeat != prevHeartbeatValue) {
             // New heartbeat value from the coprocessor
             prevHeartbeatChangeTime = now;
@@ -327,13 +329,15 @@ public class PhotonCamera {
         // assume that a camera with that name was never connected in the first place.
         if (!heartbeatEntry.exists()) {
             DriverStation.reportError(
-                    "PhotonVision coprocessor at path " + cameraTablePath + " not found on NetworkTables!", true);
+                    "PhotonVision coprocessor at path " + cameraTablePath + " not found on NetworkTables!",
+                    true);
         }
 
         // Check for connection status. Warn if disconnected.
         if (!isConnected()) {
             DriverStation.reportWarning(
-                    "PhotonVision coprocessor at path " + cameraTablePath + " is not sending new data.", true);
+                    "PhotonVision coprocessor at path " + cameraTablePath + " is not sending new data.",
+                    true);
         }
 
         // Check for version. Warn if the versions aren't aligned.

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -104,6 +104,8 @@ public class PhotonCamera {
 
     private final Packet packet = new Packet(1);
 
+    private final PhotonCameraMountConfig cameraMountConfig;
+
     /**
      * Constructs a PhotonCamera from a root table.
      *
@@ -111,9 +113,12 @@ public class PhotonCamera {
      *     simulation, but should *usually* be the default NTInstance from
      *     NetworkTableInstance::getDefault
      * @param cameraName The name of the camera, as seen in the UI.
+     * @param config The mount config of the PhotonCamera.
      */
-    public PhotonCamera(NetworkTableInstance instance, String cameraName) {
+    public PhotonCamera(
+            NetworkTableInstance instance, String cameraName, PhotonCameraMountConfig config) {
         this.cameraName = cameraName;
+        this.cameraMountConfig = config;
 
         NetworkTable photonTable = instance.getTable("photonvision");
         this.ledModeEntry = photonTable.getIntegerTopic("ledMode").getEntry(-1);
@@ -133,9 +138,10 @@ public class PhotonCamera {
      * Constructs a PhotonCamera from the name of the camera.
      *
      * @param cameraName The nickname of the camera (found in the PhotonVision UI).
+     * @param config The mount config of the PhotonCamera.
      */
-    public PhotonCamera(String cameraName) {
-        this(NetworkTableInstance.getDefault(), cameraName);
+    public PhotonCamera(String cameraName, PhotonCameraMountConfig config) {
+        this(NetworkTableInstance.getDefault(), cameraName, config);
     }
 
     /**
@@ -295,6 +301,15 @@ public class PhotonCamera {
      */
     public String getName() {
         return cameraName;
+    }
+
+    /**
+     * Return the mount config of the photon camera.
+     *
+     * @return camera mount config.
+     */
+    public PhotonCameraMountConfig getCameraMountConfig() {
+        return cameraMountConfig;
     }
 
     /**

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -42,7 +42,7 @@ import org.photonvision.common.hardware.VisionLEDMode;
 import org.photonvision.targeting.PhotonPipelineResult;
 
 /** Represents a camera that is connected to PhotonVision. */
-public class PhotonCamera {
+public class PhotonCamera implements AutoCloseable {
     protected final NetworkTable cameraTable;
 
     // NetworkTables entries
@@ -63,29 +63,6 @@ public class PhotonCamera {
     DoublePublisher targetAreaEntry;
     DoubleArrayPublisher targetPoseEntry;
     DoublePublisher targetSkewEntry;
-
-    /**
-     * Close out the NetworkTables entries used to communicate with the camera and releases their
-     * resources.
-     */
-    public void close() {
-        rawBytesEntry.close();
-        driverModeEntry.close();
-        driverModePublisher.close();
-        driverModeSubscriber.close();
-        latencyMillisEntry.close();
-        hasTargetEntry.close();
-        targetPitchEntry.close();
-        targetYawEntry.close();
-        targetAreaEntry.close();
-        targetPoseEntry.close();
-        targetSkewEntry.close();
-        versionEntry.close();
-        inputSaveImgEntry.close();
-        outputSaveImgEntry.close();
-        pipelineIndexEntry.close();
-        ledModeEntry.close();
-    }
 
     private final String cameraTablePath;
     private final String cameraName;
@@ -365,5 +342,29 @@ public class PhotonCamera {
                             + "!",
                     true);
         }
+    }
+
+    /**
+     * Close out the NetworkTables entries used to communicate with the camera and releases their
+     * resources.
+     */
+    @Override
+    public void close() {
+        rawBytesEntry.close();
+        driverModeEntry.close();
+        driverModePublisher.close();
+        driverModeSubscriber.close();
+        latencyMillisEntry.close();
+        hasTargetEntry.close();
+        targetPitchEntry.close();
+        targetYawEntry.close();
+        targetAreaEntry.close();
+        targetPoseEntry.close();
+        targetSkewEntry.close();
+        versionEntry.close();
+        inputSaveImgEntry.close();
+        outputSaveImgEntry.close();
+        pipelineIndexEntry.close();
+        ledModeEntry.close();
     }
 }

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -54,7 +54,6 @@ public class PhotonCamera {
     IntegerEntry pipelineIndexEntry, ledModeEntry;
     IntegerSubscriber heartbeatEntry;
 
-    // Unused TODO: why are these here?
     BooleanPublisher driverModePublisher;
     BooleanSubscriber driverModeSubscriber;
     DoublePublisher latencyMillisEntry;
@@ -70,8 +69,6 @@ public class PhotonCamera {
      * resources.
      */
     public void close() {
-        // TODO: what is the point of this method, most teams create the object in RobotInit then leave
-        // the object for the lifecycle of the robot, this serves no purpose.
         rawBytesEntry.close();
         driverModeEntry.close();
         driverModePublisher.close();

--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -164,21 +164,44 @@ public class PhotonCamera {
     }
 
     /**
+     * Get the current vision mode of the camera.
+     *
+     * @return current vision mode.
+     */
+    public VisionCamMode getCamMode() {
+        return driverModeEntry.get(false) ? VisionCamMode.kDriver : VisionCamMode.kProcessing;
+    }
+
+    /**
+     * Set the current vision mode of the camera.
+     *
+     * @param mode new vision mode to set.
+     */
+    public void setCamMode(VisionCamMode mode) {
+        driverModeEntry.set(mode == VisionCamMode.kDriver);
+    }
+
+
+    /**
      * Returns whether the camera is in driver mode.
      *
      * @return Whether the camera is in driver mode.
+     * @deprecated this method should be replaced with {@link PhotonCamera#getCamMode()}
      */
+    @Deprecated
     public boolean getDriverMode() {
-        return driverModeEntry.get(false);
+        return getCamMode() == VisionCamMode.kDriver;
     }
 
     /**
      * Toggles driver mode.
      *
      * @param driverMode Whether to set driver mode.
+     * @deprecated this method should be replaced with {@link PhotonCamera#setCamMode(VisionCamMode)}
      */
+    @Deprecated
     public void setDriverMode(boolean driverMode) {
-        driverModeEntry.set(driverMode);
+        setCamMode(driverMode ? VisionCamMode.kDriver : VisionCamMode.kProcessing);
     }
 
     /**

--- a/photon-lib/src/main/java/org/photonvision/PhotonCameraMountConfig.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCameraMountConfig.java
@@ -1,0 +1,147 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 PhotonVision
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.photonvision;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Represents the position of a photon camera relative to the origin of the robot in the <a
+ * href="https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#robot-coordinate-system">Robot
+ * Coordinate System</a>.
+ */
+public class PhotonCameraMountConfig {
+    private final Pose3d robotOriginPosition;
+    private final Supplier<Pose3d> cameraPosition;
+
+    /**
+     * Construct a PhotonCameraMountConfig from a {@link Pose3d} supplier. This can be useful if the
+     * camera is mounted on a non-static surface such as a turret or telescoping pole. The supplier
+     * <b>cannot</b> return null or else an error will be thrown.
+     *
+     * @param robotOriginPosition {@link Pose3d} representing the position of the robot origin in the RCS.
+     * @param cameraPosition {@link Pose3d} supplier that returns the position of the camera in the
+     *     RCS.
+     */
+    public PhotonCameraMountConfig(Pose3d robotOriginPosition, Supplier<Pose3d> cameraPosition) {
+        this.robotOriginPosition = Objects.requireNonNull(robotOriginPosition);
+        this.cameraPosition = Objects.requireNonNull(cameraPosition);
+
+        if (!robotOriginPosition.getRotation().equals(new Rotation3d())) {
+            throw new IllegalArgumentException(
+                    "Robot origin cannot have a non-zero roll, pitch, or yaw.");
+        }
+    }
+
+    /**
+     * Construct a PhotonCameraMountConfig from a {@link Pose3d} supplier. This can be useful if the
+     * camera is mounted on a non-static surface such as a turret or telescoping pole. The supplier
+     * <b>cannot</b> return null or else an error will be thrown. Assumes that the robot origin is the
+     * point on the floor horizontally and vertically centered to the robot.
+     *
+     * @param cameraPosition {@link Pose3d} representing the position of the camera in the RCS.
+     */
+    public PhotonCameraMountConfig(Supplier<Pose3d> cameraPosition) {
+        this(new Pose3d(), cameraPosition);
+    }
+
+    /**
+     * Construct a PhotonCameraMountConfig for a statically mounted camera from the position of the
+     * camera as a {@link Pose3d}.
+     *
+     * @param robotOriginPosition {@link Pose3d} representing the position of the robot origin in the RCS.
+     * @param cameraPosition {@link Pose3d} representing the position of the camera in the RCS.
+     */
+    public PhotonCameraMountConfig(Pose3d robotOriginPosition, Pose3d cameraPosition) {
+        this(robotOriginPosition, () -> cameraPosition);
+    }
+
+    /**
+     * Construct a PhotonCameraMountConfig for a statically mounted camera from the position of the
+     * camera as a {@link Pose3d}. Assumes that the robot origin is the point on the floor
+     * horizontally and vertically centered to the robot.
+     *
+     * @param cameraPosition {@link Pose3d} of the position of the camera in the RCS.
+     */
+    public PhotonCameraMountConfig(Pose3d cameraPosition) {
+        this(new Pose3d(), cameraPosition);
+    }
+
+    /**
+     * Return the specified robot origin in the RCS.
+     *
+     * @return robot origin in the RCS.
+     */
+    public Pose3d getRobotOriginPosition() {
+        return this.robotOriginPosition;
+    }
+
+    /**
+     * Return the current position of the camera in the RCS.
+     *
+     * @return camera position in the RCS.
+     */
+    public Pose3d getCameraPosition() {
+        return Objects.requireNonNull(cameraPosition.get(), "The provided camera position was null");
+    }
+
+    /**
+     * Return the current transform between the origin of the robot to the camera.
+     *
+     * @return current {@link Transform3d}.
+     */
+    public Transform3d getRobotToCamera() {
+        return new Transform3d(robotOriginPosition, getCameraPosition());
+    }
+
+    /**
+     * Return the pitch of the camera relative to the horizontal plane the camera sits on assuming the
+     * plane bisects the camera's sensor. This angle is signed.
+     *
+     * @return camera pitch in radians.
+     * @see <a
+     *     href="https://docs.limelightvision.io/en/latest/_images/DistanceEstimation.jpg"><i>a1</i>
+     *     in the figure</a>
+     */
+    public double getCameraPitch() {
+        return getCameraPosition().getRotation().getY();
+    }
+
+    /**
+     * Return the height of the camera relative to the origin of the robot. Assuming the origin has a
+     * height/Z value of 0, this would be the height of the camera off the floor.
+     *
+     * @return height of the camera relative to the origin of the robot.
+     * @see <a
+     *     href="https://docs.limelightvision.io/en/latest/_images/DistanceEstimation.jpg"><i>h1</i>
+     *     in the figure</a>
+     */
+    public double getCameraHeight() {
+        return getCameraPosition().getTranslation().getZ();
+    }
+}

--- a/photon-lib/src/main/java/org/photonvision/PhotonCameraMountConfig.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCameraMountConfig.java
@@ -44,7 +44,8 @@ public class PhotonCameraMountConfig {
      * camera is mounted on a non-static surface such as a turret or telescoping pole. The supplier
      * <b>cannot</b> return null or else an error will be thrown.
      *
-     * @param robotOriginPosition {@link Pose3d} representing the position of the robot origin in the RCS.
+     * @param robotOriginPosition {@link Pose3d} representing the position of the robot origin in the
+     *     RCS.
      * @param cameraPosition {@link Pose3d} supplier that returns the position of the camera in the
      *     RCS.
      */
@@ -74,7 +75,8 @@ public class PhotonCameraMountConfig {
      * Construct a PhotonCameraMountConfig for a statically mounted camera from the position of the
      * camera as a {@link Pose3d}.
      *
-     * @param robotOriginPosition {@link Pose3d} representing the position of the robot origin in the RCS.
+     * @param robotOriginPosition {@link Pose3d} representing the position of the robot origin in the
+     *     RCS.
      * @param cameraPosition {@link Pose3d} representing the position of the camera in the RCS.
      */
     public PhotonCameraMountConfig(Pose3d robotOriginPosition, Pose3d cameraPosition) {

--- a/photon-lib/src/main/java/org/photonvision/SimVisionSystem.java
+++ b/photon-lib/src/main/java/org/photonvision/SimVisionSystem.java
@@ -73,7 +73,7 @@ public class SimVisionSystem {
      *     make it visible. Set to 9000 or more if your vision system does not rely on LED's.
      * @param cameraResWidth Width of your camera's image sensor in pixels
      * @param cameraResHeight Height of your camera's image sensor in pixels
-     * @param minTargetArea Minimum area that that the target should be before it's recognized as a
+     * @param minTargetArea Minimum area that the target should be before it's recognized as a
      *     target by the camera. Match this with your contour filtering settings in the PhotonVision
      *     GUI.
      */

--- a/photon-lib/src/main/java/org/photonvision/SimVisionSystem.java
+++ b/photon-lib/src/main/java/org/photonvision/SimVisionSystem.java
@@ -73,9 +73,8 @@ public class SimVisionSystem {
      *     make it visible. Set to 9000 or more if your vision system does not rely on LED's.
      * @param cameraResWidth Width of your camera's image sensor in pixels
      * @param cameraResHeight Height of your camera's image sensor in pixels
-     * @param minTargetArea Minimum area that the target should be before it's recognized as a
-     *     target by the camera. Match this with your contour filtering settings in the PhotonVision
-     *     GUI.
+     * @param minTargetArea Minimum area that the target should be before it's recognized as a target
+     *     by the camera. Match this with your contour filtering settings in the PhotonVision GUI.
      */
     public SimVisionSystem(
             String camName,

--- a/photon-lib/src/main/java/org/photonvision/VisionCamMode.java
+++ b/photon-lib/src/main/java/org/photonvision/VisionCamMode.java
@@ -1,0 +1,8 @@
+package org.photonvision;
+
+public enum VisionCamMode {
+    /** Use the vision system solely as a driver camera */
+    kDriver,
+    /** Use the vision system for vision processing */
+    kProcessing
+}


### PR DESCRIPTION
As more and more new features are added to PhotonVision, the robot code client lib seems to be feeling a little lackluster. I wanted to create this PR in order to add some ease-of-life features to PhotonLib. Here are some of the main things I want to add:
- Clean up some of the extra or useless structurings within the classes, such as excessive publicly exposed variables.
- In order to integrate with utilities within the camera, add a parameter to the PhotonCamera constructor to accept a "mount config" of the camera in the RCS like [this](https://github.com/Talon540Programming/TalonLib/blob/068680ae94adc25c296e475ecf7c3f4902775b69/src/main/java/org/talon540/sensors/vision/VisionCameraMountConfig.java).
- As previously stated, integrate a lot of the functionalities from the PhotonUtils class and other similar classes from wpi directly into the camera using a system of Optional return methods. By doing this, we can further remove a lot of the hassle behind the calculations from the user. When #571 is merged, this can also be included.
- Move sim classes into their own sim folder as done in WPI.