### PR TITLE
Load libquadmath on Windows

### DIFF
--- a/photon-core/src/main/java/org/photonvision/mrcal/MrCalJNILoader.java
+++ b/photon-core/src/main/java/org/photonvision/mrcal/MrCalJNILoader.java
@@ -40,6 +40,7 @@ public class MrCalJNILoader extends PhotonJNICommon {
                             "libccolamd",
                             "openblas",
                             "libgcc_s_seh-1",
+                            "libquadmath-0",
                             "libgfortran-5",
                             "liblapack",
                             "libcholmod",


### PR DESCRIPTION
Previously would throw ULEs if you didn't also happen to have Perl installed for some reason