### PR TITLE
Fix detection of CSI cameras in UI

### DIFF
--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -12,7 +12,7 @@ const cameraRotations = computed(() =>
   ["Normal", "90° CW", "180°", "90° CCW"].map((v, i) => ({
     name: v,
     value: i,
-    disabled: useSettingsStore().gpuAccelerationEnabled ? [1, 3].includes(i) : false
+    disabled: useCameraSettingsStore().isCSICamera ? [1, 3].includes(i) : false
   }))
 );
 

--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -58,6 +58,9 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
     },
     isCalibrationMode(): boolean {
       return this.currentCameraSettings.currentPipelineIndex == WebsocketPipelineType.Calib3d;
+    },
+    isCSICamera(): boolean {
+      return this.currentCameraSettings.isCSICamera;
     }
   },
   actions: {
@@ -99,6 +102,7 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
           perViewErrors: calib.perViewErrors,
           intrinsics: calib.intrinsics
         })),
+        isCSICamera: d.isCSICamera,
         pipelineNicknames: d.pipelineNicknames,
         currentPipelineIndex: d.currentPipelineIndex,
         pipelineSettings: d.currentPipelineSettings

--- a/photon-client/src/types/SettingTypes.ts
+++ b/photon-client/src/types/SettingTypes.ts
@@ -112,6 +112,7 @@ export interface CameraSettings {
   currentPipelineIndex: number;
   pipelineNicknames: string[];
   pipelineSettings: ActivePipelineSettings;
+  isCSICamera: boolean;
 }
 
 export const PlaceholderCameraSettings: CameraSettings = {
@@ -145,7 +146,8 @@ export const PlaceholderCameraSettings: CameraSettings = {
   pipelineNicknames: ["Placeholder Pipeline"],
   lastPipelineIndex: 0,
   currentPipelineIndex: 0,
-  pipelineSettings: DefaultAprilTagPipelineSettings
+  pipelineSettings: DefaultAprilTagPipelineSettings,
+  isCSICamera: false
 };
 
 export enum CalibrationBoardTypes {

--- a/photon-client/src/types/WebsocketDataTypes.ts
+++ b/photon-client/src/types/WebsocketDataTypes.ts
@@ -52,6 +52,7 @@ export interface WebsocketCameraSettingsUpdate {
   fov: number;
   inputStreamPort: number;
   isFovConfigurable: boolean;
+  isCSICamera: boolean;
   nickname: string;
   outputStreamPort: number;
   pipelineNicknames: string[];

--- a/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
@@ -174,5 +174,6 @@ public class PhotonConfiguration {
         public int inputStreamPort;
         public List<HashMap<String, Object>> calibrations;
         public boolean isFovConfigurable = true;
+        public boolean isCSICamera;
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -41,6 +41,7 @@ import org.photonvision.common.logging.Logger;
 import org.photonvision.common.util.SerializationUtils;
 import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
 import org.photonvision.vision.camera.CameraQuirk;
+import org.photonvision.vision.camera.CameraType;
 import org.photonvision.vision.camera.LibcameraGpuSource;
 import org.photonvision.vision.camera.QuirkyCamera;
 import org.photonvision.vision.camera.USBCameraSource;
@@ -498,6 +499,7 @@ public class VisionModule {
         var ret = new PhotonConfiguration.UICameraConfiguration();
 
         ret.fov = visionSource.getSettables().getFOV();
+        ret.isCSICamera = visionSource.getCameraConfiguration().cameraType == CameraType.ZeroCopyPicam;
         ret.nickname = visionSource.getSettables().getConfiguration().nickname;
         ret.currentPipelineSettings =
                 SerializationUtils.objectToHashMap(pipelineManager.getCurrentPipelineSettings());


### PR DESCRIPTION
UI would say that every camera on a Pi device was a CSI camera basically. It would not let you rotate usb cameras 90 degrees or 270 degrees because it thought that they were CSI cameras.

Fixes: #1098 

BEFORE:
![image](https://github.com/PhotonVision/photonvision/assets/14988163/24a8be62-1327-4c80-8427-950d15a14c4b)
AFTER:
![image](https://github.com/PhotonVision/photonvision/assets/14988163/fe70dd21-9c56-4034-b1f3-b2255e19f780)
AFTER (pi camera / CSI camera):
![image](https://github.com/PhotonVision/photonvision/assets/14988163/d96c0ea6-1485-43fa-868a-6350cf492213)

