### PR TITLE
typo in camera name

### DIFF
--- a/photon-client/src/components/cameras/CameraSettingsCard.vue
+++ b/photon-client/src/components/cameras/CameraSettingsCard.vue
@@ -128,7 +128,7 @@ watchEffect(() => {
         label="Arducam Model"
         :items="[
           { name: 'None', value: 0, disabled: true },
-          { name: 'OV9821', value: 1 },
+          { name: 'OV9281', value: 1 },
           { name: 'OV2311', value: 2 }
         ]"
         :select-cols="8"


### PR DESCRIPTION
In the Arducam dropdown, the OV9281 camera name had a typo.