### PR TITLE
Add configurable maximiumPoseAmbiguityThreshold for use in PhotonPoseEstimator

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -73,7 +73,7 @@ public class PhotonPoseEstimator {
     private Pose3d referencePose;
     private final Set<Integer> reportedErrors = new HashSet<>();
 
-    private final static double IMPOSSIBLY_HIGH_POSE_AMBIGUITY = 10.0;
+    private static final double IMPOSSIBLY_HIGH_POSE_AMBIGUITY = 10.0;
     private double maximumPoseAmbiguityThreshold = IMPOSSIBLY_HIGH_POSE_AMBIGUITY;
 
     /**
@@ -188,6 +188,7 @@ public class PhotonPoseEstimator {
 
     /**
      * Set the maximum PoseAmbiguity a target can have and still be used for pose updates.
+     *
      * @param maximumPoseAmbiguityThreshold
      */
     public void setMaximumPoseAmbiguityThreshold(double maximumPoseAmbiguityThreshold) {
@@ -212,9 +213,11 @@ public class PhotonPoseEstimator {
             return Optional.empty();
         }
 
-        // If target Pose Ambiguity is too high (typically due to the camera being distant from the AprilTag), one or
+        // If target Pose Ambiguity is too high (typically due to the camera being distant from the
+        // AprilTag), one or
         // more targets can be optionally removed from consideration.
-        cameraResult.targets.removeIf(target -> target.getPoseAmbiguity() > maximumPoseAmbiguityThreshold);
+        cameraResult.targets.removeIf(
+                target -> target.getPoseAmbiguity() > maximumPoseAmbiguityThreshold);
 
         Optional<EstimatedRobotPose> estimatedPose;
         switch (strategy) {

--- a/photon-lib/src/test/java/org/photonvision/PhotonPoseEstimatorTest.java
+++ b/photon-lib/src/test/java/org/photonvision/PhotonPoseEstimatorTest.java
@@ -559,7 +559,8 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void removeHighAmbiguityPoses() {
-        // Using the same test data as testLowestAmbiguityStrategy, but will manipulate the ambiguity and test thresholds.
+        // Using the same test data as testLowestAmbiguityStrategy, but will manipulate the ambiguity
+        // and test thresholds.
         PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         setTypicalTestData(cameraOne, 11);
 
@@ -567,7 +568,8 @@ class PhotonPoseEstimatorTest {
                 new PhotonPoseEstimator(
                         aprilTags, PoseStrategy.LOWEST_AMBIGUITY, cameraOne, new Transform3d());
 
-        // Set the threshold quite low. Since the results above have pose ambiguities at 0.7, 0.3, and 0.4, all will be removed.
+        // Set the threshold quite low. Since the results above have pose ambiguities at 0.7, 0.3, and
+        // 0.4, all will be removed.
         estimator.setMaximumPoseAmbiguityThreshold(0.1);
         Optional<EstimatedRobotPose> estimatedPose = estimator.update();
         assertTrue(estimatedPose.isEmpty());


### PR DESCRIPTION
When cameras are distant from AprilTags, it's quite common to have very high pose ambiguities, leading to significant deviations in estimated pose. Since the PhotonPoseEstimator calls `camera.getLatestResult()` internally, there's no opportunity for user code to check the values in that result and do any filtering of their own.

This PR adds a configurable threshold, via `setMaximumPoseAmbiguityThreshold(double maximumPoseAmbiguityThreshold)`, that is used in the `update()` method of PhotonPoseEstimator to remove any targets with high pose ambiguities from consideration by the various strategies. 
