### PR TITLE
Install JRE instead of JDK in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,11 +53,11 @@ else
     echo 'GOVERNOR=performance' > /etc/default/cpufrequtils
 fi
 
-echo "Installing the JDK..."
-if ! package_is_installed openjdk-11-jdk-headless
+echo "Installing the JRE..."
+if ! package_is_installed openjre-11-jre-headless
 then
    apt-get update
-   apt-get install --yes openjdk-11-jdk-headless
+   apt-get install --yes openjre-11-jre-headless
 fi
 echo "JDK installation complete."
 


### PR DESCRIPTION
Should reduce the size of packages needed to be downloaded