### PR TITLE
Enable detecting generic Linux ARM32 in Platform enum

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/hardware/Platform.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/Platform.java
@@ -166,6 +166,8 @@ public enum Platform {
             } else if (RuntimeDetector.isArm64()) {
                 // TODO - os detection needed?
                 return LINUX_AARCH64;
+            } else if (RuntimeDetector.isArm32()) {
+                return LINUX_ARM32;
             } else {
                 // Unknown or otherwise unsupported platform
                 return Platform.UNKNOWN;


### PR DESCRIPTION
If detect ARM32 platform, pass that back. Means the metrics work.