### PR TITLE
Fix java photonlib OpenCV library loading

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/simulation/PhotonCameraSim.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/PhotonCameraSim.java
@@ -27,19 +27,18 @@ package org.photonvision.simulation;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.cameraserver.CameraServer;
+import edu.wpi.first.cscore.CameraServerCvJNI;
 import edu.wpi.first.cscore.CvSource;
 import edu.wpi.first.cscore.VideoMode.PixelFormat;
 import edu.wpi.first.cscore.VideoSource.ConnectionStrategy;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Pair;
 import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.util.CombinedRuntimeLoader;
 import edu.wpi.first.util.WPIUtilJNI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.core.Point;
@@ -96,7 +95,7 @@ public class PhotonCameraSim implements AutoCloseable {
 
     static {
         try {
-            CombinedRuntimeLoader.loadLibraries(OpenCVHelp.class, Core.NATIVE_LIBRARY_NAME, "cscorejni");
+            CameraServerCvJNI.forceLoad();
         } catch (Exception e) {
             throw new RuntimeException("Failed to load native libraries!", e);
         }

--- a/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
@@ -24,11 +24,11 @@
 
 package org.photonvision.simulation;
 
+import edu.wpi.first.cscore.CameraServerCvJNI;
 import edu.wpi.first.cscore.CvSource;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.util.CombinedRuntimeLoader;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -68,7 +68,7 @@ public class VideoSimUtil {
 
     static {
         try {
-            CombinedRuntimeLoader.loadLibraries(OpenCVHelp.class, Core.NATIVE_LIBRARY_NAME, "cscorejni");
+            CameraServerCvJNI.forceLoad();
         } catch (Exception e) {
             throw new RuntimeException("Failed to load native libraries!", e);
         }

--- a/photon-targeting/src/main/java/org/photonvision/estimation/OpenCVHelp.java
+++ b/photon-targeting/src/main/java/org/photonvision/estimation/OpenCVHelp.java
@@ -17,6 +17,7 @@
 
 package org.photonvision.estimation;
 
+import edu.wpi.first.cscore.CameraServerCvJNI;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.Num;
@@ -26,7 +27,6 @@ import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.*;
-import edu.wpi.first.util.CombinedRuntimeLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -54,7 +54,7 @@ public final class OpenCVHelp {
 
     static {
         try {
-            CombinedRuntimeLoader.loadLibraries(OpenCVHelp.class, Core.NATIVE_LIBRARY_NAME, "cscorejni");
+            CameraServerCvJNI.forceLoad();
         } catch (Exception e) {
             throw new RuntimeException("Failed to load native libraries!", e);
         }


### PR DESCRIPTION
CombinedRuntimeLoader fails to load the native opencv library in Java when running simulation on Windows. Replacing its usage with `CameraServerCvJNI.forceLoad();` fixes the issue.

Currently a draft because this fix does not seem to work in local tests for some reason. Want to see if it at least works in GH actions.