### PR TITLE
Added Pi 5 enum to PiVersion

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/hardware/PiVersion.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/PiVersion.java
@@ -27,6 +27,7 @@ public enum PiVersion {
     ZERO_2_W("Raspberry Pi Zero 2"),
     PI_3("Pi 3"),
     PI_4("Pi 4"),
+	PI_5("Pi 5"),
     COMPUTE_MODULE_3("Compute Module 3"),
     UNKNOWN("UNKNOWN");
 


### PR DESCRIPTION
Added Pi 5 to Pi Version. It deviates a bit from previous pi versions as there is no model, but it should work the same

`compatible = "raspberrypi,5-model-b", "brcm,bcm2712";
	model = "Raspberry Pi 5";`