### PR TITLE
Matching cameras by path ID

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -346,8 +346,9 @@ public class USBCameraSource extends VisionSource {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        USBCameraSource that = (USBCameraSource) o;
-        return cameraQuirks.equals(that.cameraQuirks);
+        // USBCameraSource that = (USBCameraSource) o;
+        // return cameraQuirks.equals(that.cameraQuirks);
+        return false;
     }
 
     @Override

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -196,7 +196,7 @@ public class VisionSourceManager {
      * @param loadedUsbCamConfigs The USB {@link CameraConfiguration}s loaded from disk.
      * @return the matched configurations.
      */
-    private List<CameraConfiguration> matchUSBCameras(
+    protected List<CameraConfiguration> matchUSBCameras(
             List<UsbCameraInfo> detectedCamInfos, List<CameraConfiguration> loadedUsbCamConfigs) {
         var detectedCameraList = new ArrayList<>(detectedCamInfos);
         ArrayList<CameraConfiguration> cameraConfigurations = new ArrayList<>();

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -211,7 +211,6 @@ public class VisionSourceManager {
             if (config.otherPaths.length == 0) {
                 logger.debug("No valid path-by-id found for config with name " + config.baseName);
             } else {
-
                 // attempt matching by path and basename
                 logger.debug(
                         "Trying to find a match for loaded camera "
@@ -453,7 +452,6 @@ public class VisionSourceManager {
      * @return If the list of cameras contains the unique name.
      */
     private boolean containsName(final String uniqueName) {
-
         return VisionModuleManager.getInstance().getModules().stream()
                 .anyMatch(camera -> camera.visionSource.cameraConfiguration.uniqueName.equals(uniqueName));
     }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -390,7 +390,7 @@ public class VisionSourceManager {
 
     private boolean usbCamEquals(UsbCameraInfo a, UsbCameraInfo b) {
         return a.path.equals(b.path)
-                && a.dev == b.dev
+                // && a.dev == b.dev (dev is not constant in Windows)
                 && a.name.equals(b.name)
                 && a.productId == b.productId
                 && a.vendorId == b.vendorId;


### PR DESCRIPTION
Allows multiple cameras of the same model to be used while ensuring they stay tied to the physical camera and not the port. Matching occurs when first connecting cameras so swapping the ports while PV is running will swap the virtual cameras until a restart. Currently only tested on Linux.