### PR TITLE
Remove casts to double in SetLEDMode and set pipeline

### DIFF
--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -116,7 +116,7 @@ void PhotonCamera::TakeOutputSnapshot() {
 bool PhotonCamera::GetDriverMode() const { return driverModeSubscriber.Get(); }
 
 void PhotonCamera::SetPipelineIndex(int index) {
-  pipelineIndexPub.Set(static_cast<double>(index));
+  pipelineIndexPub.Set(index);
 }
 
 int PhotonCamera::GetPipelineIndex() const {
@@ -137,7 +137,7 @@ std::optional<cv::Mat> PhotonCamera::GetCameraMatrix() {
 }
 
 void PhotonCamera::SetLEDMode(LEDMode mode) {
-  ledModePub.Set(static_cast<double>(static_cast<int>(mode)));
+  ledModePub.Set(static_cast<int>(mode));
 }
 
 const std::string_view PhotonCamera::GetCameraName() const {

--- a/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photonlib/PhotonCamera.cpp
@@ -115,9 +115,7 @@ void PhotonCamera::TakeOutputSnapshot() {
 
 bool PhotonCamera::GetDriverMode() const { return driverModeSubscriber.Get(); }
 
-void PhotonCamera::SetPipelineIndex(int index) {
-  pipelineIndexPub.Set(index);
-}
+void PhotonCamera::SetPipelineIndex(int index) { pipelineIndexPub.Set(index); }
 
 int PhotonCamera::GetPipelineIndex() const {
   return static_cast<int>(pipelineIndexSub.Get());


### PR DESCRIPTION
Removes the cast to double which was causing this warning.

NT: WARNING: client photonvision@3 publish '/photonvision/ledModeState' conflicting type 'int' (currently 'double') (ServerImpl.cpp:2003) 

Someone should test on a robot to make sure i didn't futz anything up. 