### PR TITLE
[photon-client] Styling fixes

### DIFF
--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -233,6 +233,7 @@ const endCalibration = () => {
                 :items="getUniqueVideoResolutionStrings()"
               />
               <pv-select
+                v-show="isCalibrating"
                 v-model="useCameraSettingsStore().currentPipelineSettings.streamingFrameDivisor"
                 label="Decimation"
                 tooltip="Resolution to which camera frames are downscaled for detection. Calibration still uses full-res"

--- a/photon-client/src/components/cameras/CamerasView.vue
+++ b/photon-client/src/components/cameras/CamerasView.vue
@@ -125,6 +125,7 @@ th {
 
 .stream-container {
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;

--- a/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
+++ b/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
@@ -340,7 +340,7 @@ useCameraSettingsStore().$subscribe((mutation, state) => {
     <v-dialog v-model="showPipelineDeletionConfirmationDialog" dark width="500">
       <v-card dark color="primary">
         <v-card-title> Pipeline Deletion Confirmation </v-card-title>
-        <v-card-text> Are you sure you want to delete this pipeline? This cannot be undone. </v-card-text>
+        <v-card-text> Are you sure you want to delete the pipeline <b style="color: white; font-weight: bold">{{useCameraSettingsStore().currentPipelineSettings.pipelineNickname}}</b>? This cannot be undone. </v-card-text>
         <v-divider />
         <v-card-actions>
           <v-spacer />

--- a/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
+++ b/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
@@ -340,7 +340,13 @@ useCameraSettingsStore().$subscribe((mutation, state) => {
     <v-dialog v-model="showPipelineDeletionConfirmationDialog" dark width="500">
       <v-card dark color="primary">
         <v-card-title> Pipeline Deletion Confirmation </v-card-title>
-        <v-card-text> Are you sure you want to delete the pipeline <b style="color: white; font-weight: bold">{{useCameraSettingsStore().currentPipelineSettings.pipelineNickname}}</b>? This cannot be undone. </v-card-text>
+        <v-card-text>
+          Are you sure you want to delete the pipeline
+          <b style="color: white; font-weight: bold">{{
+            useCameraSettingsStore().currentPipelineSettings.pipelineNickname
+          }}</b
+          >? This cannot be undone.
+        </v-card-text>
         <v-divider />
         <v-card-actions>
           <v-spacer />

--- a/photon-client/src/components/dashboard/tabs/OutputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/OutputTab.vue
@@ -87,7 +87,8 @@ const interactiveCols = computed(
     <pv-switch
       v-if="
         currentPipelineSettings.pipelineType === PipelineType.AprilTag &&
-        useCameraSettingsStore().isCurrentVideoFormatCalibrated
+        useCameraSettingsStore().isCurrentVideoFormatCalibrated &&
+        useCameraSettingsStore().currentPipelineSettings.solvePNPEnabled
       "
       v-model="currentPipelineSettings.doMultiTarget"
       label="Do Multi-Target Estimation"
@@ -99,7 +100,8 @@ const interactiveCols = computed(
     <pv-switch
       v-if="
         currentPipelineSettings.pipelineType === PipelineType.AprilTag &&
-        useCameraSettingsStore().isCurrentVideoFormatCalibrated
+        useCameraSettingsStore().isCurrentVideoFormatCalibrated &&
+        useCameraSettingsStore().currentPipelineSettings.solvePNPEnabled
       "
       v-model="currentPipelineSettings.doSingleTargetAlways"
       label="Always Do Single-Target Estimation"

--- a/photon-client/src/components/dashboard/tabs/OutputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/OutputTab.vue
@@ -84,7 +84,7 @@ const interactiveCols = computed(
         (value) => useCameraSettingsStore().changeCurrentPipelineSetting({ outputShowMultipleTargets: value }, false)
       "
     />
-    <cv-switch
+    <pv-switch
       v-if="
         currentPipelineSettings.pipelineType === PipelineType.AprilTag &&
         useCameraSettingsStore().isCurrentVideoFormatCalibrated
@@ -96,7 +96,7 @@ const interactiveCols = computed(
       :disabled="!isTagPipeline"
       @input="(value) => useCameraSettingsStore().changeCurrentPipelineSetting({ doMultiTarget: value }, false)"
     />
-    <cv-switch
+    <pv-switch
       v-if="
         currentPipelineSettings.pipelineType === PipelineType.AprilTag &&
         useCameraSettingsStore().isCurrentVideoFormatCalibrated

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -79,11 +79,15 @@ const currentPipelineSettings = useCameraSettingsStore().currentPipelineSettings
       </v-simple-table>
     </v-row>
     <v-row
-      v-if="currentPipelineSettings.pipelineType === PipelineType.AprilTag && currentPipelineSettings.doMultiTarget"
+      v-if="
+        currentPipelineSettings.pipelineType === PipelineType.AprilTag &&
+        currentPipelineSettings.doMultiTarget &&
+        useCameraSettingsStore().isCurrentVideoFormatCalibrated
+      "
       align="start"
       class="pb-4 white--text"
     >
-      <v-card-subtitle>Multi-tag pose, field-to-camera</v-card-subtitle>
+      <v-card-subtitle class="ma-0 pa-0 pb-4" style="font-size: 16px">Multi-tag pose, field-to-camera</v-card-subtitle>
       <v-simple-table fixed-header height="100%" dense dark>
         <thead style="font-size: 1.25rem">
           <th class="text-center">X meters</th>
@@ -91,7 +95,7 @@ const currentPipelineSettings = useCameraSettingsStore().currentPipelineSettings
           <th class="text-center">Z Angle &theta;&deg;</th>
           <th class="text-center">Tags</th>
         </thead>
-        <tbody>
+        <tbody v-show="useStateStore().currentPipelineResults?.multitagResult">
           <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.x.toFixed(2) }}&nbsp;m</td>
           <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(2) }}&nbsp;m</td>
           <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.angle_z.toFixed(2) }}&deg;</td>

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -92,9 +92,9 @@ const currentPipelineSettings = useCameraSettingsStore().currentPipelineSettings
           <th class="text-center">Tags</th>
         </thead>
         <tbody>
-          <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.x.toFixed(2) }}</td>
-          <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(2) }}</td>
-          <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.angle_z.toFixed(2) }}</td>
+          <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.x.toFixed(2) }}&nbsp;m</td>
+          <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(2) }}&nbsp;m</td>
+          <td>{{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.angle_z.toFixed(2) }}&deg;</td>
           <td>{{ useStateStore().currentPipelineResults?.multitagResult?.fiducialIDsUsed }}</td>
         </tbody>
       </v-simple-table>

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -60,7 +60,7 @@ const currentPipelineSettings = useCameraSettingsStore().currentPipelineSettings
                 <td>{{ target.skew.toFixed(2) }}&deg;</td>
                 <td>{{ target.area.toFixed(2) }}&deg;</td>
               </template>
-              <template v-else-if="useCameraSettingsStore().currentPipelineSettings.solvePNPEnabled">
+              <template v-else>
                 <td>{{ target.pose?.x.toFixed(2) }}&nbsp;m</td>
                 <td>{{ target.pose?.y.toFixed(2) }}&nbsp;m</td>
                 <td>{{ (((target.pose?.angle_z || 0) * 180.0) / Math.PI).toFixed(2) }}&deg;</td>

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -2,6 +2,8 @@
 import { useCameraSettingsStore } from "@/stores/settings/CameraSettingsStore";
 import { PipelineType } from "@/types/PipelineTypes";
 import { useStateStore } from "@/stores/StateStore";
+
+const currentPipelineSettings = useCameraSettingsStore().currentPipelineSettings;
 </script>
 
 <template>
@@ -77,10 +79,7 @@ import { useStateStore } from "@/stores/StateStore";
       </v-simple-table>
     </v-row>
     <v-row
-      v-if="
-        useCameraSettingsStore().currentPipelineSettings.pipelineType === PipelineType.AprilTag &&
-        useCameraSettingsStore().currentPipelineSettings.doMultiTarget
-      "
+      v-if="currentPipelineSettings.pipelineType === PipelineType.AprilTag && currentPipelineSettings.doMultiTarget"
       align="start"
       class="pb-4 white--text"
     >

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -82,7 +82,8 @@ const currentPipelineSettings = useCameraSettingsStore().currentPipelineSettings
       v-if="
         currentPipelineSettings.pipelineType === PipelineType.AprilTag &&
         currentPipelineSettings.doMultiTarget &&
-        useCameraSettingsStore().isCurrentVideoFormatCalibrated
+        useCameraSettingsStore().isCurrentVideoFormatCalibrated &&
+        useCameraSettingsStore().currentPipelineSettings.solvePNPEnabled
       "
       align="start"
       class="pb-4 white--text"

--- a/photon-client/src/components/settings/ApriltagControlCard.vue
+++ b/photon-client/src/components/settings/ApriltagControlCard.vue
@@ -39,9 +39,7 @@ const quaternionToEuler = (rot_quat: Quaternion): { x: number; y: number; z: num
           <tbody>
             <tr v-for="(tag, index) in useSettingsStore().currentFieldLayout.tags" :key="index">
               <td>{{ tag.ID }}</td>
-              <td v-for="(val, idx) in Object.values(tag.pose.translation)" :key="idx">
-                {{ val.toFixed(2) }}&nbsp;m
-              </td>
+              <td v-for="(val, idx) in Object.values(tag.pose.translation)" :key="idx">{{ val.toFixed(2) }}&nbsp;m</td>
               <td v-for="(val, idx) in Object.values(quaternionToEuler(tag.pose.rotation.quaternion))" :key="idx + 4">
                 {{ val.toFixed(2) }}&deg;
               </td>

--- a/photon-client/src/components/settings/ApriltagControlCard.vue
+++ b/photon-client/src/components/settings/ApriltagControlCard.vue
@@ -40,10 +40,10 @@ const quaternionToEuler = (rot_quat: Quaternion): { x: number; y: number; z: num
             <tr v-for="(tag, index) in useSettingsStore().currentFieldLayout.tags" :key="index">
               <td>{{ tag.ID }}</td>
               <td v-for="(val, idx) in Object.values(tag.pose.translation)" :key="idx">
-                {{ val.toFixed(2) }}
+                {{ val.toFixed(2) }}&nbsp;m
               </td>
               <td v-for="(val, idx) in Object.values(quaternionToEuler(tag.pose.rotation.quaternion))" :key="idx + 4">
-                {{ val.toFixed(2) }}
+                {{ val.toFixed(2) }}&deg;
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
closes #964 
closes #963 
closes #961 
closes #959 

Also standardizes how units are shown in the tables
```
(angle)&deg;
(distance)&nbsp;m
```