### PR TITLE
Un-finalize robotToCamera, add getters and setters

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -67,7 +67,7 @@ public class PhotonPoseEstimator {
     private AprilTagFieldLayout fieldTags;
     private PoseStrategy strategy;
     private final PhotonCamera camera;
-    private final Transform3d robotToCamera;
+    private Transform3d robotToCamera;
 
     private Pose3d lastPose;
     private Pose3d referencePose;
@@ -181,6 +181,24 @@ public class PhotonPoseEstimator {
      */
     public void setLastPose(Pose2d lastPose) {
         setLastPose(new Pose3d(lastPose));
+    }
+    
+    /**
+     * @return The current transform from the center of the robot to the camera
+     *         mount position
+     */
+    public Transform3d getRobotToCameraTransform() {
+        return robotToCamera;
+    }
+    
+    /**
+     * Useful for pan and tilt mechanisms and such.
+     * 
+     * @param The current transform from the center of the robot to the camera
+     *            mount position
+     */
+    public void setRobotToCameraTransform(Transform3d robotToCamera) {
+        this.robotToCamera = robotToCamera;
     }
 
     /**


### PR DESCRIPTION
Not sure if this was intended for whatever reason but this allows teams with a mechanism that moves the camera's position (eg, a pan and tilt mechanism) to update the location of their camera for their pose calculations.