### PR TITLE
PhotonPoseEstimator: Include what you use

### DIFF
--- a/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
@@ -34,6 +34,7 @@
 #include <frc/geometry/Transform3d.h>
 
 #include "photonlib/PhotonCamera.h"
+#include "photonlib/PhotonPipelineResult.h"
 
 namespace photonlib {
 enum PoseStrategy : int {

--- a/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
There are a few references to PhotonPipelineResult in this header. I noticed this was being indirectly included when trying to remove the PhotonCamera dependency.

Add an explicit include so nobody else makes the same mistake.

Also remove an include that _wasn't_ used.