### PR TITLE
Bind-mount repo in image builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,8 @@ jobs:
           image_additional_mb: ${{ matrix.image_additional_mb }}
           optimize_image: yes
           cpu: ${{ matrix.cpu }}
+          # We do _not_ wanna copy photon into the image. Bind mount instead
+          bind_mount_repository: true
           commands: |
             chmod +x scripts/armrunner.sh
             ./scripts/armrunner.sh


### PR DESCRIPTION
Reduces built image size by not accidentally copying source in