### PR TITLE
Don't give ArUco as an option in the UI, for now

### DIFF
--- a/photon-client/src/components/pipeline/CameraAndPipelineSelect.vue
+++ b/photon-client/src/components/pipeline/CameraAndPipelineSelect.vue
@@ -153,7 +153,7 @@
           v-model="currentPipelineType"
           name="Type"
           tooltip="Changes the pipeline type, which changes the type of processing that will happen on input frames"
-          :list="['Reflective Tape', 'Colored Shape', 'AprilTag', 'Aruco']"
+          :list="['Reflective Tape', 'Colored Shape', 'AprilTag']"
           @input="e => showTypeDialog(e)"
         />
       </v-col>


### PR DESCRIPTION
Seems to be broken on things going through the libcamera path. Odd. Hopefully we can re-enable this later on.