### PR TITLE
Fix positioning of multitarget struct in pipelineresult unpack

### DIFF
--- a/photon-targeting/src/main/native/cpp/photon/targeting/PhotonPipelineResult.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/PhotonPipelineResult.cpp
@@ -37,12 +37,13 @@ bool PhotonPipelineResult::operator==(const PhotonPipelineResult& other) const {
 
 Packet& operator<<(Packet& packet, const PhotonPipelineResult& result) {
   // Encode latency and number of targets.
-  packet << result.latency.value() << result.multitagResult
+  packet << result.latency.value()
          << static_cast<int8_t>(result.targets.size());
 
   // Encode the information of each target.
   for (auto& target : result.targets) packet << target;
 
+  packet << result.multitagResult;
   // Return the packet
   return packet;
 }

--- a/photon-targeting/src/main/native/cpp/photon/targeting/PhotonPipelineResult.cpp
+++ b/photon-targeting/src/main/native/cpp/photon/targeting/PhotonPipelineResult.cpp
@@ -51,7 +51,7 @@ Packet& operator>>(Packet& packet, PhotonPipelineResult& result) {
   // Decode latency, existence of targets, and number of targets.
   double latencyMillis = 0;
   int8_t targetCount = 0;
-  packet >> latencyMillis >> result.multitagResult >> targetCount;
+  packet >> latencyMillis >> targetCount;
   result.latency = units::millisecond_t(latencyMillis);
 
   result.targets.clear();
@@ -62,6 +62,8 @@ Packet& operator>>(Packet& packet, PhotonPipelineResult& result) {
     packet >> target;
     result.targets.push_back(target);
   }
+
+  packet >> result.multitagResult;
   return packet;
 }
 }  // namespace photon


### PR DESCRIPTION
In the c++ library, the Multitarget structure is unpacked right after the latency double, which is out of place. Currently, it's supposed to be the last struct in the bytes. This incorrect unpacking order essentially makes it such that the rest of the data (targets, etc) are "corrupted".

I think the order in the java library was changed in #1058 and the c++ library wasn't updated.

**TLDR;** I fixed the unpacking order to match the current pipelineresult data layout.