### PR TITLE
Fix typo in systemd parameter

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -104,7 +104,7 @@ WorkingDirectory=/opt/photonvision
 Nice=-10
 # for non-uniform CPUs, like big.LITTLE, you want to select the big cores
 # look up the right values for your CPU
-# AllowCPUs=4-7
+# AllowedCPUs=4-7
 
 ExecStart=/usr/bin/java -Xmx512m -jar /opt/photonvision/photonvision.jar
 ExecStop=/bin/systemctl kill photonvision


### PR DESCRIPTION
This is low priority, but I discovered that I had mistyped the Systemd parameter which restricts PV to use particular CPUs. This is commented out by default so will not affect anything unless they actively turned on the parametr.