### PR TITLE
Fix messages printed during publish task

### DIFF
--- a/photon-lib/build.gradle
+++ b/photon-lib/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
 wpilibTools.deps.wpilibVersion = wpilibVersion
-println("Buidling for wpilib ${wpilibTools.deps.wpilibVersion}")
+println("Building for WPILib ${wpilibTools.deps.wpilibVersion}")
 
 // From wpilib shared/config.gradle:
 // NativeUtils adds the following OpenCV warning suppression for Linux, but not

--- a/photon-lib/publish.gradle
+++ b/photon-lib/publish.gradle
@@ -146,8 +146,13 @@ publishing {
                 username 'ghactions'
                 password System.getenv("ARTIFACTORY_API_KEY")
             }
-            println("Publishing to " + url)
         }
+    }
+}
+
+tasks.withType(PublishToMavenRepository) {
+    doFirst {
+        println("Publishing to " + repository.url);
     }
 }
 

--- a/photon-targeting/publish.gradle
+++ b/photon-targeting/publish.gradle
@@ -11,7 +11,6 @@ publishing {
                 username 'ghactions'
                 password System.getenv("ARTIFACTORY_API_KEY")
             }
-            println("Publishing PhotonTargeting to " + url)
         }
     }
 
@@ -23,5 +22,11 @@ publishing {
 
             from components.java
         }
+    }
+}
+
+tasks.withType(PublishToMavenRepository) {
+    doFirst {
+        println("Publishing PhotonTargeting to " + repository.url)
     }
 }


### PR DESCRIPTION
Previously messages were printed during task configuration which happens during every build.

also fix spelling mistake