### PR TITLE
PhotonPoseEstimator: Add constructor taking unique_ptr

### DIFF
--- a/photon-lib/src/main/native/cpp/photonlib/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonPoseEstimator.cpp
@@ -69,6 +69,12 @@ PhotonPoseEstimator::PhotonPoseEstimator(frc::AprilTagFieldLayout tags,
       referencePose(frc::Pose3d()),
       poseCacheTimestamp(-1_s) {}
 
+PhotonPoseEstimator::PhotonPoseEstimator(frc::AprilTagFieldLayout tags,
+                                         PoseStrategy strat,
+                                         std::unique_ptr<PhotonCamera> cam,
+                                         frc::Transform3d robotToCamera)
+    : PhotonPoseEstimator(tags, strat, std::move(*cam), robotToCamera) {}
+
 void PhotonPoseEstimator::SetMultiTagFallbackStrategy(PoseStrategy strategy) {
   if (strategy == MULTI_TAG_PNP) {
     FRC_ReportError(

--- a/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photonlib/PhotonPoseEstimator.h
@@ -91,6 +91,21 @@ class PhotonPoseEstimator {
                                frc::Transform3d robotToCamera);
 
   /**
+   * Create a new PhotonPoseEstimator.
+   *
+   * @param aprilTags A AprilTagFieldLayout linking AprilTag IDs to Pose3ds with
+   * respect to the FIRST field.
+   * @param strategy The strategy it should use to determine the best pose.
+   * @param camera The PhotonCamera.
+   * @param robotToCamera Transform3d from the center of the robot to the camera
+   * mount positions (ie, robot ➔ camera).
+   */
+  explicit PhotonPoseEstimator(frc::AprilTagFieldLayout aprilTags,
+                               PoseStrategy strategy,
+                               std::unique_ptr<PhotonCamera> camera,
+                               frc::Transform3d robotToCamera);
+
+  /**
    * Get the AprilTagFieldLayout being used by the PositionEstimator.
    *
    * @return the AprilTagFieldLayout


### PR DESCRIPTION
This unblocks the RobotPy update.

Ultimately though I don't think the `PhotonPoseEstimator` should need any I/O so #840 might be a preferable solution.