### PR TITLE
Remove ErodeDilate from UI and ColoredShapePipeline

### DIFF
--- a/photon-client/src/views/PipelineViews/ThresholdTab.vue
+++ b/photon-client/src/views/PipelineViews/ThresholdTab.vue
@@ -41,23 +41,6 @@
       @input="handlePipelineData('hueInverted')"
       @rollback="e => rollback('hueInverted',e)"
     />
-    <template v-if="currentPipelineType() === 3">
-      <CVSwitch
-        v-model="erode"
-        name="Erode"
-        tooltip="Removes pixels around the edges of white areas in the thresholded image"
-        @input="handlePipelineData('erode')"
-        @rollback="e => rollback('erode',e)"
-      />
-      <CVSwitch
-        v-model="dilate"
-        class="mb-0"
-        name="Dilate"
-        tooltip="Adds pixels around the edges of white areas in the thresholded image"
-        @input="handlePipelineData('dilate')"
-        @rollback="e => rollback('dilate',e)"
-      />
-    </template>
     <div class="pt-3 white--text">
       Color Picker
     </div>
@@ -193,22 +176,6 @@ export default {
       },
       set(val) {
         this.$store.commit("mutatePipeline", {"hsvValue": val});
-      }
-    },
-    erode: {
-      get() {
-        return this.$store.getters.currentPipelineSettings.erode;
-      },
-      set(val) {
-        this.$store.commit("mutatePipeline", {"erode": val});
-      }
-    },
-    dilate: {
-      get() {
-        return this.$store.getters.currentPipelineSettings.dilate;
-      },
-      set(val) {
-        this.$store.commit("mutatePipeline", {"dilate": val});
       }
     },
   },

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipeline.java
@@ -34,7 +34,6 @@ import org.photonvision.vision.target.TrackedTarget;
 @SuppressWarnings({"DuplicatedCode"})
 public class ColoredShapePipeline
         extends CVPipeline<CVPipelineResult, ColoredShapePipelineSettings> {
-    private final ErodeDilatePipe erodeDilatePipe = new ErodeDilatePipe();
     private final SpeckleRejectPipe speckleRejectPipe = new SpeckleRejectPipe();
     private final FindContoursPipe findContoursPipe = new FindContoursPipe();
     private final FindPolygonPipe findPolygonPipe = new FindPolygonPipe();
@@ -71,11 +70,6 @@ public class ColoredShapePipeline
                         settings.offsetDualPointAArea,
                         settings.offsetDualPointB,
                         settings.offsetDualPointBArea);
-
-        ErodeDilatePipe.ErodeDilateParams erodeDilateParams =
-                new ErodeDilatePipe.ErodeDilateParams(settings.erode, settings.dilate, 5);
-        // TODO: add kernel size to pipeline settings
-        erodeDilatePipe.setParams(erodeDilateParams);
 
         SpeckleRejectPipe.SpeckleRejectParams speckleRejectParams =
                 new SpeckleRejectPipe.SpeckleRejectParams(settings.contourSpecklePercentage);
@@ -174,12 +168,6 @@ public class ColoredShapePipeline
     @Override
     protected CVPipelineResult process(Frame frame, ColoredShapePipelineSettings settings) {
         long sumPipeNanosElapsed = 0L;
-
-        //        var erodeDilateResult = erodeDilatePipe.run(rawInputMat);
-        //        sumPipeNanosElapsed += erodeDilateResult.nanosElapsed;
-        //
-        //        CVPipeResult<Mat> hsvPipeResult = hsvPipe.run(rawInputMat);
-        //        sumPipeNanosElapsed += hsvPipeResult.nanosElapsed;
 
         CVPipeResult<List<Contour>> findContoursResult =
                 findContoursPipe.run(frame.processedImage.getMat());

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipelineSettings.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipelineSettings.java
@@ -39,9 +39,6 @@ public class ColoredShapePipelineSettings extends AdvancedPipelineSettings {
     // 3d settings
     public CameraCalibrationCoefficients cameraCalibration;
 
-    public boolean erode = false;
-    public boolean dilate = false;
-
     public ColoredShapePipelineSettings() {
         super();
         pipelineType = PipelineType.ColoredShape;
@@ -64,8 +61,6 @@ public class ColoredShapePipelineSettings extends AdvancedPipelineSettings {
                 && cornerDetectionSideCount == that.cornerDetectionSideCount
                 && Double.compare(that.cornerDetectionAccuracyPercentage, cornerDetectionAccuracyPercentage)
                         == 0
-                && erode == that.erode
-                && dilate == that.dilate
                 && contourShape == that.contourShape
                 && Objects.equals(contourArea, that.contourArea)
                 && Objects.equals(contourPerimeter, that.contourPerimeter)
@@ -96,8 +91,6 @@ public class ColoredShapePipelineSettings extends AdvancedPipelineSettings {
                 cornerDetectionUseConvexHulls,
                 cornerDetectionExactSideCount,
                 cornerDetectionSideCount,
-                cornerDetectionAccuracyPercentage,
-                erode,
-                dilate);
+                cornerDetectionAccuracyPercentage);
     }
 }


### PR DESCRIPTION
This is an alternative to #827 since the functionality is too hard on performance. It just removes the options from the UI in order to avoid confusing users. Fixes #419.