### PR TITLE
Add ability query camera results outside of PhotonPoseEstimator

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -217,11 +217,10 @@ public class PhotonPoseEstimator {
     }
 
     /**
-     * Updates the estimated position of the robot. Returns
-     * empty if there are no cameras set or no targets were found from the cameras.
+     * Updates the estimated position of the robot. Returns empty if there are no cameras set or no
+     * targets were found from the cameras.
      *
      * @param cameraResult The latest pipeline result from the camera
-     *
      * @return an EstimatedRobotPose with an estimated pose, and information about the camera(s) and
      *     pipeline results used to create the estimate
      */

--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -197,6 +197,20 @@ public class PhotonPoseEstimator {
         }
 
         PhotonPipelineResult cameraResult = camera.getLatestResult();
+
+        return update(cameraResult);
+    }
+
+    /**
+     * Updates the estimated position of the robot. Returns
+     * empty if there are no cameras set or no targets were found from the cameras.
+     *
+     * @param cameraResult The latest pipeline result from the camera
+     *
+     * @return an EstimatedRobotPose with an estimated pose, and information about the camera(s) and
+     *     pipeline results used to create the estimate
+     */
+    public Optional<EstimatedRobotPose> update(PhotonPipelineResult cameraResult) {
         if (!cameraResult.hasTargets()) {
             return Optional.empty();
         }

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonPoseEstimator.cpp
@@ -55,7 +55,10 @@ PhotonPoseEstimator::PhotonPoseEstimator(frc::AprilTagFieldLayout tags,
 
 std::optional<EstimatedRobotPose> PhotonPoseEstimator::Update() {
   auto result = camera.GetLatestResult();
+  return Update(result);
+}
 
+std::optional<EstimatedRobotPose> PhotonPoseEstimator::Update(const PhotonPipelineResult& result) {
   if (!result.HasTargets()) {
     return std::nullopt;
   }

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonPoseEstimator.cpp
@@ -58,7 +58,8 @@ std::optional<EstimatedRobotPose> PhotonPoseEstimator::Update() {
   return Update(result);
 }
 
-std::optional<EstimatedRobotPose> PhotonPoseEstimator::Update(const PhotonPipelineResult& result) {
+std::optional<EstimatedRobotPose> PhotonPoseEstimator::Update(
+    const PhotonPipelineResult& result) {
   if (!result.HasTargets()) {
     return std::nullopt;
   }

--- a/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
@@ -137,6 +137,11 @@ class PhotonPoseEstimator {
    */
   std::optional<EstimatedRobotPose> Update();
 
+  /**
+   * Update the pose estimator.
+   */
+  std::optional<EstimatedRobotPose> Update(const PhotonPipelineResult& result);
+
   inline PhotonCamera& GetCamera() { return camera; }
 
  private:


### PR DESCRIPTION
We are likely going to want to filter some of the targets out (bad ambiguity, tag too far away to get good estimate, etc), so this adds the option to query the camera outside of the pose estimator, filter the targets, and then inject that into the strategy picker