### PR TITLE
[photon-lib java] Fix classes with protobuf support not "announcing it" and as a result causing crashes with AdvantageKit

### DIFF
--- a/photon-targeting/src/main/java/org/photonvision/targeting/MultiTargetPNPResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/MultiTargetPNPResult.java
@@ -19,11 +19,12 @@ package org.photonvision.targeting;
 
 import java.util.ArrayList;
 import java.util.List;
+import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.MultiTargetPNPResultProto;
 
-public class MultiTargetPNPResult {
+public class MultiTargetPNPResult implements ProtobufSerializable {
     // Seeing 32 apriltags at once seems like a sane limit
     private static final int MAX_IDS = 32;
 

--- a/photon-targeting/src/main/java/org/photonvision/targeting/MultiTargetPNPResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/MultiTargetPNPResult.java
@@ -17,9 +17,9 @@
 
 package org.photonvision.targeting;
 
+import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import java.util.ArrayList;
 import java.util.List;
-import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.MultiTargetPNPResultProto;

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PNPResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PNPResult.java
@@ -18,6 +18,7 @@
 package org.photonvision.targeting;
 
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.PNPResultProto;
@@ -32,7 +33,7 @@ import org.photonvision.utils.PacketUtils;
  * <p>Note that the coordinate frame of these transforms depends on the implementing solvePnP
  * method.
  */
-public class PNPResult {
+public class PNPResult implements ProtobufSerializable {
     /**
      * If this result is valid. A false value indicates there was an error in estimation, and this
      * result should not be used.

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineResult.java
@@ -19,12 +19,13 @@ package org.photonvision.targeting;
 
 import java.util.ArrayList;
 import java.util.List;
+import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.PhotonPipelineResultProto;
 
 /** Represents a pipeline result from a PhotonCamera. */
-public class PhotonPipelineResult {
+public class PhotonPipelineResult implements ProtobufSerializable {
     private static boolean HAS_WARNED = false;
 
     // Targets to store.

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineResult.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineResult.java
@@ -17,9 +17,9 @@
 
 package org.photonvision.targeting;
 
+import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import java.util.ArrayList;
 import java.util.List;
-import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.PhotonPipelineResultProto;

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PhotonTrackedTarget.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PhotonTrackedTarget.java
@@ -18,6 +18,7 @@
 package org.photonvision.targeting;
 
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.photonvision.common.dataflow.structures.Packet;
@@ -25,7 +26,7 @@ import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.PhotonTrackedTargetProto;
 import org.photonvision.utils.PacketUtils;
 
-public class PhotonTrackedTarget {
+public class PhotonTrackedTarget implements ProtobufSerializable {
     private static final int MAX_CORNERS = 8;
 
     private final double yaw;

--- a/photon-targeting/src/main/java/org/photonvision/targeting/TargetCorner.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/TargetCorner.java
@@ -17,8 +17,8 @@
 
 package org.photonvision.targeting;
 
-import java.util.Objects;
 import edu.wpi.first.util.protobuf.ProtobufSerializable;
+import java.util.Objects;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.TargetCornerProto;

--- a/photon-targeting/src/main/java/org/photonvision/targeting/TargetCorner.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/TargetCorner.java
@@ -18,6 +18,7 @@
 package org.photonvision.targeting;
 
 import java.util.Objects;
+import edu.wpi.first.util.protobuf.ProtobufSerializable;
 import org.photonvision.common.dataflow.structures.Packet;
 import org.photonvision.common.dataflow.structures.PacketSerde;
 import org.photonvision.targeting.proto.TargetCornerProto;
@@ -26,7 +27,7 @@ import org.photonvision.targeting.proto.TargetCornerProto;
  * Represents a point in an image at the corner of the minimum-area bounding rectangle, in pixels.
  * Origin at the top left, plus-x to the right, plus-y down.
  */
-public class TargetCorner {
+public class TargetCorner implements ProtobufSerializable {
     public final double x;
     public final double y;
 


### PR DESCRIPTION
Since they didn't implement `ProtobufSerializable` this meant that most other software didn't even know protobufs were even implemented. In AdvantageKit for example this would cause it to not work it all and crash.

Disclaimer: I haven't actually been able to test these *with* AdvantageKit. But looking at the docs for `ProtobufSerializable` I don't see how this would cause any issues unless there were some already present in the protobuf implementation.