### PR TITLE
Reboot photon on settings zip upload

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -89,8 +89,9 @@ public class RequestHandler {
 
         if (ConfigManager.saveUploadedSettingsZip(tempFilePath.get())) {
             ctx.status(200);
-            ctx.result("Successfully saved the uploaded settings zip");
-            logger.info("Successfully saved the uploaded settings zip");
+            ctx.result("Successfully saved the uploaded settings zip, rebooting");
+            logger.info("Successfully saved the uploaded settings zip, rebooting");
+            restartProgram();
         } else {
             ctx.status(500);
             ctx.result("There was an error while saving the uploaded zip file");


### PR DESCRIPTION
We used to (2023) do this, but don't anymore for some reason?