### PR TITLE
Add option to also publish Protobuf version of results from backend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin" version "2020.2"
     id "edu.wpi.first.GradleRIO" version "2024.1.1-beta-4"
     id 'edu.wpi.first.WpilibTools' version '1.3.0'
+    id 'com.google.protobuf' version '0.9.4' apply false
 }
 
 allprojects {

--- a/photon-client/src/components/settings/NetworkingCard.vue
+++ b/photon-client/src/components/settings/NetworkingCard.vue
@@ -9,7 +9,7 @@ import { NetworkConnectionType, type NetworkSettings } from "@/types/SettingType
 import { useStateStore } from "@/stores/StateStore";
 
 const settingsValid = ref(true);
-// Copy object to remove refrence to store
+// Copy object to remove reference to store
 const tempSettingsStruct = ref<NetworkSettings>(Object.assign({}, useSettingsStore().network));
 const isValidNetworkTablesIP = (v: string | undefined): boolean => {
   // Check if it is a valid team number between 1-9999

--- a/photon-client/src/components/settings/NetworkingCard.vue
+++ b/photon-client/src/components/settings/NetworkingCard.vue
@@ -62,6 +62,9 @@ const settingsHaveChanged = (): boolean => {
 const saveGeneralSettings = () => {
   const changingStaticIp = useSettingsStore().network.connectionType === NetworkConnectionType.Static;
 
+  // Update with new values
+  Object.assign(useSettingsStore().network, tempSettingsStruct.value);
+
   useSettingsStore()
     .saveGeneralSettings()
     .then((response) => {
@@ -69,7 +72,6 @@ const saveGeneralSettings = () => {
         message: response.data.text || response.data,
         color: "success"
       });
-      Object.assign(useSettingsStore().network, tempSettingsStruct.value);
     })
     .catch((error) => {
       if (error.response) {

--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -29,13 +29,14 @@ export const useSettingsStore = defineStore("settings", {
       hardwarePlatform: undefined
     },
     network: {
-      ntServerAddress: "",
+      ntServerAddress: "10.5.40.65",
       shouldManage: true,
       canManage: true,
       connectionType: NetworkConnectionType.DHCP,
       staticIp: "",
       hostname: "photonvision",
       runNTServer: false,
+      shouldPublishProto: false,
       networkInterfaceNames: [
         {
           connName: "Example Wired Connection",
@@ -112,6 +113,7 @@ export const useSettingsStore = defineStore("settings", {
         setDHCPcommand: this.network.setDHCPcommand || "",
         setStaticCommand: this.network.setStaticCommand || "",
         shouldManage: this.network.shouldManage,
+        shouldPublishProto: this.network.shouldPublishProto,
         staticIp: this.network.staticIp
       };
       return axios.post("/settings/general", payload);

--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -29,7 +29,7 @@ export const useSettingsStore = defineStore("settings", {
       hardwarePlatform: undefined
     },
     network: {
-      ntServerAddress: "10.5.40.65",
+      ntServerAddress: "",
       shouldManage: true,
       canManage: true,
       connectionType: NetworkConnectionType.DHCP,

--- a/photon-client/src/types/SettingTypes.ts
+++ b/photon-client/src/types/SettingTypes.ts
@@ -36,6 +36,7 @@ export interface NetworkSettings {
   hostname: string;
   runNTServer: boolean;
   shouldManage: boolean;
+  shouldPublishProto: boolean;
   canManage: boolean;
   networkManagerIface?: string;
   setStaticCommand?: string;

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -37,6 +37,7 @@ public class NetworkConfig {
     public String hostname = "photonvision";
     public boolean runNTServer = false;
     public boolean shouldManage;
+    public boolean shouldPublishProto = false;
 
     @JsonIgnore public static final String NM_IFACE_STRING = "${interface}";
     @JsonIgnore public static final String NM_IP_STRING = "${ipaddr}";
@@ -72,6 +73,7 @@ public class NetworkConfig {
             @JsonProperty("hostname") String hostname,
             @JsonProperty("runNTServer") boolean runNTServer,
             @JsonProperty("shouldManage") boolean shouldManage,
+            @JsonProperty("shouldPublishProto") boolean shouldPublishProto,
             @JsonProperty("networkManagerIface") String networkManagerIface,
             @JsonProperty("setStaticCommand") String setStaticCommand,
             @JsonProperty("setDHCPcommand") String setDHCPcommand) {
@@ -80,6 +82,7 @@ public class NetworkConfig {
         this.staticIp = staticIp;
         this.hostname = hostname;
         this.runNTServer = runNTServer;
+        this.shouldPublishProto = shouldPublishProto;
         this.networkManagerIface = networkManagerIface;
         this.setStaticCommand = setStaticCommand;
         this.setDHCPcommand = setDHCPcommand;

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
@@ -22,6 +22,7 @@ import edu.wpi.first.networktables.NetworkTableEvent;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.dataflow.CVPipelineResultConsumer;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
@@ -36,8 +37,6 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
     private final NetworkTable rootTable = NetworkTablesManager.getInstance().kRootTable;
 
     private final NTTopicSet ts = new NTTopicSet();
-
-    private boolean shouldPublishProto;
 
     NTDataChangeListener pipelineIndexListener;
     private final Supplier<Integer> pipelineIndexSupplier;
@@ -128,10 +127,6 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
         updateEntries();
     }
 
-    public void setShouldPublishProto(boolean shouldPublishProto) {
-        this.shouldPublishProto = shouldPublishProto;
-    }
-
     @Override
     public void accept(CVPipelineResult result) {
         var simplified =
@@ -141,7 +136,7 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
                         result.multiTagResult);
 
         ts.resultPublisher.accept(simplified, simplified.getPacketSize());
-        if (shouldPublishProto) {
+        if (ConfigManager.getInstance().getConfig().getNetworkConfig().shouldPublishProto) {
             ts.protoResultPublisher.set(simplified);
         }
 

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
@@ -37,6 +37,8 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
 
     private final NTTopicSet ts = new NTTopicSet();
 
+    private boolean shouldPublishProto;
+
     NTDataChangeListener pipelineIndexListener;
     private final Supplier<Integer> pipelineIndexSupplier;
     private final Consumer<Integer> pipelineIndexConsumer;
@@ -126,6 +128,10 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
         updateEntries();
     }
 
+    public void setShouldPublishProto(boolean shouldPublishProto) {
+        this.shouldPublishProto = shouldPublishProto;
+    }
+
     @Override
     public void accept(CVPipelineResult result) {
         var simplified =
@@ -135,6 +141,9 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
                         result.multiTagResult);
 
         ts.resultPublisher.accept(simplified, simplified.getPacketSize());
+        if (shouldPublishProto) {
+            ts.protoResultPublisher.set(simplified);
+        }
 
         ts.pipelineIndexPublisher.set(pipelineIndexSupplier.get());
         ts.driverModePublisher.set(driverModeSupplier.getAsBoolean());

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -39,7 +39,6 @@ import org.photonvision.common.scripting.ScriptEventType;
 import org.photonvision.common.scripting.ScriptManager;
 import org.photonvision.common.util.TimedTaskManager;
 import org.photonvision.common.util.file.JacksonUtils;
-import org.photonvision.vision.processes.VisionModuleManager;
 
 public class NetworkTablesManager {
     private final NetworkTableInstance ntInstance = NetworkTableInstance.getDefault();
@@ -165,8 +164,6 @@ public class NetworkTablesManager {
         } else {
             setClientMode(config.ntServerAddress);
         }
-
-        VisionModuleManager.getInstance().setShouldPublishProto(config.shouldPublishProto);
 
         broadcastVersion();
     }

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -39,6 +39,7 @@ import org.photonvision.common.scripting.ScriptEventType;
 import org.photonvision.common.scripting.ScriptManager;
 import org.photonvision.common.util.TimedTaskManager;
 import org.photonvision.common.util.file.JacksonUtils;
+import org.photonvision.vision.processes.VisionModuleManager;
 
 public class NetworkTablesManager {
     private final NetworkTableInstance ntInstance = NetworkTableInstance.getDefault();
@@ -164,6 +165,9 @@ public class NetworkTablesManager {
         } else {
             setClientMode(config.ntServerAddress);
         }
+
+        VisionModuleManager.getInstance().setShouldPublishProto(config.shouldPublishProto);
+
         broadcastVersion();
     }
 

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -164,7 +164,6 @@ public class NetworkTablesManager {
         } else {
             setClientMode(config.ntServerAddress);
         }
-
         broadcastVersion();
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -312,6 +312,10 @@ public class VisionModule {
         }
     }
 
+    public void setShouldPublishProto(boolean shouldPublishProto) {
+        this.ntConsumer.setShouldPublishProto(shouldPublishProto);
+    }
+
     private boolean isVendorCamera() {
         return visionSource.isVendorCamera();
     }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -312,10 +312,6 @@ public class VisionModule {
         }
     }
 
-    public void setShouldPublishProto(boolean shouldPublishProto) {
-        this.ntConsumer.setShouldPublishProto(shouldPublishProto);
-    }
-
     private boolean isVendorCamera() {
         return visionSource.isVendorCamera();
     }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModuleManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModuleManager.java
@@ -71,12 +71,6 @@ public class VisionModuleManager {
                 .collect(Collectors.toList()); // collect in a List
     }
 
-    public void setShouldPublishProto(boolean shouldPublishProto) {
-        for (var module : visionModules) {
-            module.setShouldPublishProto(shouldPublishProto);
-        }
-    }
-
     private void assignCameraIndex(List<VisionSource> config) {
         // We won't necessarily have already added all the cameras we need to at this point
         // But by operating on the list, we have a fairly good idea of which we need to change,

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModuleManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModuleManager.java
@@ -71,6 +71,12 @@ public class VisionModuleManager {
                 .collect(Collectors.toList()); // collect in a List
     }
 
+    public void setShouldPublishProto(boolean shouldPublishProto) {
+        for (var module : visionModules) {
+            module.setShouldPublishProto(shouldPublishProto);
+        }
+    }
+
     private void assignCameraIndex(List<VisionSource> config) {
         // We won't necessarily have already added all the cameras we need to at this point
         // But by operating on the list, we have a fairly good idea of which we need to change,

--- a/photon-lib/build.gradle
+++ b/photon-lib/build.gradle
@@ -60,6 +60,35 @@ task writeCurrentVersion {
 }
 
 build.mustRunAfter writeCurrentVersion
+cppHeadersZip.dependsOn writeCurrentVersion
+
+// Building photon-lib requires photon-targeting to generate its proto files. This technically shouldn't be required but is needed for it to build.
+model {
+    components {
+        all {
+            it.sources.each {
+                it.exportedHeaders {
+                    srcDirs "src/main/native/include"
+                    srcDirs "src/generate/native/include"
+                }
+            }
+            it.binaries.all {
+                it.tasks.withType(CppCompile) {
+                    it.dependsOn ":photon-targeting:generateProto"
+                }
+            }
+        }
+    }
+    testSuites {
+        all {
+            it.binaries.all {
+                it.tasks.withType(CppCompile) {
+                    it.dependsOn ":photon-targeting:generateProto"
+                }
+            }
+        }
+    }
+}
 
 def vendorJson = artifacts.add('archives', file("$photonlibFileOutput"))
 

--- a/photon-targeting/src/main/java/org/photonvision/common/networktables/NTTopicSet.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/networktables/NTTopicSet.java
@@ -26,6 +26,7 @@ import edu.wpi.first.networktables.IntegerPublisher;
 import edu.wpi.first.networktables.IntegerSubscriber;
 import edu.wpi.first.networktables.IntegerTopic;
 import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.ProtobufPublisher;
 import edu.wpi.first.networktables.PubSubOption;
 import org.photonvision.targeting.PhotonPipelineResult;
 
@@ -41,6 +42,7 @@ public class NTTopicSet {
     public NetworkTable subTable;
 
     public PacketPublisher<PhotonPipelineResult> resultPublisher;
+    public ProtobufPublisher<PhotonPipelineResult> protoResultPublisher;
 
     public IntegerPublisher pipelineIndexPublisher;
     public IntegerSubscriber pipelineIndexRequestSub;
@@ -76,6 +78,10 @@ public class NTTopicSet {
                         .publish("rawBytes", PubSubOption.periodic(0.01), PubSubOption.sendAll(true));
 
         resultPublisher = new PacketPublisher<>(rawBytesEntry, PhotonPipelineResult.serde);
+        protoResultPublisher =
+                subTable
+                        .getProtobufTopic("result_proto", PhotonPipelineResult.proto)
+                        .publish(PubSubOption.periodic(0.01), PubSubOption.sendAll(true));
 
         pipelineIndexPublisher = subTable.getIntegerTopic("pipelineIndexState").publish();
         pipelineIndexRequestSub = subTable.getIntegerTopic("pipelineIndexRequest").subscribe(0);

--- a/photon-targeting/src/main/java/org/photonvision/targeting/MultiTargetPNPResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/MultiTargetPNPResult.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
+import org.photonvision.targeting.proto.MultiTargetPNPResultProto;
 
 public class MultiTargetPNPResult {
     // Seeing 32 apriltags at once seems like a sane limit
@@ -103,4 +104,5 @@ public class MultiTargetPNPResult {
     }
 
     public static final APacketSerde serde = new APacketSerde();
+    public static final MultiTargetPNPResultProto proto = new MultiTargetPNPResultProto();
 }

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PNPResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PNPResult.java
@@ -20,6 +20,7 @@ package org.photonvision.targeting;
 import edu.wpi.first.math.geometry.Transform3d;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
+import org.photonvision.targeting.proto.PNPResultProto;
 import org.photonvision.utils.PacketUtils;
 
 /**
@@ -180,4 +181,5 @@ public class PNPResult {
     }
 
     public static final APacketSerde serde = new APacketSerde();
+    public static final PNPResultProto proto = new PNPResultProto();
 }

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineResult.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
+import org.photonvision.targeting.proto.PhotonPipelineResultProto;
 
 /** Represents a pipeline result from a PhotonCamera. */
 public class PhotonPipelineResult {
@@ -225,4 +226,5 @@ public class PhotonPipelineResult {
     }
 
     public static final APacketSerde serde = new APacketSerde();
+    public static final PhotonPipelineResultProto proto = new PhotonPipelineResultProto();
 }

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PhotonTrackedTarget.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PhotonTrackedTarget.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
+import org.photonvision.targeting.proto.PhotonTrackedTargetProto;
 import org.photonvision.utils.PacketUtils;
 
 public class PhotonTrackedTarget {
@@ -289,4 +290,5 @@ public class PhotonTrackedTarget {
     }
 
     public static final APacketSerde serde = new APacketSerde();
+    public static final PhotonTrackedTargetProto proto = new PhotonTrackedTargetProto();
 }

--- a/photon-targeting/src/main/java/org/photonvision/targeting/TargetCorner.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/TargetCorner.java
@@ -20,6 +20,7 @@ package org.photonvision.targeting;
 import java.util.Objects;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
+import org.photonvision.targeting.proto.TargetCornerProto;
 
 /**
  * Represents a point in an image at the corner of the minimum-area bounding rectangle, in pixels.
@@ -71,4 +72,5 @@ public class TargetCorner {
     }
 
     public static final APacketSerde serde = new APacketSerde();
+    public static final TargetCornerProto proto = new TargetCornerProto();
 }

--- a/photon-targeting/src/main/java/org/photonvision/targeting/proto/MultiTargetPNPResultProto.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/proto/MultiTargetPNPResultProto.java
@@ -18,8 +18,7 @@
 package org.photonvision.targeting.proto;
 
 import edu.wpi.first.util.protobuf.Protobuf;
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
 import org.photonvision.proto.Photon.ProtobufMultiTargetPNPResult;
 import org.photonvision.targeting.MultiTargetPNPResult;
 import org.photonvision.targeting.PNPResult;
@@ -50,10 +49,12 @@ public class MultiTargetPNPResultProto
 
     @Override
     public MultiTargetPNPResult unpack(ProtobufMultiTargetPNPResult msg) {
-        return new MultiTargetPNPResult(
-                PNPResult.proto.unpack(msg.getEstimatedPose()),
-                // TODO better way of doing this
-                Arrays.stream(msg.getFiducialIdsUsed().array()).boxed().collect(Collectors.toList()));
+        ArrayList<Integer> fidIdsUsed = new ArrayList<>(msg.getFiducialIdsUsed().length());
+        for (var packedFidId : msg.getFiducialIdsUsed()) {
+            fidIdsUsed.add(packedFidId);
+        }
+
+        return new MultiTargetPNPResult(PNPResult.proto.unpack(msg.getEstimatedPose()), fidIdsUsed);
     }
 
     @Override

--- a/photon-targeting/src/main/java/org/photonvision/targeting/proto/MultiTargetPNPResultProto.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/proto/MultiTargetPNPResultProto.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import edu.wpi.first.util.protobuf.Protobuf;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.photonvision.proto.Photon.ProtobufMultiTargetPNPResult;
+import org.photonvision.targeting.MultiTargetPNPResult;
+import org.photonvision.targeting.PNPResult;
+import us.hebi.quickbuf.Descriptors.Descriptor;
+import us.hebi.quickbuf.RepeatedInt;
+
+public class MultiTargetPNPResultProto
+        implements Protobuf<MultiTargetPNPResult, ProtobufMultiTargetPNPResult> {
+    @Override
+    public Class<MultiTargetPNPResult> getTypeClass() {
+        return MultiTargetPNPResult.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return ProtobufMultiTargetPNPResult.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+        return new Protobuf<?, ?>[] {PNPResult.proto};
+    }
+
+    @Override
+    public ProtobufMultiTargetPNPResult createMessage() {
+        return ProtobufMultiTargetPNPResult.newInstance();
+    }
+
+    @Override
+    public MultiTargetPNPResult unpack(ProtobufMultiTargetPNPResult msg) {
+        return new MultiTargetPNPResult(
+                PNPResult.proto.unpack(msg.getEstimatedPose()),
+                // TODO better way of doing this
+                Arrays.stream(msg.getFiducialIdsUsed().array()).boxed().collect(Collectors.toList()));
+    }
+
+    @Override
+    public void pack(ProtobufMultiTargetPNPResult msg, MultiTargetPNPResult value) {
+        PNPResult.proto.pack(msg.getMutableEstimatedPose(), value.estimatedPose);
+
+        RepeatedInt idsUsed = msg.getMutableFiducialIdsUsed().reserve(value.fiducialIDsUsed.size());
+        for (int i = 0; i < value.fiducialIDsUsed.size(); i++) {
+            idsUsed.add(value.fiducialIDsUsed.get(i));
+        }
+    }
+}

--- a/photon-targeting/src/main/java/org/photonvision/targeting/proto/PNPResultProto.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/proto/PNPResultProto.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import org.photonvision.proto.Photon.ProtobufPNPResult;
+import org.photonvision.targeting.PNPResult;
+import us.hebi.quickbuf.Descriptors.Descriptor;
+
+public class PNPResultProto implements Protobuf<PNPResult, ProtobufPNPResult> {
+    @Override
+    public Class<PNPResult> getTypeClass() {
+        return PNPResult.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return ProtobufPNPResult.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+        return new Protobuf<?, ?>[] {Transform3d.proto};
+    }
+
+    @Override
+    public ProtobufPNPResult createMessage() {
+        return ProtobufPNPResult.newInstance();
+    }
+
+    @Override
+    public PNPResult unpack(ProtobufPNPResult msg) {
+        if (!msg.getIsPresent()) {
+            return new PNPResult();
+        }
+
+        return new PNPResult(
+                Transform3d.proto.unpack(msg.getBest()),
+                Transform3d.proto.unpack(msg.getAlt()),
+                msg.getAmbiguity(),
+                msg.getBestReprojErr(),
+                msg.getAltReprojErr());
+    }
+
+    @Override
+    public void pack(ProtobufPNPResult msg, PNPResult value) {
+        Transform3d.proto.pack(msg.getMutableBest(), value.best);
+        Transform3d.proto.pack(msg.getMutableAlt(), value.alt);
+        msg.setAmbiguity(value.ambiguity)
+                .setBestReprojErr(value.bestReprojErr)
+                .setAltReprojErr(value.altReprojErr)
+                .setIsPresent(value.isPresent);
+    }
+}

--- a/photon-targeting/src/main/java/org/photonvision/targeting/proto/PhotonPipelineResultProto.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/proto/PhotonPipelineResultProto.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import edu.wpi.first.util.protobuf.Protobuf;
+import org.photonvision.proto.Photon.ProtobufPhotonPipelineResult;
+import org.photonvision.targeting.MultiTargetPNPResult;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+import us.hebi.quickbuf.Descriptors.Descriptor;
+
+public class PhotonPipelineResultProto
+        implements Protobuf<PhotonPipelineResult, ProtobufPhotonPipelineResult> {
+    @Override
+    public Class<PhotonPipelineResult> getTypeClass() {
+        return PhotonPipelineResult.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return ProtobufPhotonPipelineResult.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+        return new Protobuf<?, ?>[] {PhotonTrackedTarget.proto, MultiTargetPNPResult.proto};
+    }
+
+    @Override
+    public ProtobufPhotonPipelineResult createMessage() {
+        return ProtobufPhotonPipelineResult.newInstance();
+    }
+
+    @Override
+    public PhotonPipelineResult unpack(ProtobufPhotonPipelineResult msg) {
+        return new PhotonPipelineResult(
+                msg.getLatencyMs(),
+                PhotonTrackedTarget.proto.unpack(msg.getTargets()),
+                MultiTargetPNPResult.proto.unpack(msg.getMultiTargetResult()));
+    }
+
+    @Override
+    public void pack(ProtobufPhotonPipelineResult msg, PhotonPipelineResult value) {
+        PhotonTrackedTarget.proto.pack(msg.getMutableTargets(), value.getTargets());
+        MultiTargetPNPResult.proto.pack(msg.getMutableMultiTargetResult(), value.getMultiTagResult());
+
+        msg.setLatencyMs(value.getLatencyMillis());
+    }
+}

--- a/photon-targeting/src/main/java/org/photonvision/targeting/proto/PhotonTrackedTargetProto.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/proto/PhotonTrackedTargetProto.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import java.util.ArrayList;
+import java.util.List;
+import org.photonvision.proto.Photon.ProtobufPhotonTrackedTarget;
+import org.photonvision.targeting.PhotonTrackedTarget;
+import org.photonvision.targeting.TargetCorner;
+import us.hebi.quickbuf.Descriptors.Descriptor;
+import us.hebi.quickbuf.RepeatedMessage;
+
+public class PhotonTrackedTargetProto
+        implements Protobuf<PhotonTrackedTarget, ProtobufPhotonTrackedTarget> {
+    @Override
+    public Class<PhotonTrackedTarget> getTypeClass() {
+        return PhotonTrackedTarget.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return ProtobufPhotonTrackedTarget.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+        return new Protobuf<?, ?>[] {Transform3d.proto, TargetCorner.proto};
+    }
+
+    @Override
+    public ProtobufPhotonTrackedTarget createMessage() {
+        return ProtobufPhotonTrackedTarget.newInstance();
+    }
+
+    @Override
+    public PhotonTrackedTarget unpack(ProtobufPhotonTrackedTarget msg) {
+        return new PhotonTrackedTarget(
+                msg.getYaw(),
+                msg.getPitch(),
+                msg.getArea(),
+                msg.getSkew(),
+                msg.getFiducialId(),
+                Transform3d.proto.unpack(msg.getBestCameraToTarget()),
+                Transform3d.proto.unpack(msg.getAltCameraToTarget()),
+                msg.getPoseAmbiguity(),
+                TargetCorner.proto.unpack(msg.getMinAreaRectCorners()),
+                TargetCorner.proto.unpack(msg.getDetectedCorners()));
+    }
+
+    public List<PhotonTrackedTarget> unpack(RepeatedMessage<ProtobufPhotonTrackedTarget> msg) {
+        ArrayList<PhotonTrackedTarget> targets = new ArrayList<>(msg.length());
+        for (ProtobufPhotonTrackedTarget target : msg) {
+            targets.add(unpack(target));
+        }
+        return targets;
+    }
+
+    @Override
+    public void pack(ProtobufPhotonTrackedTarget msg, PhotonTrackedTarget value) {
+        msg.setYaw(value.getYaw())
+                .setPitch(value.getPitch())
+                .setSkew(value.getSkew())
+                .setArea(value.getArea())
+                .setFiducialId(value.getFiducialId())
+                .setPoseAmbiguity(value.getPoseAmbiguity());
+
+        Transform3d.proto.pack(msg.getMutableBestCameraToTarget(), value.getBestCameraToTarget());
+        Transform3d.proto.pack(msg.getMutableAltCameraToTarget(), value.getAlternateCameraToTarget());
+
+        TargetCorner.proto.pack(msg.getMutableMinAreaRectCorners(), value.getMinAreaRectCorners());
+        TargetCorner.proto.pack(msg.getMutableDetectedCorners(), value.getDetectedCorners());
+    }
+
+    public void pack(
+            RepeatedMessage<ProtobufPhotonTrackedTarget> msg, List<PhotonTrackedTarget> value) {
+        var targets = msg.reserve(value.size());
+        for (PhotonTrackedTarget trackedTarget : value) {
+            var target = targets.next();
+            pack(target, trackedTarget);
+        }
+    }
+}

--- a/photon-targeting/src/main/java/org/photonvision/targeting/proto/TargetCornerProto.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/proto/TargetCornerProto.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import edu.wpi.first.util.protobuf.Protobuf;
+import java.util.ArrayList;
+import java.util.List;
+import org.photonvision.proto.Photon.ProtobufTargetCorner;
+import org.photonvision.targeting.TargetCorner;
+import us.hebi.quickbuf.Descriptors.Descriptor;
+import us.hebi.quickbuf.RepeatedMessage;
+
+public class TargetCornerProto implements Protobuf<TargetCorner, ProtobufTargetCorner> {
+    @Override
+    public Class<TargetCorner> getTypeClass() {
+        return TargetCorner.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return ProtobufTargetCorner.getDescriptor();
+    }
+
+    @Override
+    public ProtobufTargetCorner createMessage() {
+        return ProtobufTargetCorner.newInstance();
+    }
+
+    @Override
+    public TargetCorner unpack(ProtobufTargetCorner msg) {
+        return new TargetCorner(msg.getX(), msg.getY());
+    }
+
+    public List<TargetCorner> unpack(RepeatedMessage<ProtobufTargetCorner> msg) {
+        ArrayList<TargetCorner> corners = new ArrayList<>(msg.length());
+        for (ProtobufTargetCorner corner : msg) {
+            corners.add(unpack(corner));
+        }
+        return corners;
+    }
+
+    @Override
+    public void pack(ProtobufTargetCorner msg, TargetCorner value) {
+        msg.setX(value.x).setY(value.y);
+    }
+
+    public void pack(RepeatedMessage<ProtobufTargetCorner> msg, List<TargetCorner> value) {
+        var corners = msg.reserve(value.size());
+        for (TargetCorner targetCorner : value) {
+            var corner = corners.next();
+            pack(corner, targetCorner);
+        }
+    }
+}

--- a/photon-targeting/src/main/native/cpp/photon/targeting/PhotonPipelineResult.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/PhotonPipelineResult.cpp
@@ -19,12 +19,12 @@
 
 namespace photon {
 PhotonPipelineResult::PhotonPipelineResult(
-    units::second_t latency, std::span<const PhotonTrackedTarget> targets)
+    units::millisecond_t latency, std::span<const PhotonTrackedTarget> targets)
     : latency(latency),
       targets(targets.data(), targets.data() + targets.size()) {}
 
 PhotonPipelineResult::PhotonPipelineResult(
-    units::second_t latency, std::span<const PhotonTrackedTarget> targets,
+    units::millisecond_t latency, std::span<const PhotonTrackedTarget> targets,
     MultiTargetPNPResult multitagResult)
     : latency(latency),
       targets(targets.data(), targets.data() + targets.size()),
@@ -37,7 +37,7 @@ bool PhotonPipelineResult::operator==(const PhotonPipelineResult& other) const {
 
 Packet& operator<<(Packet& packet, const PhotonPipelineResult& result) {
   // Encode latency and number of targets.
-  packet << result.latency.value() * 1000 << result.multitagResult
+  packet << result.latency.value() << result.multitagResult
          << static_cast<int8_t>(result.targets.size());
 
   // Encode the information of each target.
@@ -52,7 +52,7 @@ Packet& operator>>(Packet& packet, PhotonPipelineResult& result) {
   double latencyMillis = 0;
   int8_t targetCount = 0;
   packet >> latencyMillis >> result.multitagResult >> targetCount;
-  result.latency = units::second_t(latencyMillis / 1000.0);
+  result.latency = units::millisecond_t(latencyMillis);
 
   result.targets.clear();
 

--- a/photon-targeting/src/main/native/cpp/photon/targeting/proto/MultiTargetPNPResultProto.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/proto/MultiTargetPNPResultProto.cpp
@@ -18,6 +18,7 @@
 #include "photon/targeting/proto/MultiTargetPNPResultProto.h"
 
 #include "photon.pb.h"
+#include "photon/targeting/proto/PNPResultProto.h"
 
 google::protobuf::Message* wpi::Protobuf<photon::MultiTargetPNPResult>::New(
     google::protobuf::Arena* arena) {

--- a/photon-targeting/src/main/native/cpp/photon/targeting/proto/MultiTargetPNPResultProto.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/proto/MultiTargetPNPResultProto.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "photon/targeting/proto/MultiTargetPNPResultProto.h"
+
+#include "photon.pb.h"
+
+google::protobuf::Message* wpi::Protobuf<photon::MultiTargetPNPResult>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      photonvision::proto::ProtobufMultiTargetPNPResult>(arena);
+}
+
+photon::MultiTargetPNPResult
+wpi::Protobuf<photon::MultiTargetPNPResult>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m =
+      static_cast<const photonvision::proto::ProtobufMultiTargetPNPResult*>(
+          &msg);
+
+  wpi::SmallVector<int16_t, 32> fiducialIdsUsed;
+  for (int i = 0; i < m->fiducial_ids_used_size(); i++) {
+    fiducialIdsUsed.push_back(m->fiducial_ids_used(i));
+  }
+
+  return photon::MultiTargetPNPResult{
+      wpi::UnpackProtobuf<photon::PNPResult>(m->estimated_pose()),
+      fiducialIdsUsed};
+}
+
+void wpi::Protobuf<photon::MultiTargetPNPResult>::Pack(
+    google::protobuf::Message* msg, const photon::MultiTargetPNPResult& value) {
+  auto m = static_cast<photonvision::proto::ProtobufMultiTargetPNPResult*>(msg);
+
+  wpi::PackProtobuf(m->mutable_estimated_pose(), value.result);
+
+  m->clear_fiducial_ids_used();
+  for (const auto& t : value.fiducialIdsUsed) {
+    m->add_fiducial_ids_used(t);
+  }
+}

--- a/photon-targeting/src/main/native/cpp/photon/targeting/proto/PNPResultProto.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/proto/PNPResultProto.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "photon/targeting/proto/PNPResultProto.h"
+
+#include "photon.pb.h"
+
+google::protobuf::Message* wpi::Protobuf<photon::PNPResult>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      photonvision::proto::ProtobufPNPResult>(arena);
+}
+
+photon::PNPResult wpi::Protobuf<photon::PNPResult>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const photonvision::proto::ProtobufPNPResult*>(&msg);
+
+  if (!m->is_present()) {
+    return photon::PNPResult();
+  }
+
+  return photon::PNPResult{wpi::UnpackProtobuf<frc::Transform3d>(m->best()),
+                           m->best_reproj_err(),
+                           wpi::UnpackProtobuf<frc::Transform3d>(m->alt()),
+                           m->alt_reproj_err(), m->ambiguity()};
+}
+
+void wpi::Protobuf<photon::PNPResult>::Pack(google::protobuf::Message* msg,
+                                            const photon::PNPResult& value) {
+  auto m = static_cast<photonvision::proto::ProtobufPNPResult*>(msg);
+
+  m->set_is_present(value.isPresent);
+  wpi::PackProtobuf(m->mutable_best(), value.best);
+  m->set_best_reproj_err(value.bestReprojErr);
+  wpi::PackProtobuf(m->mutable_alt(), value.alt);
+  m->set_alt_reproj_err(value.altReprojErr);
+  m->set_ambiguity(value.ambiguity);
+}

--- a/photon-targeting/src/main/native/cpp/photon/targeting/proto/PNPResultProto.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/proto/PNPResultProto.cpp
@@ -33,10 +33,12 @@ photon::PNPResult wpi::Protobuf<photon::PNPResult>::Unpack(
     return photon::PNPResult();
   }
 
-  return photon::PNPResult{wpi::UnpackProtobuf<frc::Transform3d>(m->best()),
+  return photon::PNPResult{true,
+                           wpi::UnpackProtobuf<frc::Transform3d>(m->best()),
                            m->best_reproj_err(),
                            wpi::UnpackProtobuf<frc::Transform3d>(m->alt()),
-                           m->alt_reproj_err(), m->ambiguity()};
+                           m->alt_reproj_err(),
+                           m->ambiguity()};
 }
 
 void wpi::Protobuf<photon::PNPResult>::Pack(google::protobuf::Message* msg,

--- a/photon-targeting/src/main/native/cpp/photon/targeting/proto/PhotonPipelineResultProto.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/proto/PhotonPipelineResultProto.cpp
@@ -18,6 +18,8 @@
 #include "photon/targeting/proto/PhotonPipelineResultProto.h"
 
 #include "photon.pb.h"
+#include "photon/targeting/proto/MultiTargetPNPResultProto.h"
+#include "photon/targeting/proto/PhotonTrackedTargetProto.h"
 
 google::protobuf::Message* wpi::Protobuf<photon::PhotonPipelineResult>::New(
     google::protobuf::Arena* arena) {

--- a/photon-targeting/src/main/native/cpp/photon/targeting/proto/PhotonPipelineResultProto.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/proto/PhotonPipelineResultProto.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "photon/targeting/proto/PhotonPipelineResultProto.h"
+
+#include "photon.pb.h"
+
+google::protobuf::Message* wpi::Protobuf<photon::PhotonPipelineResult>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      photonvision::proto::ProtobufPhotonPipelineResult>(arena);
+}
+
+photon::PhotonPipelineResult
+wpi::Protobuf<photon::PhotonPipelineResult>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m =
+      static_cast<const photonvision::proto::ProtobufPhotonPipelineResult*>(
+          &msg);
+
+  std::vector<photon::PhotonTrackedTarget> targets;
+  targets.reserve(m->targets_size());
+  for (const auto& t : m->targets()) {
+    targets.emplace_back(wpi::UnpackProtobuf<photon::PhotonTrackedTarget>(t));
+  }
+
+  return photon::PhotonPipelineResult{
+      units::millisecond_t{m->latency_ms()}, targets,
+      wpi::UnpackProtobuf<photon::MultiTargetPNPResult>(
+          m->multi_target_result())};
+}
+
+void wpi::Protobuf<photon::PhotonPipelineResult>::Pack(
+    google::protobuf::Message* msg, const photon::PhotonPipelineResult& value) {
+  auto m = static_cast<photonvision::proto::ProtobufPhotonPipelineResult*>(msg);
+
+  m->set_latency_ms(value.latency.value());
+
+  m->clear_targets();
+  for (const auto& t : value.GetTargets()) {
+    wpi::PackProtobuf(m->add_targets(), t);
+  }
+
+  wpi::PackProtobuf(m->mutable_multi_target_result(), value.multitagResult);
+}

--- a/photon-targeting/src/main/native/cpp/photon/targeting/proto/PhotonTrackedTargetProto.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/proto/PhotonTrackedTargetProto.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "photon/targeting/proto/PhotonTrackedTargetProto.h"
+
+#include "photon.pb.h"
+
+google::protobuf::Message* wpi::Protobuf<photon::PhotonTrackedTarget>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      photonvision::proto::ProtobufPhotonTrackedTarget>(arena);
+}
+
+photon::PhotonTrackedTarget wpi::Protobuf<photon::PhotonTrackedTarget>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const photonvision::proto::ProtobufPhotonTrackedTarget*>(
+      &msg);
+
+  wpi::SmallVector<std::pair<double, double>, 4> minAreaRectCorners;
+  for (const auto& t : m->min_area_rect_corners()) {
+    minAreaRectCorners.emplace_back(t.x(), t.y());
+  }
+
+  std::vector<std::pair<double, double>> detectedCorners;
+  detectedCorners.reserve(m->detected_corners_size());
+  for (const auto& t : m->detected_corners()) {
+    detectedCorners.emplace_back(t.x(), t.y());
+  }
+
+  return photon::PhotonTrackedTarget{
+      m->yaw(),
+      m->pitch(),
+      m->area(),
+      m->skew(),
+      m->fiducial_id(),
+      wpi::UnpackProtobuf<frc::Transform3d>(m->best_camera_to_target()),
+      wpi::UnpackProtobuf<frc::Transform3d>(m->alt_camera_to_target()),
+      m->pose_ambiguity(),
+      minAreaRectCorners,
+      detectedCorners};
+}
+
+void wpi::Protobuf<photon::PhotonTrackedTarget>::Pack(
+    google::protobuf::Message* msg, const photon::PhotonTrackedTarget& value) {
+  auto m = static_cast<photonvision::proto::ProtobufPhotonTrackedTarget*>(msg);
+
+  m->set_yaw(value.yaw);
+  m->set_pitch(value.pitch);
+  m->set_area(value.area);
+  m->set_skew(value.skew);
+  m->set_fiducial_id(value.fiducialId);
+  wpi::PackProtobuf(m->mutable_best_camera_to_target(),
+                    value.bestCameraToTarget);
+  wpi::PackProtobuf(m->mutable_alt_camera_to_target(), value.altCameraToTarget);
+  m->set_pose_ambiguity(value.poseAmbiguity);
+
+  m->clear_min_area_rect_corners();
+  for (const auto& t : value.GetMinAreaRectCorners()) {
+    auto* corner = m->add_min_area_rect_corners();
+    corner->set_x(t.first);
+    corner->set_y(t.second);
+  }
+
+  m->clear_detected_corners();
+  for (const auto& t : value.GetDetectedCorners()) {
+    auto* corner = m->add_detected_corners();
+    corner->set_x(t.first);
+    corner->set_y(t.second);
+  }
+}

--- a/photon-targeting/src/main/native/include/geometry3d.pb.h
+++ b/photon-targeting/src/main/native/include/geometry3d.pb.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+// So wpilib publishes protbufs here at wpimath/protobuf. but generated code
+// assumes that the protobuf includes are on your include path. So we need this
+// stupid shim
+#include "wpimath/protobuf/geometry3d.pb.h"

--- a/photon-targeting/src/main/native/include/photon/targeting/PhotonPipelineResult.h
+++ b/photon-targeting/src/main/native/include/photon/targeting/PhotonPipelineResult.h
@@ -44,7 +44,7 @@ class PhotonPipelineResult {
    * @param latency The latency in the pipeline.
    * @param targets The list of targets identified by the pipeline.
    */
-  PhotonPipelineResult(units::second_t latency,
+  PhotonPipelineResult(units::millisecond_t latency,
                        std::span<const PhotonTrackedTarget> targets);
 
   /**
@@ -53,7 +53,7 @@ class PhotonPipelineResult {
    * @param targets The list of targets identified by the pipeline.
    * @param multitagResult The multitarget result
    */
-  PhotonPipelineResult(units::second_t latency,
+  PhotonPipelineResult(units::millisecond_t latency,
                        std::span<const PhotonTrackedTarget> targets,
                        MultiTargetPNPResult multitagResult);
 
@@ -81,7 +81,7 @@ class PhotonPipelineResult {
    * Returns the latency in the pipeline.
    * @return The latency in the pipeline.
    */
-  units::second_t GetLatency() const { return latency; }
+  units::millisecond_t GetLatency() const { return latency; }
 
   /**
    * Returns the estimated time the frame was taken,
@@ -125,7 +125,7 @@ class PhotonPipelineResult {
   friend Packet& operator<<(Packet& packet, const PhotonPipelineResult& result);
   friend Packet& operator>>(Packet& packet, PhotonPipelineResult& result);
 
-  units::second_t latency = 0_s;
+  units::millisecond_t latency = 0_s;
   units::second_t timestamp = -1_s;
   wpi::SmallVector<PhotonTrackedTarget, 10> targets;
   MultiTargetPNPResult multitagResult;

--- a/photon-targeting/src/main/native/include/photon/targeting/proto/MultiTargetPNPResultProto.h
+++ b/photon-targeting/src/main/native/include/photon/targeting/proto/MultiTargetPNPResultProto.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wpi/protobuf/Protobuf.h>
+
+#include "photon/targeting/MultiTargetPNPResult.h"
+
+template <>
+struct wpi::Protobuf<photon::MultiTargetPNPResult> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static photon::MultiTargetPNPResult Unpack(
+      const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const photon::MultiTargetPNPResult& value);
+};

--- a/photon-targeting/src/main/native/include/photon/targeting/proto/PNPResultProto.h
+++ b/photon-targeting/src/main/native/include/photon/targeting/proto/PNPResultProto.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wpi/protobuf/Protobuf.h>
+
+#include "photon/targeting/PNPResult.h"
+
+template <>
+struct wpi::Protobuf<photon::PNPResult> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static photon::PNPResult Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const photon::PNPResult& value);
+};

--- a/photon-targeting/src/main/native/include/photon/targeting/proto/PhotonPipelineResultProto.h
+++ b/photon-targeting/src/main/native/include/photon/targeting/proto/PhotonPipelineResultProto.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wpi/protobuf/Protobuf.h>
+
+#include "photon/targeting/PhotonPipelineResult.h"
+
+template <>
+struct wpi::Protobuf<photon::PhotonPipelineResult> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static photon::PhotonPipelineResult Unpack(
+      const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const photon::PhotonPipelineResult& value);
+};

--- a/photon-targeting/src/main/native/include/photon/targeting/proto/PhotonTrackedTargetProto.h
+++ b/photon-targeting/src/main/native/include/photon/targeting/proto/PhotonTrackedTargetProto.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <wpi/protobuf/Protobuf.h>
+
+#include "photon/targeting/PhotonTrackedTarget.h"
+
+template <>
+struct wpi::Protobuf<photon::PhotonTrackedTarget> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static photon::PhotonTrackedTarget Unpack(
+      const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const photon::PhotonTrackedTarget& value);
+};

--- a/photon-targeting/src/main/proto/photon.proto
+++ b/photon-targeting/src/main/proto/photon.proto
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+syntax = "proto3";
+
+package photonvision.proto;
+
+import "geometry3d.proto";
+
+option java_package = "org.photonvision.proto";
+
+message ProtobufTargetCorner {
+  double x = 1;
+  double y = 2;
+}
+
+message ProtobufPNPResult {
+  bool is_present = 1;
+  wpi.proto.ProtobufTransform3d best = 2;
+  double best_reproj_err = 3;
+  optional wpi.proto.ProtobufTransform3d alt = 4;
+  optional double alt_reproj_err = 5;
+  double ambiguity = 6;
+}
+
+message ProtobufMultiTargetPNPResult {
+  ProtobufPNPResult estimated_pose = 1;
+  repeated int32 fiducial_ids_used = 2;
+}
+
+message ProtobufPhotonTrackedTarget {
+  double yaw = 1;
+  double pitch = 2;
+  double area = 3;
+  double skew = 4;
+  int32 fiducial_id = 5;
+  wpi.proto.ProtobufTransform3d best_camera_to_target = 6;
+  wpi.proto.ProtobufTransform3d alt_camera_to_target = 7;
+  double pose_ambiguity = 8;
+  repeated ProtobufTargetCorner min_area_rect_corners = 9;
+  repeated ProtobufTargetCorner detected_corners = 10;
+}
+
+message ProtobufPhotonPipelineResult {
+  double latency_ms = 1;
+
+  repeated ProtobufPhotonTrackedTarget targets = 2;
+  ProtobufMultiTargetPNPResult multi_target_result = 3;
+}

--- a/photon-targeting/src/test/java/org/photonvision/targeting/proto/MultiTargetPNPResultProtoTest.java
+++ b/photon-targeting/src/test/java/org/photonvision/targeting/proto/MultiTargetPNPResultProtoTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.photonvision.targeting.MultiTargetPNPResult;
+import org.photonvision.targeting.PNPResult;
+
+public class MultiTargetPNPResultProtoTest {
+    @Test
+    public void protobufTest() {
+        var result = new MultiTargetPNPResult();
+        var serializedResult = MultiTargetPNPResult.proto.createMessage();
+        MultiTargetPNPResult.proto.pack(serializedResult, result);
+        var unpackedResult = MultiTargetPNPResult.proto.unpack(serializedResult);
+        assertEquals(result, unpackedResult);
+
+        result =
+                new MultiTargetPNPResult(
+                        new PNPResult(
+                                new Transform3d(new Translation3d(1, 2, 3), new Rotation3d(1, 2, 3)), 0.1),
+                        List.of(1, 2, 3));
+        serializedResult = MultiTargetPNPResult.proto.createMessage();
+        MultiTargetPNPResult.proto.pack(serializedResult, result);
+        unpackedResult = MultiTargetPNPResult.proto.unpack(serializedResult);
+        assertEquals(result, unpackedResult);
+    }
+}

--- a/photon-targeting/src/test/java/org/photonvision/targeting/proto/PNPResultProtoTest.java
+++ b/photon-targeting/src/test/java/org/photonvision/targeting/proto/PNPResultProtoTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import org.junit.jupiter.api.Test;
+import org.photonvision.targeting.PNPResult;
+
+public class PNPResultProtoTest {
+    @Test
+    public void protobufTest() {
+        var pnpRes = new PNPResult();
+        var serializedPNPRes = PNPResult.proto.createMessage();
+        PNPResult.proto.pack(serializedPNPRes, pnpRes);
+        var unpackedPNPRes = PNPResult.proto.unpack(serializedPNPRes);
+        assertEquals(pnpRes, unpackedPNPRes);
+
+        pnpRes = new PNPResult(new Transform3d(1, 2, 3, new Rotation3d(1, 2, 3)), 0.1);
+        serializedPNPRes = PNPResult.proto.createMessage();
+        PNPResult.proto.pack(serializedPNPRes, pnpRes);
+        unpackedPNPRes = PNPResult.proto.unpack(serializedPNPRes);
+        assertEquals(pnpRes, unpackedPNPRes);
+    }
+}

--- a/photon-targeting/src/test/java/org/photonvision/targeting/proto/PhotonPipelineResultProtoTest.java
+++ b/photon-targeting/src/test/java/org/photonvision/targeting/proto/PhotonPipelineResultProtoTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.photonvision.targeting.*;
+
+public class PhotonPipelineResultProtoTest {
+    @Test
+    public void protobufTest() {
+        // Empty Result
+        var result = new PhotonPipelineResult();
+        var serializedResult = PhotonPipelineResult.proto.createMessage();
+        PhotonPipelineResult.proto.pack(serializedResult, result);
+        var unpackedResult = PhotonPipelineResult.proto.unpack(serializedResult);
+        assertEquals(result, unpackedResult);
+
+        // non multitag result
+        result =
+                new PhotonPipelineResult(
+                        2,
+                        List.of(
+                                new PhotonTrackedTarget(
+                                        3.0,
+                                        -4.0,
+                                        9.0,
+                                        4.0,
+                                        2,
+                                        new Transform3d(new Translation3d(1, 2, 3), new Rotation3d(1, 2, 3)),
+                                        new Transform3d(new Translation3d(1, 2, 3), new Rotation3d(1, 2, 3)),
+                                        0.25,
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8)),
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8))),
+                                new PhotonTrackedTarget(
+                                        3.0,
+                                        -4.0,
+                                        9.1,
+                                        6.7,
+                                        3,
+                                        new Transform3d(new Translation3d(4, 2, 3), new Rotation3d(1, 5, 3)),
+                                        new Transform3d(new Translation3d(4, 2, 3), new Rotation3d(1, 5, 3)),
+                                        0.25,
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8)),
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8)))));
+        serializedResult = PhotonPipelineResult.proto.createMessage();
+        PhotonPipelineResult.proto.pack(serializedResult, result);
+        unpackedResult = PhotonPipelineResult.proto.unpack(serializedResult);
+        assertEquals(result, unpackedResult);
+
+        // multitag result
+        result =
+                new PhotonPipelineResult(
+                        2,
+                        List.of(
+                                new PhotonTrackedTarget(
+                                        3.0,
+                                        -4.0,
+                                        9.0,
+                                        4.0,
+                                        2,
+                                        new Transform3d(new Translation3d(1, 2, 3), new Rotation3d(1, 2, 3)),
+                                        new Transform3d(new Translation3d(1, 2, 3), new Rotation3d(1, 2, 3)),
+                                        0.25,
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8)),
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8))),
+                                new PhotonTrackedTarget(
+                                        3.0,
+                                        -4.0,
+                                        9.1,
+                                        6.7,
+                                        3,
+                                        new Transform3d(new Translation3d(4, 2, 3), new Rotation3d(1, 5, 3)),
+                                        new Transform3d(new Translation3d(4, 2, 3), new Rotation3d(1, 5, 3)),
+                                        0.25,
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8)),
+                                        List.of(
+                                                new TargetCorner(1, 2),
+                                                new TargetCorner(3, 4),
+                                                new TargetCorner(5, 6),
+                                                new TargetCorner(7, 8)))),
+                        new MultiTargetPNPResult(
+                                new PNPResult(
+                                        new Transform3d(new Translation3d(1, 2, 3), new Rotation3d(1, 2, 3)), 0.1),
+                                List.of(1, 2, 3)));
+        serializedResult = PhotonPipelineResult.proto.createMessage();
+        PhotonPipelineResult.proto.pack(serializedResult, result);
+        unpackedResult = PhotonPipelineResult.proto.unpack(serializedResult);
+        assertEquals(result, unpackedResult);
+    }
+}

--- a/photon-targeting/src/test/java/org/photonvision/targeting/proto/PhotonTrackedTargetProtoTest.java
+++ b/photon-targeting/src/test/java/org/photonvision/targeting/proto/PhotonTrackedTargetProtoTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.photonvision.proto.Photon.ProtobufPhotonTrackedTarget;
+import org.photonvision.targeting.PhotonTrackedTarget;
+import org.photonvision.targeting.TargetCorner;
+import us.hebi.quickbuf.RepeatedMessage;
+
+public class PhotonTrackedTargetProtoTest {
+    @Test
+    public void protobufTest() {
+        var target =
+                new PhotonTrackedTarget(
+                        3.0,
+                        4.0,
+                        9.0,
+                        -5.0,
+                        -1,
+                        new Transform3d(new Translation3d(), new Rotation3d()),
+                        new Transform3d(new Translation3d(), new Rotation3d()),
+                        0.25,
+                        List.of(
+                                new TargetCorner(1, 2),
+                                new TargetCorner(3, 4),
+                                new TargetCorner(5, 6),
+                                new TargetCorner(7, 8)),
+                        List.of(
+                                new TargetCorner(1, 2),
+                                new TargetCorner(3, 4),
+                                new TargetCorner(5, 6),
+                                new TargetCorner(7, 8)));
+        var serializedTarget = PhotonTrackedTarget.proto.createMessage();
+        PhotonTrackedTarget.proto.pack(serializedTarget, target);
+        var unpackedTarget = PhotonTrackedTarget.proto.unpack(serializedTarget);
+        assertEquals(target, unpackedTarget);
+    }
+
+    @Test
+    public void protobufListTest() {
+        List<PhotonTrackedTarget> targets = List.of();
+        var serializedTargets =
+                RepeatedMessage.newEmptyInstance(ProtobufPhotonTrackedTarget.getFactory());
+        PhotonTrackedTarget.proto.pack(serializedTargets, targets);
+        var unpackedTargets = PhotonTrackedTarget.proto.unpack(serializedTargets);
+        assertEquals(targets, unpackedTargets);
+
+        targets =
+                List.of(
+                        new PhotonTrackedTarget(
+                                3.0,
+                                4.0,
+                                9.0,
+                                -5.0,
+                                -1,
+                                new Transform3d(new Translation3d(), new Rotation3d()),
+                                new Transform3d(new Translation3d(), new Rotation3d()),
+                                0.25,
+                                List.of(
+                                        new TargetCorner(1, 2),
+                                        new TargetCorner(3, 4),
+                                        new TargetCorner(5, 6),
+                                        new TargetCorner(7, 8)),
+                                List.of(
+                                        new TargetCorner(1, 2),
+                                        new TargetCorner(3, 4),
+                                        new TargetCorner(5, 6),
+                                        new TargetCorner(7, 8))),
+                        new PhotonTrackedTarget(
+                                7.0,
+                                2.0,
+                                1.0,
+                                -9.0,
+                                -1,
+                                new Transform3d(new Translation3d(), new Rotation3d()),
+                                new Transform3d(new Translation3d(), new Rotation3d()),
+                                0.25,
+                                List.of(
+                                        new TargetCorner(1, 2),
+                                        new TargetCorner(3, 4),
+                                        new TargetCorner(5, 6),
+                                        new TargetCorner(7, 8)),
+                                List.of(
+                                        new TargetCorner(1, 2),
+                                        new TargetCorner(3, 4),
+                                        new TargetCorner(5, 6),
+                                        new TargetCorner(7, 8))));
+        serializedTargets = RepeatedMessage.newEmptyInstance(ProtobufPhotonTrackedTarget.getFactory());
+        PhotonTrackedTarget.proto.pack(serializedTargets, targets);
+        unpackedTargets = PhotonTrackedTarget.proto.unpack(serializedTargets);
+        assertEquals(targets, unpackedTargets);
+    }
+}

--- a/photon-targeting/src/test/java/org/photonvision/targeting/proto/TargetCornerProtoTest.java
+++ b/photon-targeting/src/test/java/org/photonvision/targeting/proto/TargetCornerProtoTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.targeting.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.photonvision.targeting.TargetCorner;
+
+public class TargetCornerProtoTest {
+    @Test
+    public void protobufTest() {
+        var corner = new TargetCorner(0, 1);
+        var serializedCorner = TargetCorner.proto.createMessage();
+        TargetCorner.proto.pack(serializedCorner, corner);
+        var unpackedCorner = TargetCorner.proto.unpack(serializedCorner);
+        assertEquals(corner, unpackedCorner);
+    }
+}

--- a/photon-targeting/src/test/native/cpp/targeting/proto/MultiTargetPNPResultProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/MultiTargetPNPResultProtoTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gtest/gtest.h"
+#include "photon.pb.h"
+#include "photon/targeting/MultiTargetPNPResult.h"
+
+TEST(MultiTargetPNPResultTest, Roundtrip) {
+  photon::MultiTargetPNPResult result;
+
+  google::protobuf::Arena arena;
+  google::protobuf::Message* proto =
+      wpi::Protobuf<photon::MultiTargetPNPResult>::New(&arena);
+  wpi::Protobuf<photon::MultiTargetPNPResult>::Pack(proto, result);
+
+  photon::MultiTargetPNPResult unpacked_data =
+      wpi::Protobuf<photon::MultiTargetPNPResult>::Unpack(*proto);
+
+  EXPECT_EQ(result, unpacked_data);
+
+  photon::PNPResult pnpRes{
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      0.1,
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      0.1, 0};
+
+  photon::MultiTargetPNPResult result1{pnpRes, {1, 2, 3, 4}};
+
+  proto = wpi::Protobuf<photon::MultiTargetPNPResult>::New(&arena);
+  wpi::Protobuf<photon::MultiTargetPNPResult>::Pack(proto, result1);
+
+  photon::MultiTargetPNPResult unpacked_data1 =
+      wpi::Protobuf<photon::MultiTargetPNPResult>::Unpack(*proto);
+
+  EXPECT_EQ(result1, unpacked_data1);
+}

--- a/photon-targeting/src/test/native/cpp/targeting/proto/MultiTargetPNPResultProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/MultiTargetPNPResultProtoTest.cpp
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "photon.pb.h"
 #include "photon/targeting/MultiTargetPNPResult.h"
+#include "photon/targeting/proto/MultiTargetPNPResultProto.h"
 
 TEST(MultiTargetPNPResultTest, Roundtrip) {
   photon::MultiTargetPNPResult result;
@@ -33,12 +34,14 @@ TEST(MultiTargetPNPResultTest, Roundtrip) {
   EXPECT_EQ(result, unpacked_data);
 
   photon::PNPResult pnpRes{
+      true,
       frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
                        frc::Rotation3d(1_rad, 2_rad, 3_rad)),
       0.1,
       frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
                        frc::Rotation3d(1_rad, 2_rad, 3_rad)),
-      0.1, 0};
+      0.1,
+      0};
 
   photon::MultiTargetPNPResult result1{pnpRes, {1, 2, 3, 4}};
 

--- a/photon-targeting/src/test/native/cpp/targeting/proto/PNPResultProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/PNPResultProtoTest.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gtest/gtest.h"
+#include "photon.pb.h"
+#include "photon/targeting/PNPResult.h"
+
+TEST(PNPResultTest, Roundtrip) {
+  photon::PNPResult result;
+
+  google::protobuf::Arena arena;
+  google::protobuf::Message* proto =
+      wpi::Protobuf<photon::PNPResult>::New(&arena);
+  wpi::Protobuf<photon::PNPResult>::Pack(proto, result);
+
+  photon::PNPResult unpacked_data =
+      wpi::Protobuf<photon::PNPResult>::Unpack(*proto);
+
+  EXPECT_EQ(result, unpacked_data);
+
+  photon::PNPResult result1{
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      0.1,
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      0.1, 0};
+
+  proto = wpi::Protobuf<photon::PNPResult>::New(&arena);
+  wpi::Protobuf<photon::PNPResult>::Pack(proto, result1);
+
+  photon::PNPResult unpacked_data2 =
+      wpi::Protobuf<photon::PNPResult>::Unpack(*proto);
+
+  EXPECT_EQ(result1, unpacked_data2);
+}

--- a/photon-targeting/src/test/native/cpp/targeting/proto/PNPResultProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/PNPResultProtoTest.cpp
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "photon.pb.h"
 #include "photon/targeting/PNPResult.h"
+#include "photon/targeting/proto/PNPResultProto.h"
 
 TEST(PNPResultTest, Roundtrip) {
   photon::PNPResult result;
@@ -33,12 +34,14 @@ TEST(PNPResultTest, Roundtrip) {
   EXPECT_EQ(result, unpacked_data);
 
   photon::PNPResult result1{
+      true,
       frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
                        frc::Rotation3d(1_rad, 2_rad, 3_rad)),
       0.1,
       frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
                        frc::Rotation3d(1_rad, 2_rad, 3_rad)),
-      0.1, 0};
+      0.1,
+      0};
 
   proto = wpi::Protobuf<photon::PNPResult>::New(&arena);
   wpi::Protobuf<photon::PNPResult>::Pack(proto, result1);

--- a/photon-targeting/src/test/native/cpp/targeting/proto/PhotonPipelineResultProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/PhotonPipelineResultProtoTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gtest/gtest.h"
+#include "photon.pb.h"
+#include "photon/targeting/PhotonPipelineResult.h"
+
+TEST(PhotonPipelineResultTest, Roundtrip) {
+  photon::PhotonPipelineResult result{12_ms, {}};
+
+  google::protobuf::Arena arena;
+  google::protobuf::Message* proto =
+      wpi::Protobuf<photon::PhotonPipelineResult>::New(&arena);
+  wpi::Protobuf<photon::PhotonPipelineResult>::Pack(proto, result);
+
+  photon::PhotonPipelineResult unpacked_data =
+      wpi::Protobuf<photon::PhotonPipelineResult>::Unpack(*proto);
+
+  EXPECT_EQ(result, unpacked_data);
+
+  wpi::SmallVector<photon::PhotonTrackedTarget, 2> targets{
+      photon::PhotonTrackedTarget{
+          3.0,
+          -4.0,
+          9.0,
+          4.0,
+          1,
+          frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                           frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+          frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                           frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+          -1,
+          {std::pair{1, 2}, std::pair{3, 4}, std::pair{5, 6}, std::pair{7, 8}},
+          {std::pair{1, 2}, std::pair{3, 4}, std::pair{5, 6}, std::pair{7, 8}}},
+      photon::PhotonTrackedTarget{
+          3.0,
+          -4.0,
+          9.1,
+          6.7,
+          -1,
+          frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                           frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+          frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                           frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+          -1,
+          {std::pair{1, 2}, std::pair{3, 4}, std::pair{5, 6}, std::pair{7, 8}},
+          {std::pair{1, 2}, std::pair{3, 4}, std::pair{5, 6},
+           std::pair{7, 8}}}};
+
+  photon::PhotonPipelineResult result2{12_ms, targets};
+
+  proto = wpi::Protobuf<photon::PhotonPipelineResult>::New(&arena);
+  wpi::Protobuf<photon::PhotonPipelineResult>::Pack(proto, result2);
+
+  photon::PhotonPipelineResult unpacked_data2 =
+      wpi::Protobuf<photon::PhotonPipelineResult>::Unpack(*proto);
+
+  EXPECT_EQ(result2, unpacked_data2);
+
+  photon::PNPResult pnpRes{
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      0.1,
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      0.1, 0};
+
+  photon::MultiTargetPNPResult multitagRes{pnpRes, {1, 2, 3, 4}};
+
+  photon::PhotonPipelineResult result3{12_ms, targets, multitagRes};
+
+  proto = wpi::Protobuf<photon::PhotonPipelineResult>::New(&arena);
+  wpi::Protobuf<photon::PhotonPipelineResult>::Pack(proto, result3);
+
+  photon::PhotonPipelineResult unpacked_data3 =
+      wpi::Protobuf<photon::PhotonPipelineResult>::Unpack(*proto);
+
+  EXPECT_EQ(result3, unpacked_data3);
+}

--- a/photon-targeting/src/test/native/cpp/targeting/proto/PhotonPipelineResultProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/PhotonPipelineResultProtoTest.cpp
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "photon.pb.h"
 #include "photon/targeting/PhotonPipelineResult.h"
+#include "photon/targeting/proto/PhotonPipelineResultProto.h"
 
 TEST(PhotonPipelineResultTest, Roundtrip) {
   photon::PhotonPipelineResult result{12_ms, {}};
@@ -72,12 +73,14 @@ TEST(PhotonPipelineResultTest, Roundtrip) {
   EXPECT_EQ(result2, unpacked_data2);
 
   photon::PNPResult pnpRes{
+      true,
       frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
                        frc::Rotation3d(1_rad, 2_rad, 3_rad)),
       0.1,
       frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
                        frc::Rotation3d(1_rad, 2_rad, 3_rad)),
-      0.1, 0};
+      0.1,
+      0};
 
   photon::MultiTargetPNPResult multitagRes{pnpRes, {1, 2, 3, 4}};
 

--- a/photon-targeting/src/test/native/cpp/targeting/proto/PhotonTrackedTargetProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/PhotonTrackedTargetProtoTest.cpp
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "photon.pb.h"
 #include "photon/targeting/PhotonTrackedTarget.h"
+#include "photon/targeting/proto/PhotonTrackedTargetProto.h"
 
 TEST(PhotonTrackedTargetTest, Roundtrip) {
   photon::PhotonTrackedTarget target{

--- a/photon-targeting/src/test/native/cpp/targeting/proto/PhotonTrackedTargetProtoTest.cpp
+++ b/photon-targeting/src/test/native/cpp/targeting/proto/PhotonTrackedTargetProtoTest.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gtest/gtest.h"
+#include "photon.pb.h"
+#include "photon/targeting/PhotonTrackedTarget.h"
+
+TEST(PhotonTrackedTargetTest, Roundtrip) {
+  photon::PhotonTrackedTarget target{
+      3.0,
+      4.0,
+      9.0,
+      -5.0,
+      -1,
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      frc::Transform3d(frc::Translation3d(1_m, 2_m, 3_m),
+                       frc::Rotation3d(1_rad, 2_rad, 3_rad)),
+      -1,
+      {std::pair{1, 2}, std::pair{3, 4}, std::pair{5, 6}, std::pair{7, 8}},
+      {std::pair{1, 2}, std::pair{3, 4}, std::pair{5, 6}, std::pair{7, 8}}};
+
+  google::protobuf::Arena arena;
+  google::protobuf::Message* proto =
+      wpi::Protobuf<photon::PhotonTrackedTarget>::New(&arena);
+  wpi::Protobuf<photon::PhotonTrackedTarget>::Pack(proto, target);
+
+  photon::PhotonTrackedTarget unpacked_data =
+      wpi::Protobuf<photon::PhotonTrackedTarget>::Unpack(*proto);
+
+  EXPECT_EQ(target, unpacked_data);
+}

--- a/shared/javacommon.gradle
+++ b/shared/javacommon.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java-library'
 apply plugin: 'jacoco'
+apply plugin: 'com.google.protobuf'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -136,5 +137,29 @@ jacocoTestReport {
     reports {
         xml.required = true
         html.required = true
+    }
+}
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.21.12'
+    }
+    plugins {
+        quickbuf {
+            artifact = 'us.hebi.quickbuf:protoc-gen-quickbuf:1.3.3'
+        }
+    }
+    generateProtoTasks {
+        all().configureEach { task ->
+            task.builtins {
+                cpp {}
+                remove java
+            }
+            task.plugins {
+                quickbuf {
+                    option "gen_descriptors=true"
+                }
+            }
+        }
     }
 }

--- a/shared/javacpp/setupBuild.gradle
+++ b/shared/javacpp/setupBuild.gradle
@@ -38,11 +38,11 @@ model {
             sources {
                 cpp {
                     source {
-                        srcDirs 'src/main/native/cpp'
-                        include '**/*.cpp'
+                        srcDirs 'src/main/native/cpp', "$buildDir/generated/source/proto/main/cpp"
+                        include '**/*.cpp', '**/*.cc'
                     }
                     exportedHeaders {
-                        srcDirs 'src/main/native/include'
+                        srcDirs 'src/main/native/include', "$buildDir/generated/source/proto/main/cpp"
                         if (project.hasProperty('generatedHeaders')) {
                             srcDir generatedHeaders
                         }
@@ -51,8 +51,11 @@ model {
                 }
             }
 
-            if(project.hasProperty('includePhotonTargeting')) {
-                binaries.all {
+            binaries.all {
+                it.tasks.withType(CppCompile) {
+                    it.dependsOn generateProto
+                }
+                if(project.hasProperty('includePhotonTargeting')) {
                     lib project: ':photon-targeting', library: 'photontargeting', linkage: 'shared'
                 }
             }
@@ -77,13 +80,16 @@ model {
                         include '**/*.cpp'
                     }
                     exportedHeaders {
-                        srcDirs 'src/test/native/include', 'src/main/native/cpp'
+                        srcDirs 'src/test/native/include', "$buildDir/generated/source/proto/main/cpp"
                     }
                 }
             }
 
-            if(project.hasProperty('includePhotonTargeting')) {
-                binaries.all {
+            binaries.all {
+                it.tasks.withType(CppCompile) {
+                    it.dependsOn generateProto
+                }
+                if(project.hasProperty('includePhotonTargeting')) {
                     lib project: ':photon-targeting', library: 'photontargeting', linkage: 'shared'
                 }
             }


### PR DESCRIPTION
Allows logging software and live data view to see results. Also removes the requirement for AScope to keep up with the packet serde schema and instead just use the Protobuf descriptor.