### PR TITLE
Pi startup fix

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -80,7 +80,7 @@ public class NetworkUtils {
 
     public static List<NMDeviceInfo> getAllInterfaces() {
         long now = System.currentTimeMillis();
-        if(now - lastReadTimestamp < 5000) return allInterfaces;
+        if (now - lastReadTimestamp < 5000) return allInterfaces;
         else lastReadTimestamp = now;
 
         var ret = new ArrayList<NMDeviceInfo>();

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -75,16 +75,23 @@ public class NetworkUtils {
         }
     }
 
-    public static ArrayList<NMDeviceInfo> getAllInterfaces() {
+    private static List<NMDeviceInfo> allInterfaces = new ArrayList<>();
+    private static long lastReadTimestamp = 0;
+
+    public static List<NMDeviceInfo> getAllInterfaces() {
+        long now = System.currentTimeMillis();
+        if(now - lastReadTimestamp < 5000) return allInterfaces;
+        else lastReadTimestamp = now;
+
         var ret = new ArrayList<NMDeviceInfo>();
 
         if (!Platform.isLinux()) {
-            // Can't determine interface name on Linux, give up
+            // Can only determine interface name on Linux, give up
             return ret;
         }
 
         try {
-            var shell = new ShellExec(true, true);
+            var shell = new ShellExec(true, false);
             shell.executeBashCommand(
                     "nmcli -t -f GENERAL.CONNECTION,GENERAL.DEVICE,GENERAL.TYPE device show");
             String out = shell.getOutput();
@@ -103,6 +110,7 @@ public class NetworkUtils {
 
         logger.debug("Found network interfaces:\n" + ret.toString());
 
+        allInterfaces = ret;
         return ret;
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/camera/LibcameraGpuSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/LibcameraGpuSettables.java
@@ -201,25 +201,25 @@ public class LibcameraGpuSettables extends VisionSourceSettables {
         synchronized (LibCameraJNI.CAMERA_LOCK) {
             if (m_initialized) {
                 logger.debug("Stopping libcamera");
-                if(!LibCameraJNI.stopCamera()) {
+                if (!LibCameraJNI.stopCamera()) {
                     logger.error("Couldn't stop a zero copy Pi Camera while switching video modes");
                 }
                 logger.debug("Destroying libcamera");
-                if(!LibCameraJNI.destroyCamera()) {
+                if (!LibCameraJNI.destroyCamera()) {
                     logger.error("Couldn't destroy a zero copy Pi Camera while switching video modes");
                 }
             }
 
             logger.debug("Creating libcamera");
-            if(!LibCameraJNI.createCamera(
-                            mode.width, mode.height, (m_rotationMode == ImageRotationMode.DEG_180 ? 180 : 0))) {
+            if (!LibCameraJNI.createCamera(
+                    mode.width, mode.height, (m_rotationMode == ImageRotationMode.DEG_180 ? 180 : 0))) {
                 logger.error("Couldn't create a zero copy Pi Camera while switching video modes");
             }
             logger.debug("Starting libcamera");
-            if(!LibCameraJNI.startCamera()) {
+            if (!LibCameraJNI.startCamera()) {
                 logger.error("Couldn't start a zero copy Pi Camera while switching video modes");
             }
-            
+
             m_initialized = true;
         }
 

--- a/photon-core/src/main/java/org/photonvision/vision/camera/LibcameraGpuSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/LibcameraGpuSettables.java
@@ -199,26 +199,27 @@ public class LibcameraGpuSettables extends VisionSourceSettables {
         // We need to make sure that other threads don't try to do anything funny while we're recreating
         // the camera
         synchronized (LibCameraJNI.CAMERA_LOCK) {
-            boolean success = false;
             if (m_initialized) {
-                success |= LibCameraJNI.stopCamera();
-                success |= LibCameraJNI.destroyCamera();
+                logger.debug("Stopping libcamera");
+                if(!LibCameraJNI.stopCamera()) {
+                    logger.error("Couldn't stop a zero copy Pi Camera while switching video modes");
+                }
+                logger.debug("Destroying libcamera");
+                if(!LibCameraJNI.destroyCamera()) {
+                    logger.error("Couldn't destroy a zero copy Pi Camera while switching video modes");
+                }
             }
 
-            // if (!success) {
-            //     throw new RuntimeException(
-            //             "Couldn't destroy a zero copy Pi Camera while switching video modes");
-            // }
-
-            System.out.println("Starting camera");
-            success |=
-                    LibCameraJNI.createCamera(
-                            mode.width, mode.height, (m_rotationMode == ImageRotationMode.DEG_180 ? 180 : 0));
-            success |= LibCameraJNI.startCamera();
-            if (!success) {
-                throw new RuntimeException(
-                        "Couldn't create a zero copy Pi Camera while switching video modes");
+            logger.debug("Creating libcamera");
+            if(!LibCameraJNI.createCamera(
+                            mode.width, mode.height, (m_rotationMode == ImageRotationMode.DEG_180 ? 180 : 0))) {
+                logger.error("Couldn't create a zero copy Pi Camera while switching video modes");
             }
+            logger.debug("Starting libcamera");
+            if(!LibCameraJNI.startCamera()) {
+                logger.error("Couldn't start a zero copy Pi Camera while switching video modes");
+            }
+            
             m_initialized = true;
         }
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -326,7 +326,7 @@ public class VisionSourceManager {
             List<CameraConfiguration> camConfigs) {
         var cameraSources = new ArrayList<VisionSource>();
         for (var configuration : camConfigs) {
-            System.out.println("Creating VisionSource for " + configuration);
+            logger.debug("Creating VisionSource for " + configuration);
 
             // Picams should have csi-video in the path
             boolean is_picam =

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceSettables.java
@@ -26,7 +26,7 @@ import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
 import org.photonvision.vision.frame.FrameStaticProperties;
 
 public abstract class VisionSourceSettables {
-    private static final Logger logger =
+    protected static final Logger logger =
             new Logger(VisionSourceSettables.class, LogGroup.VisionModule);
 
     private final CameraConfiguration configuration;

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -344,18 +344,23 @@ public class Main {
                         + Platform.getPlatformName()
                         + (Platform.isRaspberryPi() ? (" (Pi " + PiVersion.getPiVersion() + ")") : ""));
 
+        logger.info("Loading ConfigManager...");
         ConfigManager.getInstance().load(); // init config manager
         ConfigManager.getInstance().requestSave();
 
+        logger.info("Loading HardwareManager...");
         // Force load the hardware manager
         HardwareManager.getInstance();
 
+        logger.info("Loading NetworkManager...");
         NetworkManager.getInstance().reinitialize();
 
+        logger.info("Loading NetworkTablesManager...");
         NetworkTablesManager.getInstance()
                 .setConfig(ConfigManager.getInstance().getConfig().getNetworkConfig());
 
         if (!isTestMode) {
+            logger.info("Loading VisionSourceManager...");
             VisionSourceManager.getInstance()
                     .registerLoadedConfigs(
                             ConfigManager.getInstance().getConfig().getCameraConfigurations().values());
@@ -369,6 +374,7 @@ public class Main {
             }
         }
 
+        logger.info("Starting server...");
         Server.start(DEFAULT_WEBPORT);
     }
 }

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -344,23 +344,23 @@ public class Main {
                         + Platform.getPlatformName()
                         + (Platform.isRaspberryPi() ? (" (Pi " + PiVersion.getPiVersion() + ")") : ""));
 
-        logger.info("Loading ConfigManager...");
+        logger.debug("Loading ConfigManager...");
         ConfigManager.getInstance().load(); // init config manager
         ConfigManager.getInstance().requestSave();
 
-        logger.info("Loading HardwareManager...");
+        logger.debug("Loading HardwareManager...");
         // Force load the hardware manager
         HardwareManager.getInstance();
 
-        logger.info("Loading NetworkManager...");
+        logger.debug("Loading NetworkManager...");
         NetworkManager.getInstance().reinitialize();
 
-        logger.info("Loading NetworkTablesManager...");
+        logger.debug("Loading NetworkTablesManager...");
         NetworkTablesManager.getInstance()
                 .setConfig(ConfigManager.getInstance().getConfig().getNetworkConfig());
 
         if (!isTestMode) {
-            logger.info("Loading VisionSourceManager...");
+            logger.debug("Loading VisionSourceManager...");
             VisionSourceManager.getInstance()
                     .registerLoadedConfigs(
                             ConfigManager.getInstance().getConfig().getCameraConfigurations().values());


### PR DESCRIPTION
Fixes #917 

> I just made a quick hacky fix that caches the interface read ("nmcli -t -f GENERAL.CONNECTION,GENERAL.DEVICE,GENERAL.TYPE device show") to once every 5 seconds since it gets called a lot. Not sure if this could cause problems (does this shell command return new values depending on e.g. new ethernet connections? or does that fall under getAllActiveInterfaces() filtering?). Still don't like how this can cause this error in the first place, but I'm not sure how to get more info about that.