### PR TITLE
Status leds round2

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/ProgramStatus.java
+++ b/photon-core/src/main/java/org/photonvision/common/ProgramStatus.java
@@ -20,6 +20,5 @@ package org.photonvision.common;
 public enum ProgramStatus {
     UHOH,
     RUNNING,
-    RUNNING_NT,
-    RUNNING_NT_TARGET
+    RUNNING_NT
 }

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -32,6 +32,7 @@ import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.configuration.NetworkConfig;
 import org.photonvision.common.dataflow.DataChangeService;
 import org.photonvision.common.dataflow.events.OutgoingUIEvent;
+import org.photonvision.common.hardware.HardwareManager;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 import org.photonvision.common.scripting.ScriptEventType;
@@ -91,6 +92,7 @@ public class NetworkTablesManager {
                                 event.connInfo.remote_port,
                                 event.connInfo.protocol_version);
                 logger.error(msg);
+                HardwareManager.getInstance().setNTConnected(false);
 
                 hasReportedConnectionFailure = true;
                 getInstance().broadcastConnectedStatus();
@@ -102,6 +104,7 @@ public class NetworkTablesManager {
                                 event.connInfo.remote_port,
                                 event.connInfo.protocol_version);
                 logger.info(msg);
+                HardwareManager.getInstance().setNTConnected(true);
 
                 hasReportedConnectionFailure = false;
                 ScriptManager.queueEvent(ScriptEventType.kNTConnected);

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package org.photonvision.common.dataflow.statusLEDs;
 
 import org.photonvision.common.dataflow.CVPipelineResultConsumer;
@@ -5,7 +22,6 @@ import org.photonvision.common.hardware.HardwareManager;
 import org.photonvision.vision.pipeline.result.CVPipelineResult;
 
 public class StatusLEDConsumer implements CVPipelineResultConsumer{
-
     private final int index;
 
     public StatusLEDConsumer(int index){
@@ -16,5 +32,5 @@ public class StatusLEDConsumer implements CVPipelineResultConsumer{
     public void accept(CVPipelineResult t) {
         HardwareManager.getInstance().setTargetsVisibleStatus(this.index, t.hasTargets());
     }
-    
+
 }

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
@@ -1,0 +1,20 @@
+package org.photonvision.common.dataflow.statusLEDs;
+
+import org.photonvision.common.dataflow.CVPipelineResultConsumer;
+import org.photonvision.common.hardware.HardwareManager;
+import org.photonvision.vision.pipeline.result.CVPipelineResult;
+
+public class StatusLEDConsumer implements CVPipelineResultConsumer{
+
+    private final int index;
+
+    public StatusLEDConsumer(int index){
+        this.index = index;
+    }
+
+    @Override
+    public void accept(CVPipelineResult t) {
+        HardwareManager.getInstance().setStatus()
+    }
+    
+}

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
@@ -21,10 +21,10 @@ import org.photonvision.common.dataflow.CVPipelineResultConsumer;
 import org.photonvision.common.hardware.HardwareManager;
 import org.photonvision.vision.pipeline.result.CVPipelineResult;
 
-public class StatusLEDConsumer implements CVPipelineResultConsumer{
+public class StatusLEDConsumer implements CVPipelineResultConsumer {
     private final int index;
 
-    public StatusLEDConsumer(int index){
+    public StatusLEDConsumer(int index) {
         this.index = index;
     }
 
@@ -32,5 +32,4 @@ public class StatusLEDConsumer implements CVPipelineResultConsumer{
     public void accept(CVPipelineResult t) {
         HardwareManager.getInstance().setTargetsVisibleStatus(this.index, t.hasTargets());
     }
-
 }

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/statusLEDs/StatusLEDConsumer.java
@@ -14,7 +14,7 @@ public class StatusLEDConsumer implements CVPipelineResultConsumer{
 
     @Override
     public void accept(CVPipelineResult t) {
-        HardwareManager.getInstance().setStatus()
+        HardwareManager.getInstance().setTargetsVisibleStatus(this.index, t.hasTargets());
     }
     
 }

--- a/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -160,23 +160,6 @@ public class HardwareManager {
         }
     }
 
-    public void setStatus(ProgramStatus status) {
-        switch (status) {
-            case UHOH:
-                // red flashing, green off
-                break;
-            case RUNNING:
-                // red solid, green off
-                break;
-            case RUNNING_NT:
-                // red off, green solid
-                break;
-            case RUNNING_NT_TARGET:
-                // red off, green flashing
-                break;
-        }
-    }
-
     public HardwareConfig getConfig() {
         return hardwareConfig;
     }

--- a/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -99,7 +99,7 @@ public class HardwareManager {
                         : null;
 
         if (statusLED != null) {
-            TimedTaskManager.getInstance().addTask("StatusLEDUpdate", this::statusLEDUpdate, 200);
+            TimedTaskManager.getInstance().addTask("StatusLEDUpdate", this::statusLEDUpdate, 150);
         }
 
         var hasBrightnessRange = hardwareConfig.ledBrightnessRange.size() == 2;
@@ -187,7 +187,7 @@ public class HardwareManager {
 
     private void statusLEDUpdate() {
         // make blinky
-        boolean blinky = ((blinkCounter % 2) == 0);
+        boolean blinky = ((blinkCounter % 3) > 0);
 
         // check if any pipeline has a visible target
         boolean anyTarget = false;
@@ -200,16 +200,16 @@ public class HardwareManager {
         if (this.systemRunning) {
             if (!this.ntConnected) {
                 if (anyTarget) {
-                    // alternate blue/yellow
-                    statusLED.setRGB(blinky, blinky, !blinky);
+                    // Blue Flashing
+                    statusLED.setRGB(false, false, blinky);
                 } else {
                     // Yellow flashing
                     statusLED.setRGB(blinky, blinky, false);
                 }
             } else {
                 if (anyTarget) {
-                    // alternate blue/green
-                    statusLED.setRGB(false, blinky, !blinky);
+                    // Blue
+                    statusLED.setRGB(false, false, blinky);
                 } else {
                     // blinky green
                     statusLED.setRGB(false, blinky, false);

--- a/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -175,7 +175,6 @@ public class HardwareManager {
     }
 
     public void statusLEDUpdate() {
-
         // make blinky
         boolean blinky = ((blinkCounter % 2) == 0);
 
@@ -198,8 +197,8 @@ public class HardwareManager {
                     statusLED.setRGB(blinky, blinky, !blinky);
                 } else {
                     // Yellow flashing
-                    statusLED.setRGB(blinky, blinky, false); 
-                }            
+                    statusLED.setRGB(blinky, blinky, false);
+                }
                 break;
             case RUNNING_NT:
                 if(anyTarget){

--- a/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -20,7 +20,8 @@ package org.photonvision.common.hardware;
 import edu.wpi.first.networktables.IntegerPublisher;
 import edu.wpi.first.networktables.IntegerSubscriber;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.configuration.HardwareConfig;
 import org.photonvision.common.configuration.HardwareSettings;
@@ -165,6 +166,17 @@ public class HardwareManager {
         }
     }
 
+    // API's supporting status LEDs
+
+    private Map<Integer, Boolean> pipelineTargets = new HashMap<Integer, Boolean>();
+    private boolean ntConnected = false;
+    private boolean systemRunning = false;
+    private int blinkCounter = 0;
+
+    public void setTargetsVisibleStatus(int pipelineIdx, boolean hasTargets) {
+        pipelineTargets.put(pipelineIdx, hasTargets);
+    }
+
     public void setNTConnected(boolean isConnected) {
         this.ntConnected = isConnected;
     }
@@ -173,13 +185,13 @@ public class HardwareManager {
         this.systemRunning = isRunning;
     }
 
-    public void statusLEDUpdate() {
+    private void statusLEDUpdate() {
         // make blinky
         boolean blinky = ((blinkCounter % 2) == 0);
 
         // check if any pipeline has a visible target
         boolean anyTarget = false;
-        for (var t : this.pipelineTargets) {
+        for (var t : this.pipelineTargets.values()) {
             if (t) {
                 anyTarget = true;
             }
@@ -209,16 +221,6 @@ public class HardwareManager {
         }
 
         blinkCounter++;
-    }
-
-    private ArrayList<Boolean> pipelineTargets = new ArrayList<Boolean>();
-    private boolean ntConnected = false;
-    private boolean systemRunning = false;
-    int blinkCounter = 0;
-
-    public void setTargetsVisibleStatus(int pipelineIdx, boolean hasTargets) {
-        pipelineTargets.ensureCapacity(pipelineIdx);
-        pipelineTargets.add(pipelineIdx, hasTargets);
     }
 
     public HardwareConfig getConfig() {

--- a/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -21,7 +21,6 @@ import edu.wpi.first.networktables.IntegerPublisher;
 import edu.wpi.first.networktables.IntegerSubscriber;
 import java.io.IOException;
 import java.util.ArrayList;
-import org.photonvision.common.ProgramStatus;
 import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.configuration.HardwareConfig;
 import org.photonvision.common.configuration.HardwareSettings;
@@ -186,8 +185,8 @@ public class HardwareManager {
             }
         }
 
-        if(this.systemRunning){
-            if(!this.ntConnected){
+        if (this.systemRunning) {
+            if (!this.ntConnected) {
                 if (anyTarget) {
                     // alternate blue/yellow
                     statusLED.setRGB(blinky, blinky, !blinky);
@@ -205,7 +204,7 @@ public class HardwareManager {
                 }
             }
         } else {
-            //Faulted, not running... blinky red
+            // Faulted, not running... blinky red
             statusLED.setRGB(blinky, false, false);
         }
 

--- a/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
@@ -47,7 +47,7 @@ public class StatusLED {
     }
 
     public void setRGB(boolean r, boolean g, boolean b) {
-        //System.out.printf("DEBUG setting LED's to %b %b %b\n", r, g, b);
+        // System.out.printf("DEBUG setting LED's to %b %b %b\n", r, g, b);
         redLED.setState(!r);
         redLED.setBrightness(r ? 0 : 100);
         greenLED.setState(!g);

--- a/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
@@ -45,4 +45,7 @@ public class StatusLED {
             blueLED = new CustomGPIO(statusLedPins.get(2));
         }
     }
+
+
+    // TODO backfill from other branch
 }

--- a/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
@@ -46,6 +46,13 @@ public class StatusLED {
         }
     }
 
-
-    // TODO backfill from other branch
+    public void setRGB(boolean r, boolean g, boolean b) {
+        // System.out.println("DEBUG setting LED's to %b %b %b");
+        redLED.setState(!r);
+        redLED.setBrightness(r ? 0 : 100);
+        greenLED.setState(!g);
+        greenLED.setBrightness(g ? 0 : 100);
+        blueLED.setState(!b);
+        blueLED.setBrightness(b ? 0 : 100);
+    }
 }

--- a/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
@@ -47,7 +47,7 @@ public class StatusLED {
     }
 
     public void setRGB(boolean r, boolean g, boolean b) {
-        // System.out.printf("DEBUG setting LED's to %b %b %b\n", r, g, b);
+        // Outputs are active-low, so invert the level applied
         redLED.setState(!r);
         redLED.setBrightness(r ? 0 : 100);
         greenLED.setState(!g);

--- a/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/StatusLED.java
@@ -47,7 +47,7 @@ public class StatusLED {
     }
 
     public void setRGB(boolean r, boolean g, boolean b) {
-        // System.out.println("DEBUG setting LED's to %b %b %b");
+        //System.out.printf("DEBUG setting LED's to %b %b %b\n", r, g, b);
         redLED.setState(!r);
         redLED.setBrightness(r ? 0 : 100);
         greenLED.setState(!g);

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -33,6 +33,7 @@ import org.photonvision.common.dataflow.CVPipelineResultConsumer;
 import org.photonvision.common.dataflow.DataChangeService;
 import org.photonvision.common.dataflow.events.OutgoingUIEvent;
 import org.photonvision.common.dataflow.networktables.NTDataPublisher;
+import org.photonvision.common.dataflow.statusLEDs.StatusLEDConsumer;
 import org.photonvision.common.dataflow.websocket.UIDataPublisher;
 import org.photonvision.common.hardware.HardwareManager;
 import org.photonvision.common.logging.LogGroup;
@@ -72,6 +73,7 @@ public class VisionModule {
             new LinkedList<>();
     private final NTDataPublisher ntConsumer;
     private final UIDataPublisher uiDataConsumer;
+    private final StatusLEDConsumer statusLEDsConsumer;
     protected final int moduleIndex;
     protected final QuirkyCamera cameraQuirks;
 
@@ -143,8 +145,10 @@ public class VisionModule {
                         pipelineManager::getDriverMode,
                         this::setDriverMode);
         uiDataConsumer = new UIDataPublisher(index);
+        statusLEDsConsumer = new StatusLEDConsumer(index);
         addResultConsumer(ntConsumer);
         addResultConsumer(uiDataConsumer);
+        addResultConsumer(statusLEDsConsumer);
         addResultConsumer(
                 (result) ->
                         lastPipelineResultBestTarget = result.hasTargets() ? result.targets.get(0) : null);

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -375,6 +375,7 @@ public class Main {
         }
 
         logger.info("Starting server...");
+        HardwareManager.getInstance().setRunning(true);
         Server.start(DEFAULT_WEBPORT);
     }
 }


### PR DESCRIPTION
Continuation of https://github.com/PhotonVision/photonvision/pull/802

Support RGB status LED to indicate:

Running/no-running
NT connected
At least one target visible