### PR TITLE
RobotPoseEstimator cleanup and enhancements

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/RobotPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/RobotPoseEstimator.java
@@ -225,7 +225,7 @@ public class RobotPoseEstimator {
                 estimatedPose = closestToReferencePoseStrategy(cameraResults, referencePose);
                 break;
             case AVERAGE_BEST_TARGETS:
-                estimatedPose = Optional.empty();
+                estimatedPose = averageBestTargetsStrategy(cameraResults);
                 break;
             default:
                 DriverStation.reportError("[RobotPoseEstimator] Unknown Position Estimation Strategy!", false);
@@ -476,7 +476,7 @@ public class RobotPoseEstimator {
         Translation3d transform = new Translation3d();
         Rotation3d rotation = new Rotation3d();
 
-        if(targetData.size() == 0)
+        if(targetData.isEmpty())
             return Optional.empty();
 
         double timestampSum = 0;

--- a/photon-lib/src/main/java/org/photonvision/RobotPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/RobotPoseEstimator.java
@@ -351,9 +351,7 @@ public class RobotPoseEstimator {
         }
 
         // Need to null check here in case none of the provided targets are fiducial.
-        if (closestHeightTarget == null) return Optional.empty();
-
-        return Optional.of(closestHeightTarget);
+        return Optional.ofNullable(closestHeightTarget);
     }
 
     /**

--- a/photon-lib/src/main/java/org/photonvision/RobotPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/RobotPoseEstimator.java
@@ -269,17 +269,12 @@ public class RobotPoseEstimator {
         if(lowestAmbiguityTarget == null)
             return Optional.empty();
 
-        Optional<Pose3d> targetPosition = fieldTags.getTagPose(lowestAmbiguityTarget.getFirst().getFiducialId());
+        int targetFiducialId = lowestAmbiguityTarget.getFirst().getFiducialId();
+
+        Optional<Pose3d> targetPosition = fieldTags.getTagPose(targetFiducialId);
 
         if(targetPosition.isEmpty()) {
-            int targetFiducialId = lowestAmbiguityTarget.getFirst().getFiducialId();
-            if (!reportedErrors.contains(targetFiducialId)) {
-                DriverStation.reportError(
-                        "[RobotPoseEstimator] Tried to get pose of unknown April Tag: " + targetFiducialId,
-                        false);
-                reportedErrors.add(targetFiducialId);
-            }
-
+            reportFiducialPoseError(targetFiducialId);
             return Optional.empty();
         }
 
@@ -306,7 +301,7 @@ public class RobotPoseEstimator {
 
         for(Pair<PhotonPipelineResult, Transform3d> result : results) {
             for(PhotonTrackedTarget target : result.getFirst().targets) {
-                double targetFiducialId = target.getFiducialId();
+                int targetFiducialId = target.getFiducialId();
 
                 // Don't report errors for non-fiducial targets. This could also be resolved by adding -1 to the initial HashSet.
                 if(targetFiducialId == -1)
@@ -315,13 +310,8 @@ public class RobotPoseEstimator {
                 Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
 
                 if(targetPosition.isEmpty()) {
-                    if (!reportedErrors.contains(target.getFiducialId())) {
-                        DriverStation.reportWarning(
-                                "[RobotPoseEstimator] Tried to get pose of unknown April Tag: "
-                                        + target.getFiducialId(),
-                                false);
-                        reportedErrors.add(target.getFiducialId());
-                    }
+                    reportFiducialPoseError(target.getFiducialId());
+                    continue;
                 }
 
                 double alternateTransformDelta = Math.abs(
@@ -385,7 +375,7 @@ public class RobotPoseEstimator {
 
         for(Pair<PhotonPipelineResult, Transform3d> result : results) {
             for(PhotonTrackedTarget target : result.getFirst().targets) {
-                double targetFiducialId = target.getFiducialId();
+                int targetFiducialId = target.getFiducialId();
 
                 // Don't report errors for non-fiducial targets. This could also be resolved by adding -1 to the initial HashSet.
                 if(targetFiducialId == -1)
@@ -394,13 +384,8 @@ public class RobotPoseEstimator {
                 Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
 
                 if(targetPosition.isEmpty()) {
-                    if (!reportedErrors.contains(target.getFiducialId())) {
-                        DriverStation.reportWarning(
-                                "[RobotPoseEstimator] Tried to get pose of unknown April Tag: "
-                                        + target.getFiducialId(),
-                                false);
-                        reportedErrors.add(target.getFiducialId());
-                    }
+                    reportFiducialPoseError(targetFiducialId);
+                    continue;
                 }
 
                 Pose3d altTransformPosition = targetPosition.get()
@@ -445,7 +430,7 @@ public class RobotPoseEstimator {
 
         for(Pair<PhotonPipelineResult, Transform3d> result : results) {
             for(PhotonTrackedTarget target : result.getFirst().targets) {
-                double targetFiducialId = target.getFiducialId();
+                int targetFiducialId = target.getFiducialId();
 
                 // Don't report errors for non-fiducial targets. This could also be resolved by adding -1 to the initial HashSet.
                 if(targetFiducialId == -1)
@@ -454,13 +439,8 @@ public class RobotPoseEstimator {
                 Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
 
                 if(targetPosition.isEmpty()) {
-                    if (!reportedErrors.contains(target.getFiducialId())) {
-                        DriverStation.reportWarning(
-                                "[RobotPoseEstimator] Tried to get pose of unknown April Tag: "
-                                        + target.getFiducialId(),
-                                false);
-                        reportedErrors.add(target.getFiducialId());
-                    }
+                    reportFiducialPoseError(targetFiducialId);
+                    continue;
                 }
 
                 double targetPoseAmbiguity = target.getPoseAmbiguity();

--- a/photon-lib/src/main/native/cpp/photonlib/RobotPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/RobotPoseEstimator.cpp
@@ -58,7 +58,7 @@ std::pair<frc::Pose3d, units::second_t> RobotPoseEstimator::Update() {
   if (cameras.empty()) {
     return std::make_pair(lastPose, units::seconds_t(0));
   }
-  
+
   std::pair<frc::Pose3d, units::second_t> pair;
   switch (strategy) {
     case LOWEST_AMBIGUITY:
@@ -83,12 +83,12 @@ std::pair<frc::Pose3d, units::second_t> RobotPoseEstimator::Update() {
       lastPose = pair.first;
       return pair;
     default:
-      FRC_ReportError(frc::warn::Warning, "Invalid Pose Strategy selected!","");
+      FRC_ReportError(frc::warn::Warning, "Invalid Pose Strategy selected!",
+                      "");
   }
-  
+
   return std::make_pair(lastPose, units::second_t(0));
 }
-
 
 std::pair<frc::Pose3d, units::second_t>
 RobotPoseEstimator::LowestAmbiguityStrategy() {
@@ -178,7 +178,8 @@ RobotPoseEstimator::ClosestToCameraHeightStrategy() {
 
 std::pair<frc::Pose3d, units::second_t>
 RobotPoseEstimator::ClosestToReferencePoseStrategy() {
-  units::meter_t smallestDifference = units::meter_t(std::numeric_limits<double>::infinity());
+  units::meter_t smallestDifference =
+      units::meter_t(std::numeric_limits<double>::infinity());
   units::second_t stateTimestamp = units::second_t(0);
   frc::Pose3d pose = lastPose;
 
@@ -226,7 +227,8 @@ RobotPoseEstimator::ClosestToReferencePoseStrategy() {
 
 std::pair<frc::Pose3d, units::second_t>
 RobotPoseEstimator::AverageBestTargetsStrategy() {
-  std::vector<std::pair<frc::Pose3d, std::pair<double, units::second_t>>> tempPoses;
+  std::vector<std::pair<frc::Pose3d, std::pair<double, units::second_t>>>
+      tempPoses;
   double totalAmbiguity = 0;
   units::second_t timstampSum = units::second_t(0);
 
@@ -263,7 +265,7 @@ RobotPoseEstimator::AverageBestTargetsStrategy() {
                          p.first->GetLatestResult().GetTimestamp()));
     }
   }
-  
+
   frc::Translation3d transform = frc::Translation3d();
   frc::Rotation3d rotation = frc::Rotation3d();
 
@@ -274,6 +276,7 @@ RobotPoseEstimator::AverageBestTargetsStrategy() {
     rotation = rotation + pair.first.Rotation() * weight;
   }
 
-  return std::make_pair(frc::Pose3d(transform, rotation), timstampSum / cameras.size());
+  return std::make_pair(frc::Pose3d(transform, rotation),
+                        timstampSum / cameras.size());
 }
 }  // namespace photonlib

--- a/photon-lib/src/main/native/cpp/photonlib/RobotPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/RobotPoseEstimator.cpp
@@ -56,7 +56,7 @@ RobotPoseEstimator::RobotPoseEstimator(
 
 std::pair<frc::Pose3d, units::second_t> RobotPoseEstimator::Update() {
   if (cameras.empty()) {
-    return std::make_pair(lastPose, units::seconds_t(0));
+    return std::make_pair(lastPose, units::second_t(0));
   }
 
   std::pair<frc::Pose3d, units::second_t> pair;
@@ -262,7 +262,7 @@ RobotPoseEstimator::AverageBestTargetsStrategy() {
       tempPoses.push_back(std::make_pair(
           targetPose.TransformBy(target.GetBestCameraToTarget().Inverse()),
           std::make_pair(target.GetPoseAmbiguity(),
-                         p.first->GetLatestResult().GetTimestamp()));
+                         p.first->GetLatestResult().GetTimestamp())));
     }
   }
 

--- a/photon-lib/src/main/native/cpp/photonlib/RobotPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/RobotPoseEstimator.cpp
@@ -54,11 +54,12 @@ RobotPoseEstimator::RobotPoseEstimator(
       lastPose(frc::Pose3d()),
       referencePose(frc::Pose3d()) {}
 
-std::pair<frc::Pose3d, units::millisecond_t> RobotPoseEstimator::Update() {
+std::pair<frc::Pose3d, units::second_t> RobotPoseEstimator::Update() {
   if (cameras.empty()) {
-    return std::make_pair(lastPose, units::millisecond_t(0));
+    return std::make_pair(lastPose, units::seconds_t(0));
   }
-  std::pair<frc::Pose3d, units::millisecond_t> pair;
+  
+  std::pair<frc::Pose3d, units::second_t> pair;
   switch (strategy) {
     case LOWEST_AMBIGUITY:
       pair = LowestAmbiguityStrategy();
@@ -73,7 +74,7 @@ std::pair<frc::Pose3d, units::millisecond_t> RobotPoseEstimator::Update() {
       lastPose = pair.first;
       return pair;
     case CLOSEST_TO_LAST_POSE:
-      referencePose = lastPose;
+      SetReferencePose(lastPose);
       pair = ClosestToReferencePoseStrategy();
       lastPose = pair.first;
       return pair;
@@ -82,13 +83,14 @@ std::pair<frc::Pose3d, units::millisecond_t> RobotPoseEstimator::Update() {
       lastPose = pair.first;
       return pair;
     default:
-      FRC_ReportError(frc::warn::Warning, "Invalid Pose Strategy selected!",
-                      "");
+      FRC_ReportError(frc::warn::Warning, "Invalid Pose Strategy selected!","");
   }
-  return std::make_pair(lastPose, units::millisecond_t(0));
+  
+  return std::make_pair(lastPose, units::second_t(0));
 }
 
-std::pair<frc::Pose3d, units::millisecond_t>
+
+std::pair<frc::Pose3d, units::second_t>
 RobotPoseEstimator::LowestAmbiguityStrategy() {
   int lowestAI = -1;
   int lowestAJ = -1;
@@ -107,7 +109,7 @@ RobotPoseEstimator::LowestAmbiguityStrategy() {
   }
 
   if (lowestAI == -1 || lowestAJ == -1) {
-    return std::make_pair(lastPose, units::millisecond_t(0));
+    return std::make_pair(lastPose, units::second_t(0));
   }
 
   PhotonTrackedTarget bestTarget =
@@ -119,20 +121,21 @@ RobotPoseEstimator::LowestAmbiguityStrategy() {
     FRC_ReportError(frc::warn::Warning,
                     "Tried to get pose of unknown April Tag: {}",
                     bestTarget.GetFiducialId());
-    return std::make_pair(lastPose, units::millisecond_t(0));
+    return std::make_pair(lastPose, units::second_t(0));
   }
 
   return std::make_pair(
       fiducialPose.value()
           .TransformBy(bestTarget.GetBestCameraToTarget().Inverse())
           .TransformBy(cameras[lowestAI].second.Inverse()),
-      cameras[lowestAI].first->GetLatestResult().GetLatency() / 1000.);
+      cameras[lowestAI].first->GetLatestResult().GetTimestamp());
 }
-std::pair<frc::Pose3d, units::millisecond_t>
+
+std::pair<frc::Pose3d, units::second_t>
 RobotPoseEstimator::ClosestToCameraHeightStrategy() {
   units::meter_t smallestHeightDifference =
       units::meter_t(std::numeric_limits<double>::infinity());
-  units::millisecond_t milli = units::millisecond_t(0);
+  units::second_t stateTimestamp = units::second_t(0);
   frc::Pose3d pose = lastPose;
 
   for (RobotPoseEstimator::size_type i = 0; i < cameras.size(); ++i) {
@@ -161,22 +164,22 @@ RobotPoseEstimator::ClosestToCameraHeightStrategy() {
         smallestHeightDifference = alternativeDifference;
         pose = targetPose.TransformBy(
             target.GetAlternateCameraToTarget().Inverse());
-        milli = p.first->GetLatestResult().GetLatency() / 1000.;
+        stateTimestamp = p.first->GetLatestResult().GetTimestamp();
       }
       if (bestDifference < smallestHeightDifference) {
         smallestHeightDifference = bestDifference;
         pose = targetPose.TransformBy(target.GetBestCameraToTarget().Inverse());
-        milli = p.first->GetLatestResult().GetLatency() / 1000.;
+        stateTimestamp = p.first->GetLatestResult().GetTimestamp();
       }
     }
   }
-  return std::make_pair(pose, milli);
+  return std::make_pair(pose, stateTimestamp);
 }
-std::pair<frc::Pose3d, units::millisecond_t>
+
+std::pair<frc::Pose3d, units::second_t>
 RobotPoseEstimator::ClosestToReferencePoseStrategy() {
-  units::meter_t smallestDifference =
-      units::meter_t(std::numeric_limits<double>::infinity());
-  units::millisecond_t milli = units::millisecond_t(0);
+  units::meter_t smallestDifference = units::meter_t(std::numeric_limits<double>::infinity());
+  units::second_t stateTimestamp = units::second_t(0);
   frc::Pose3d pose = lastPose;
 
   for (RobotPoseEstimator::size_type i = 0; i < cameras.size(); ++i) {
@@ -207,29 +210,31 @@ RobotPoseEstimator::ClosestToReferencePoseStrategy() {
         smallestDifference = alternativeDifference;
         pose = targetPose.TransformBy(
             target.GetAlternateCameraToTarget().Inverse());
-        milli = p.first->GetLatestResult().GetLatency() / 1000.;
+        stateTimestamp = p.first->GetLatestResult().GetTimestamp();
       }
 
       if (bestDifference < smallestDifference) {
         smallestDifference = bestDifference;
         pose = targetPose.TransformBy(target.GetBestCameraToTarget().Inverse());
-        milli = p.first->GetLatestResult().GetLatency() / 1000.;
+        stateTimestamp = p.first->GetLatestResult().GetTimestamp();
       }
     }
   }
-  return std::make_pair(pose, milli);
+
+  return std::make_pair(pose, stateTimestamp);
 }
 
-std::pair<frc::Pose3d, units::millisecond_t>
+std::pair<frc::Pose3d, units::second_t>
 RobotPoseEstimator::AverageBestTargetsStrategy() {
-  std::vector<std::pair<frc::Pose3d, std::pair<double, units::millisecond_t>>>
-      tempPoses;
+  std::vector<std::pair<frc::Pose3d, std::pair<double, units::second_t>>> tempPoses;
   double totalAmbiguity = 0;
+  units::second_t timstampSum = units::second_t(0);
 
   for (RobotPoseEstimator::size_type i = 0; i < cameras.size(); ++i) {
     std::pair<std::shared_ptr<PhotonCamera>, frc::Transform3d> p = cameras[i];
     std::span<const PhotonTrackedTarget> targets =
         p.first->GetLatestResult().GetTargets();
+    timstampSum += p.first->GetLatestResult().GetTimestamp();
     for (RobotPoseEstimator::size_type j = 0; j < targets.size(); ++j) {
       PhotonTrackedTarget target = targets[j];
       std::optional<frc::Pose3d> fiducialPose =
@@ -255,20 +260,20 @@ RobotPoseEstimator::AverageBestTargetsStrategy() {
       tempPoses.push_back(std::make_pair(
           targetPose.TransformBy(target.GetBestCameraToTarget().Inverse()),
           std::make_pair(target.GetPoseAmbiguity(),
-                         p.first->GetLatestResult().GetLatency() / 1000.)));
+                         p.first->GetLatestResult().GetTimestamp()));
     }
   }
+  
   frc::Translation3d transform = frc::Translation3d();
   frc::Rotation3d rotation = frc::Rotation3d();
-  units::millisecond_t latency = units::millisecond_t(0);
 
-  for (std::pair<frc::Pose3d, std::pair<double, units::millisecond_t>>& pair :
+  for (std::pair<frc::Pose3d, std::pair<double, units::second_t>>& pair :
        tempPoses) {
     double weight = (1. / pair.second.first) / totalAmbiguity;
     transform = transform + pair.first.Translation() * weight;
     rotation = rotation + pair.first.Rotation() * weight;
-    latency += pair.second.second * weight;
   }
-  return std::make_pair(frc::Pose3d(transform, rotation), latency);
+
+  return std::make_pair(frc::Pose3d(transform, rotation), timstampSum / cameras.size());
 }
 }  // namespace photonlib

--- a/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
@@ -52,32 +52,33 @@ enum PoseStrategy : int {
  */
 class RobotPoseEstimator {
  public:
-  using map_value_type = std::pair<std::shared_ptr<PhotonCamera>, frc::Transform3d>;
+  using map_value_type =
+      std::pair<std::shared_ptr<PhotonCamera>, frc::Transform3d>;
   using size_type = std::vector<map_value_type>::size_type;
 
   /**
    * Create a new RobotPoseEstimator.
    *
-   * <p>Example: {@code <code> <p> Map<Integer, Pose3d> map = new HashMap<>(); <p> map.put(1, new
-   * Pose3d(1.0, 2.0, 3.0, new Rotation3d())); // Tag ID 1 is at (1.0,2.0,3.0) </code> }
+   * <p>Example: {@code <code> <p> Map<Integer, Pose3d> map = new HashMap<>();
+   * <p> map.put(1, new Pose3d(1.0, 2.0, 3.0, new Rotation3d())); // Tag ID 1 is
+   * at (1.0,2.0,3.0) </code> }
    *
-   * @param aprilTags A AprilTagFieldLayout linking AprilTag IDs to Pose3ds with respect to the
-   *     FIRST field.
+   * @param aprilTags A AprilTagFieldLayout linking AprilTag IDs to Pose3ds with
+   * respect to the FIRST field.
    * @param strategy The strategy it should use to determine the best pose.
-   * @param cameras An ArrayList of Pairs of PhotonCameras and their respective Transform3ds from
-   *     the center of the robot to the cameras.
+   * @param cameras An ArrayList of Pairs of PhotonCameras and their respective
+   * Transform3ds from the center of the robot to the cameras.
    */
   explicit RobotPoseEstimator(
       std::shared_ptr<frc::AprilTagFieldLayout> aprilTags,
       PoseStrategy strategy, std::vector<map_value_type> cameras);
 
-    /**
+  /**
    * Get the AprilTagFieldLayout being used by the PositionEstimator.
    *
    * @return the AprilTagFieldLayout
    */
   frc::AprilTagFieldLayout getFieldLayout() const { return aprilTags; }
-
 
   /**
    * Get the Position Estimation Strategy being used by the Position Estimator.
@@ -86,7 +87,7 @@ class RobotPoseEstimator {
    */
   PoseStrategy GetPoseStrategy() const { return strategy; }
 
-    /**
+  /**
    * Set the Position Estimation Strategy used by the Position Estimator.
    *
    * @param strategy the strategy to set
@@ -100,9 +101,9 @@ class RobotPoseEstimator {
    */
   frc::Pose3d GetReferencePose() const { return referencePose; }
 
-    /**
-   * Update the stored reference pose for use when using the CLOSEST_TO_REFERENCE_POSE
-   * strategy.
+  /**
+   * Update the stored reference pose for use when using the
+   * CLOSEST_TO_REFERENCE_POSE strategy.
    *
    * @param referencePose the referencePose to set
    */
@@ -110,14 +111,13 @@ class RobotPoseEstimator {
     this->referencePose = referencePose;
   }
 
-    /**
-   * Update the stored last pose. Useful for setting the initial estimate when using the
-   * CLOSEST_TO_LAST_POSE strategy.
+  /**
+   * Update the stored last pose. Useful for setting the initial estimate when
+   * using the CLOSEST_TO_LAST_POSE strategy.
    *
    * @param lastPose the lastPose to set
    */
   inline void SetLastPose(frc::Pose3d lastPose) { this->lastPose = lastPose; }
-
 
   std::pair<frc::Pose3d, units::second_t> Update();
 
@@ -129,37 +129,40 @@ class RobotPoseEstimator {
   frc::Pose3d referencePose;
 
   /**
- * Return the estimated position of the robot with the lowest position ambiguity from a List of
- * pipeline results.
- *
- * @return the estimated position of the robot in the FCS and the estimated timestamp of this
- *     estimation.
- */
+   * Return the estimated position of the robot with the lowest position
+   * ambiguity from a List of pipeline results.
+   *
+   * @return the estimated position of the robot in the FCS and the estimated
+   * timestamp of this estimation.
+   */
   std::pair<frc::Pose3d, units::second_t> LowestAmbiguityStrategy();
 
-    /**
-   * Return the estimated position of the robot using the target with the lowest delta height
-   * difference between the estimated and actual height of the camera.
+  /**
+   * Return the estimated position of the robot using the target with the lowest
+   * delta height difference between the estimated and actual height of the
+   * camera.
    *
-   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
-   *     estimation.
+   * @return the estimated position of the robot in the FCS and the estimated
+   * timestamp of this estimation.
    */
   std::pair<frc::Pose3d, units::second_t> ClosestToCameraHeightStrategy();
 
-    /**
-   * Return the estimated position of the robot using the target with the lowest delta in the vector
-   * magnitude between it and the reference pose.
+  /**
+   * Return the estimated position of the robot using the target with the lowest
+   * delta in the vector magnitude between it and the reference pose.
    *
-   * @param referencePose reference pose to check vector magnitude difference against.
-   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
-   *     estimation.
+   * @param referencePose reference pose to check vector magnitude difference
+   * against.
+   * @return the estimated position of the robot in the FCS and the estimated
+   * timestamp of this estimation.
    */
   std::pair<frc::Pose3d, units::second_t> ClosestToReferencePoseStrategy();
 
   /**
    * Return the average of the best target poses using ambiguity as weight.
 
-   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+   * @return the estimated position of the robot in the FCS and the estimated
+   timestamp of this
    *     estimation.
    */
   std::pair<frc::Pose3d, units::second_t> AverageBestTargetsStrategy();

--- a/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
@@ -84,9 +84,9 @@ class RobotPoseEstimator {
 
   /**
    * Set the cameras to be used by the PoseEstimator.
-   * 
+   *
    * @param cameras cameras to set.
-  */
+   */
   inline void SetCameras(
       const std::vector<std::pair<std::shared_ptr<PhotonCamera>,
                                   frc::Transform3d>>& cameras) {

--- a/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
@@ -78,7 +78,9 @@ class RobotPoseEstimator {
    *
    * @return the AprilTagFieldLayout
    */
-  frc::AprilTagFieldLayout getFieldLayout() const { return aprilTags; }
+  std::shared_ptr<frc::AprilTagFieldLayout> getFieldLayout() const {
+    return aprilTags;
+  }
 
   /**
    * Get the Position Estimation Strategy being used by the Position Estimator.

--- a/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/RobotPoseEstimator.h
@@ -83,6 +83,17 @@ class RobotPoseEstimator {
   }
 
   /**
+   * Set the cameras to be used by the PoseEstimator.
+   * 
+   * @param cameras cameras to set.
+  */
+  inline void SetCameras(
+      const std::vector<std::pair<std::shared_ptr<PhotonCamera>,
+                                  frc::Transform3d>>& cameras) {
+    this->cameras = cameras;
+  }
+
+  /**
    * Get the Position Estimation Strategy being used by the Position Estimator.
    *
    * @return the strategy

--- a/photon-lib/src/test/java/org/photonvision/RobotPoseEstimatorTest.java
+++ b/photon-lib/src/test/java/org/photonvision/RobotPoseEstimatorTest.java
@@ -422,7 +422,6 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(7, 8)))));
         cameraTwo.result.setTimestampSeconds(13);
 
-
         estimatedPose = estimator.update();
         pose = estimatedPose.get().getFirst();
 

--- a/photon-lib/src/test/java/org/photonvision/RobotPoseEstimatorTest.java
+++ b/photon-lib/src/test/java/org/photonvision/RobotPoseEstimatorTest.java
@@ -68,12 +68,12 @@ class RobotPoseEstimatorTest {
             e.printStackTrace();
         }
 
-        List<AprilTag> atList = new ArrayList<AprilTag>(2);
-        atList.add(new AprilTag(0, new Pose3d(3, 3, 3, new Rotation3d())));
-        atList.add(new AprilTag(1, new Pose3d(5, 5, 5, new Rotation3d())));
-        var fl = Units.feetToMeters(54.0);
-        var fw = Units.feetToMeters(27.0);
-        aprilTags = new AprilTagFieldLayout(atList, fl, fw);
+        List<AprilTag> tagList = new ArrayList<AprilTag>(2);
+        tagList.add(new AprilTag(0, new Pose3d(3, 3, 3, new Rotation3d())));
+        tagList.add(new AprilTag(1, new Pose3d(5, 5, 5, new Rotation3d())));
+        double fieldLength = Units.feetToMeters(54.0);
+        double fieldWidth = Units.feetToMeters(27.0);
+        aprilTags = new AprilTagFieldLayout(tagList, fieldLength, fieldWidth);
     }
 
     @Test
@@ -113,6 +113,8 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraOne.result.setTimestampSeconds(11);
+
         PhotonCameraInjector cameraTwo = new PhotonCameraInjector();
         cameraTwo.result =
                 new PhotonPipelineResult(
@@ -132,6 +134,7 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraTwo.result.setTimestampSeconds(16);
 
         cameras.add(Pair.of(cameraOne, new Transform3d()));
         cameras.add(Pair.of(cameraTwo, new Transform3d()));
@@ -142,7 +145,7 @@ class RobotPoseEstimatorTest {
         Optional<Pair<Pose3d, Double>> estimatedPose = estimator.update();
         Pose3d pose = estimatedPose.get().getFirst();
 
-        assertEquals(2, estimatedPose.get().getSecond());
+        assertEquals(11, estimatedPose.get().getSecond());
         assertEquals(1, pose.getX(), .01);
         assertEquals(3, pose.getY(), .01);
         assertEquals(2, pose.getZ(), .01);
@@ -185,6 +188,7 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraOne.result.setTimestampSeconds(4);
         PhotonCameraInjector cameraTwo = new PhotonCameraInjector();
         cameraTwo.result =
                 new PhotonPipelineResult(
@@ -204,6 +208,7 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraTwo.result.setTimestampSeconds(12);
 
         cameras.add(Pair.of(cameraOne, new Transform3d(new Translation3d(0, 0, 4), new Rotation3d())));
         cameras.add(Pair.of(cameraTwo, new Transform3d(new Translation3d(0, 0, 2), new Rotation3d())));
@@ -214,7 +219,7 @@ class RobotPoseEstimatorTest {
         Optional<Pair<Pose3d, Double>> estimatedPose = estimator.update();
         Pose3d pose = estimatedPose.get().getFirst();
 
-        assertEquals(2, estimatedPose.get().getSecond());
+        assertEquals(4, estimatedPose.get().getSecond());
         assertEquals(4, pose.getX(), .01);
         assertEquals(4, pose.getY(), .01);
         assertEquals(0, pose.getZ(), .01);
@@ -257,6 +262,7 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraOne.result.setTimestampSeconds(4);
         PhotonCameraInjector cameraTwo = new PhotonCameraInjector();
         cameraTwo.result =
                 new PhotonPipelineResult(
@@ -276,6 +282,7 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraTwo.result.setTimestampSeconds(17);
 
         cameras.add(Pair.of(cameraOne, new Transform3d(new Translation3d(0, 0, 0), new Rotation3d())));
         cameras.add(Pair.of(cameraTwo, new Transform3d(new Translation3d(0, 0, 0), new Rotation3d())));
@@ -287,7 +294,7 @@ class RobotPoseEstimatorTest {
         Optional<Pair<Pose3d, Double>> estimatedPose = estimator.update();
         Pose3d pose = estimatedPose.get().getFirst();
 
-        assertEquals(4, estimatedPose.get().getSecond());
+        assertEquals(17, estimatedPose.get().getSecond());
         assertEquals(1, pose.getX(), .01);
         assertEquals(1.1, pose.getY(), .01);
         assertEquals(.9, pose.getZ(), .01);
@@ -393,6 +400,8 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraOne.result.setTimestampSeconds(7);
+
         cameraTwo.result =
                 new PhotonPipelineResult(
                         4,
@@ -411,11 +420,13 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8)))));
+        cameraTwo.result.setTimestampSeconds(13);
+
 
         estimatedPose = estimator.update();
         pose = estimatedPose.get().getFirst();
 
-        assertEquals(2, estimatedPose.get().getSecond());
+        assertEquals(7, estimatedPose.get().getSecond());
         assertEquals(.9, pose.getX(), .01);
         assertEquals(1.1, pose.getY(), .01);
         assertEquals(1, pose.getZ(), .01);
@@ -458,6 +469,8 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8))))); // 2 2 2 ambig .3
+        cameraOne.result.setTimestampSeconds(10);
+
         PhotonCameraInjector cameraTwo = new PhotonCameraInjector();
         cameraTwo.result =
                 new PhotonPipelineResult(
@@ -477,6 +490,7 @@ class RobotPoseEstimatorTest {
                                                 new TargetCorner(3, 4),
                                                 new TargetCorner(5, 6),
                                                 new TargetCorner(7, 8))))); // 3 3 3 ambig .4
+        cameraTwo.result.setTimestampSeconds(20);
 
         cameras.add(Pair.of(cameraOne, new Transform3d(new Translation3d(0, 0, 0), new Rotation3d())));
         cameras.add(Pair.of(cameraTwo, new Transform3d(new Translation3d(0, 0, 0), new Rotation3d())));
@@ -486,7 +500,8 @@ class RobotPoseEstimatorTest {
 
         Optional<Pair<Pose3d, Double>> estimatedPose = estimator.update();
         Pose3d pose = estimatedPose.get().getFirst();
-        assertEquals(2.6885245901639347, estimatedPose.get().getSecond(), .01);
+
+        assertEquals(15, estimatedPose.get().getSecond(), .01);
         assertEquals(2.15, pose.getX(), .01);
         assertEquals(2.15, pose.getY(), .01);
         assertEquals(2.15, pose.getZ(), .01);

--- a/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
+++ b/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
@@ -444,7 +444,8 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
   estimatedPose = estimator.Update();
   pose = estimatedPose.first;
 
-  EXPECT_NEAR(7.0, units::unit_cast<double>(estimatedPose.second) / 1000.0, .01);
+  EXPECT_NEAR(7.0, units::unit_cast<double>(estimatedPose.second) / 1000.0,
+              .01);
   EXPECT_NEAR(.9, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(1.1, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(1, units::unit_cast<double>(pose.Z()), .01);
@@ -530,7 +531,8 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(15.0, units::unit_cast<double>(estimatedPose.second) / 1000.0, .01);
+  EXPECT_NEAR(15.0, units::unit_cast<double>(estimatedPose.second) / 1000.0,
+              .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.Z()), .01);

--- a/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
+++ b/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
@@ -88,7 +88,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(units::seconds_t(11));
+  cameraOne->testResult.SetTimestamp(units::second_t(11));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -107,7 +107,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraTwo->testResult.SetTimestamp(units::seconds_t(units::seconds_t(16)));
+  cameraTwo->testResult.SetTimestamp(units::second_t(units::second_t(16)));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),
@@ -175,7 +175,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(units::seconds_t(4));
+  cameraOne->testResult.SetTimestamp(units::second_t(4));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -194,7 +194,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraOne->testResult.SetTimestamp(units::seconds_t(12));
+  cameraOne->testResult.SetTimestamp(units::second_t(12));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 4_m),
@@ -262,7 +262,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(units::seconds_t(4));
+  cameraOne->testResult.SetTimestamp(units::second_t(4));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -281,7 +281,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraTwo->testResult.SetTimestamp(units::seconds_t(17));
+  cameraTwo->testResult.SetTimestamp(units::second_t(17));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),
@@ -411,7 +411,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
            std::pair{7, 8}}}};
 
   cameraOne->testResult = {2_s, targetsThree};
-  cameraOne->testResult.SetTimestamp(units::seconds_t(7));
+  cameraOne->testResult.SetTimestamp(units::second_t(7));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsFour{
       photonlib::PhotonTrackedTarget{
@@ -429,7 +429,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
            std::pair{7, 8}}}};
 
   cameraTwo->testResult = {4_s, targetsFour};
-  cameraTwo->testResult.SetTimestamp(units::seconds_t(13));
+  cameraTwo->testResult.SetTimestamp(units::second_t(13));
 
   std::vector<
       std::pair<std::shared_ptr<photonlib::PhotonCamera>, frc::Transform3d>>
@@ -497,7 +497,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(units::seconds_t(10));
+  cameraOne->testResult.SetTimestamp(units::second_t(10));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -516,7 +516,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraTwo->testResult.SetTimestamp(units::seconds_t(20));
+  cameraTwo->testResult.SetTimestamp(units::second_t(20));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),

--- a/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
+++ b/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
@@ -88,6 +88,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
+  cameraOne->testResult.SetTimestamp(11);
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -106,6 +107,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
+  cameraTwo->testResult.SetTimestamp(16);
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),
@@ -119,7 +121,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(2, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(11, units::unit_cast<double>(estimatedPose.second), .01);
   EXPECT_NEAR(1, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(3, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(2, units::unit_cast<double>(pose.Z()), .01);
@@ -173,6 +175,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
+  cameraOne->testResult.SetTimestamp(4);
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -191,6 +194,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
+  cameraOne->testResult.SetTimestamp(12);
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 4_m),
@@ -204,7 +208,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(2, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(4, units::unit_cast<double>(estimatedPose.second), .01);
   EXPECT_NEAR(4, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(4, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(4, units::unit_cast<double>(pose.Z()), .01);
@@ -258,6 +262,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
+  cameraOne->testResult.SetTimestamp(4);
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -276,6 +281,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
+  cameraTwo->testResult.SetTimestamp(17);
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),
@@ -291,7 +297,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(4, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(17, units::unit_cast<double>(estimatedPose.second), .01);
   EXPECT_NEAR(1, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(1.1, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(.9, units::unit_cast<double>(pose.Z()), .01);
@@ -405,6 +411,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
            std::pair{7, 8}}}};
 
   cameraOne->testResult = {2_s, targetsThree};
+  cameraOne->testResult.SetTimestamp(7);
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsFour{
       photonlib::PhotonTrackedTarget{
@@ -422,6 +429,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
            std::pair{7, 8}}}};
 
   cameraTwo->testResult = {4_s, targetsFour};
+  cameraTwo->testResult.SetTimestamp(13);
 
   std::vector<
       std::pair<std::shared_ptr<photonlib::PhotonCamera>, frc::Transform3d>>
@@ -436,7 +444,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
   estimatedPose = estimator.Update();
   pose = estimatedPose.first;
 
-  EXPECT_NEAR(2, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(7.0, units::unit_cast<double>(estimatedPose.second), .01);
   EXPECT_NEAR(.9, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(1.1, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(1, units::unit_cast<double>(pose.Z()), .01);
@@ -489,6 +497,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
+  cameraOne->testResult.SetTimestamp(10);
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -507,6 +516,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
+  cameraTwo->testResult.SetTimestamp(20);
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),
@@ -520,8 +530,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(2.6885245901639347,
-              units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(15.0, units::unit_cast<double>(estimatedPose.second), .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.Z()), .01);

--- a/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
+++ b/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
@@ -88,7 +88,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(11);
+  cameraOne->testResult.SetTimestamp(units::seconds_t(11));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -107,7 +107,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraTwo->testResult.SetTimestamp(16);
+  cameraTwo->testResult.SetTimestamp(units::seconds_t(units::seconds_t(16)));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),
@@ -175,7 +175,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(4);
+  cameraOne->testResult.SetTimestamp(units::seconds_t(4));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -194,7 +194,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraOne->testResult.SetTimestamp(12);
+  cameraOne->testResult.SetTimestamp(units::seconds_t(12));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 4_m),
@@ -262,7 +262,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(4);
+  cameraOne->testResult.SetTimestamp(units::seconds_t(4));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -281,7 +281,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraTwo->testResult.SetTimestamp(17);
+  cameraTwo->testResult.SetTimestamp(units::seconds_t(17));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),
@@ -411,7 +411,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
            std::pair{7, 8}}}};
 
   cameraOne->testResult = {2_s, targetsThree};
-  cameraOne->testResult.SetTimestamp(7);
+  cameraOne->testResult.SetTimestamp(units::seconds_t(7));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsFour{
       photonlib::PhotonTrackedTarget{
@@ -429,7 +429,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
            std::pair{7, 8}}}};
 
   cameraTwo->testResult = {4_s, targetsFour};
-  cameraTwo->testResult.SetTimestamp(13);
+  cameraTwo->testResult.SetTimestamp(units::seconds_t(13));
 
   std::vector<
       std::pair<std::shared_ptr<photonlib::PhotonCamera>, frc::Transform3d>>
@@ -497,7 +497,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
 
   cameraOne->test = true;
   cameraOne->testResult = {2_s, targets};
-  cameraOne->testResult.SetTimestamp(10);
+  cameraOne->testResult.SetTimestamp(units::seconds_t(10));
 
   wpi::SmallVector<photonlib::PhotonTrackedTarget, 1> targetsTwo{
       photonlib::PhotonTrackedTarget{
@@ -516,7 +516,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
 
   cameraTwo->test = true;
   cameraTwo->testResult = {4_s, targetsTwo};
-  cameraTwo->testResult.SetTimestamp(20);
+  cameraTwo->testResult.SetTimestamp(units::seconds_t(20));
 
   cameras.push_back(std::make_pair(
       cameraOne, frc::Transform3d(frc::Translation3d(0_m, 0_m, 0_m),

--- a/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
+++ b/photon-lib/src/test/native/cpp/RobotPoseEstimatorTest.cpp
@@ -121,7 +121,7 @@ TEST(RobotPoseEstimatorTest, LowestAmbiguityStrategy) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(11, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(11, units::unit_cast<double>(estimatedPose.second) / 1000.0, .01);
   EXPECT_NEAR(1, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(3, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(2, units::unit_cast<double>(pose.Z()), .01);
@@ -208,7 +208,7 @@ TEST(RobotPoseEstimatorTest, ClosestToCameraHeightStrategy) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(4, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(12, units::unit_cast<double>(estimatedPose.second) / 1000.0, .01);
   EXPECT_NEAR(4, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(4, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(4, units::unit_cast<double>(pose.Z()), .01);
@@ -297,7 +297,7 @@ TEST(RobotPoseEstimatorTest, ClosestToReferencePoseStrategy) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(17, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(17, units::unit_cast<double>(estimatedPose.second) / 1000.0, .01);
   EXPECT_NEAR(1, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(1.1, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(.9, units::unit_cast<double>(pose.Z()), .01);
@@ -444,7 +444,7 @@ TEST(RobotPoseEstimatorTest, ClosestToLastPose) {
   estimatedPose = estimator.Update();
   pose = estimatedPose.first;
 
-  EXPECT_NEAR(7.0, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(7.0, units::unit_cast<double>(estimatedPose.second) / 1000.0, .01);
   EXPECT_NEAR(.9, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(1.1, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(1, units::unit_cast<double>(pose.Z()), .01);
@@ -530,7 +530,7 @@ TEST(RobotPoseEstimatorTest, AverageBestPoses) {
       estimator.Update();
   frc::Pose3d pose = estimatedPose.first;
 
-  EXPECT_NEAR(15.0, units::unit_cast<double>(estimatedPose.second), .01);
+  EXPECT_NEAR(15.0, units::unit_cast<double>(estimatedPose.second) / 1000.0, .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.X()), .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.Y()), .01);
   EXPECT_NEAR(2.15, units::unit_cast<double>(pose.Z()), .01);


### PR DESCRIPTION
closes #690 

- Updated documentation
- Reorganized getters and mutators
- set some variables to final
- Converted all "strategy" methods to return Optional pairs
- Converted to return the timestamp of the Pose instead of the latency
- Simplified many of the for loops (why were these so long lol?)
- Simplified expressions that did redundant checking or were unnecessarily long
- Added checks in case the target is a non-fiducial target (-1 would cause an error to be displayed in DS the first time, inexperienced teams may get confused).

TODO:
- [ ] Update C++ and headers
    - [x] Add documentation
    - [ ] Update to use optionals
- [x] Update tests
    - [x] Java
    - [x] C++
- [ ] Update examples
    - [ ] Java
    - [ ] C++