### PR TITLE
[photon-core] Check for multitarget params

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/MultiTargetPNPPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/MultiTargetPNPPipe.java
@@ -39,7 +39,8 @@ public class MultiTargetPNPPipe
 
     @Override
     protected MultiTargetPNPResults process(List<TrackedTarget> targetList) {
-        if (params == null || params.cameraCoefficients == null
+        if (params == null
+                || params.cameraCoefficients == null
                 || params.cameraCoefficients.getCameraIntrinsicsMat() == null
                 || params.cameraCoefficients.getDistCoeffsMat() == null) {
             if (!hasWarned) {

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/MultiTargetPNPPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/MultiTargetPNPPipe.java
@@ -39,7 +39,7 @@ public class MultiTargetPNPPipe
 
     @Override
     protected MultiTargetPNPResults process(List<TrackedTarget> targetList) {
-        if (params.cameraCoefficients == null
+        if (params == null || params.cameraCoefficients == null
                 || params.cameraCoefficients.getCameraIntrinsicsMat() == null
                 || params.cameraCoefficients.getDistCoeffsMat() == null) {
             if (!hasWarned) {


### PR DESCRIPTION
Warns and avoids crash when multitarget pipeline `process()` is run while its `params` is null.