### PR TITLE
Change raspi to RaspberryPi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -392,7 +392,7 @@ jobs:
           include:
             - os: ubuntu-latest
               artifact-name: LinuxArm64
-              image_suffix: raspi
+              image_suffix: RaspberryPi
               image_url: https://api.github.com/repos/photonvision/photon-pi-gen/releases/tags/v2023.1.0-beta-4_arm64
             - os: ubuntu-latest
               artifact-name: LinuxArm64


### PR DESCRIPTION
People got confused when it was raspi, this makes it clear. 