### PR TITLE
Vendor fonts for offline usage

### DIFF
--- a/photon-client/package-lock.json
+++ b/photon-client/package-lock.json
@@ -5,9 +5,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "photon-client",
       "version": "3.0.0",
       "dependencies": {
         "@femessage/log-viewer": "^1.4.2",
+        "@fontsource/prompt": "^4.5.10",
         "@vue/eslint-config-prettier": "^6.0.0",
         "axios": "^0.19.2",
         "core-js": "^2.6.11",
@@ -1932,6 +1934,11 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/@fontsource/prompt": {
+      "version": "4.5.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/prompt/-/prompt-4.5.10.tgz",
+      "integrity": "sha512-S2GQ5Upo9XfZ8jruqmW9If+nS3MSM0CobysfzmAMgzhzBOQTWWOoNIUMrX5OMOliMtSA437X/ZK5f1TT8Rt6fQ=="
+    },
     "node_modules/@hapi/address": {
       "version": "2.1.4",
       "dev": true,
@@ -2682,7 +2689,6 @@
         "thread-loader": "^2.1.3",
         "url-loader": "^2.2.0",
         "vue-loader": "^15.9.2",
-        "vue-loader-v16": "npm:vue-loader@^16.0.0-beta.3",
         "vue-style-loader": "^4.1.2",
         "webpack": "^4.0.0",
         "webpack-bundle-analyzer": "^3.8.0",
@@ -3116,7 +3122,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.14",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
@@ -4703,7 +4708,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -9167,9 +9171,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9181,11 +9182,7 @@
         "@babel/runtime": "^7.14.0",
         "atob": "^2.1.2",
         "btoa": "^1.2.1",
-        "canvg": "^3.0.6",
-        "core-js": "^3.6.0",
-        "dompurify": "^2.2.0",
-        "fflate": "^0.4.8",
-        "html2canvas": "^1.0.0-rc.5"
+        "fflate": "^0.4.8"
       },
       "optionalDependencies": {
         "canvg": "^3.0.6",
@@ -14200,10 +14197,8 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^3.4.0",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.0",
@@ -14312,7 +14307,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -14553,7 +14547,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -16744,6 +16737,11 @@
       "requires": {
         "vue-virtual-scroll-list": "^1.4.1"
       }
+    },
+    "@fontsource/prompt": {
+      "version": "4.5.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/prompt/-/prompt-4.5.10.tgz",
+      "integrity": "sha512-S2GQ5Upo9XfZ8jruqmW9If+nS3MSM0CobysfzmAMgzhzBOQTWWOoNIUMrX5OMOliMtSA437X/ZK5f1TT8Rt6fQ=="
     },
     "@hapi/address": {
       "version": "2.1.4",

--- a/photon-client/package.json
+++ b/photon-client/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@femessage/log-viewer": "^1.4.2",
+    "@fontsource/prompt": "^4.5.10",
     "@vue/eslint-config-prettier": "^6.0.0",
     "axios": "^0.19.2",
     "core-js": "^2.6.11",

--- a/photon-client/src/scss/variables.scss
+++ b/photon-client/src/scss/variables.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Prompt:wght@400;500&display=swap');
+@import "~@fontsource/prompt/index.css";
 $default-font: "Prompt",
 sans-serif !default;
 $body-font-family: $default-font;


### PR DESCRIPTION
This should reduce loading time as browsers show a blank screen while they try and load the inaccessable Google Fonts. Fontsource simply provides an easy way to integrate the font without much work on our end.

(no idea why package.json got modified so much [just did `npm i --save @fontsource/prompt`], but the UI still builds and loads.. [haven't tested it outside of `npm run serve` yet])