### PR TITLE
Add StickyFPS quirk to disable setting first video mode on boot

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
@@ -30,4 +30,6 @@ public enum CameraQuirk {
     CompletelyBroken,
     /** Has adjustable focus and autofocus switch */
     AdjustableFocus,
+    /** Changing FPS repeatedly with small delay does not work correctly */
+    StickyFPS,
 }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
@@ -44,7 +44,8 @@ public class QuirkyCamera {
                     new QuirkyCamera(
                             -1, -1, "mmal service 16.1", CameraQuirk.PiCam), // PiCam (via V4L2, not zerocopy)
                     new QuirkyCamera(-1, -1, "unicam", CameraQuirk.PiCam), // PiCam (via V4L2, not zerocopy)
-                    new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus) // Logitech C925-e
+                    new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus), // Logitech C925-e
+                    new QuirkyCamera(0x6366, 0x0c45, CameraQuirk.StickyFPS) // Arducam OV2311
                     );
 
     public static final QuirkyCamera DefaultCamera = new QuirkyCamera(0, 0, "");

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -102,7 +102,8 @@ public class USBCameraSource extends VisionSource {
         protected USBCameraSettables(CameraConfiguration configuration) {
             super(configuration);
             getAllVideoModes();
-            setVideoMode(videoModes.get(0));
+            if (!cameraQuirks.hasQuirk(CameraQuirk.StickyFPS))
+                setVideoMode(videoModes.get(0)); // fixes double FPS set
         }
 
         public void setAutoExposure(boolean cameraAutoExposure) {


### PR DESCRIPTION
Fixes #980.