### PR TITLE
[photonlib-py] Fix pose estimator bug that prevents on-coprocessor MultiTag from running

### DIFF
--- a/photon-lib/py/photonlibpy/photonPoseEstimator.py
+++ b/photon-lib/py/photonlibpy/photonPoseEstimator.py
@@ -223,7 +223,11 @@ class PhotonPoseEstimator:
         self._poseCacheTimestampSeconds = cameraResult.timestampSec
 
         # If no targets seen, trivial case -- return empty result
-        if not cameraResult.targets:
+        # On-coprocessor multi-tag doesn't need any targets
+        if (
+            not cameraResult.targets
+            and self._primaryStrategy is not PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR
+        ):
             return
 
         return self._update(cameraResult, self._primaryStrategy)

--- a/photon-lib/py/test/photonPoseEstimator_test.py
+++ b/photon-lib/py/test/photonPoseEstimator_test.py
@@ -126,32 +126,7 @@ def test_multiTagOnCoprocStrategy():
     cameraOne.result = PhotonPipelineResult(
         2,
         11,
-        # There needs to be at least one target present for pose estimation to work
-        # Doesn't matter which/how many targets for this test
-        [
-            PhotonTrackedTarget(
-                3.0,
-                -4.0,
-                9.0,
-                4.0,
-                0,
-                Transform3d(Translation3d(1, 2, 3), Rotation3d(1, 2, 3)),
-                Transform3d(Translation3d(1, 2, 3), Rotation3d(1, 2, 3)),
-                [
-                    TargetCorner(1, 2),
-                    TargetCorner(3, 4),
-                    TargetCorner(5, 6),
-                    TargetCorner(7, 8),
-                ],
-                [
-                    TargetCorner(1, 2),
-                    TargetCorner(3, 4),
-                    TargetCorner(5, 6),
-                    TargetCorner(7, 8),
-                ],
-                0.7,
-            )
-        ],
+        # On-coprocessor multi-tag shouldn't require the targets list to be populated
         multiTagResult=MultiTargetPNPResult(
             PNPResult(True, Transform3d(1, 3, 2, Rotation3d()))
         ),


### PR DESCRIPTION
This is a small fix for the PhotonPoseEstimator added in #1178, reviewed by. @mcm001 reviewed it an hour or two ago.

Before, on-coprocessor multi-tag would only run if the `PhotonPipelineResult`'s `targets` list was populated.  This list won't always have targets, even if there is a valid multi-tag result. So, multi-tag wouldn't run. The bug might also be present in the Java version of PhotonLib, but I haven't tested that.

Now, there is an exception in the `update()` method to allow multi-tag to run without a full `targets` list. 