### PR TITLE
Temperature monitoring for RK3588

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -28,6 +28,7 @@ import org.photonvision.common.hardware.metrics.cmds.CmdBase;
 import org.photonvision.common.hardware.metrics.cmds.FileCmds;
 import org.photonvision.common.hardware.metrics.cmds.LinuxCmds;
 import org.photonvision.common.hardware.metrics.cmds.PiCmds;
+import org.photonvision.common.hardware.metrics.cmds.RK3588Cmds;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 import org.photonvision.common.util.ShellExec;
@@ -44,6 +45,8 @@ public class MetricsManager {
             cmds = new FileCmds();
         } else if (Platform.isRaspberryPi()) {
             cmds = new PiCmds(); // Pi's can use a hardcoded command set
+        } else if (Platform.isRK3588()) {
+            cmds = new RK3588Cmds(); // RK3588 chipset hardcoded command set
         } else if (Platform.isLinux()) {
             cmds = new LinuxCmds(); // Linux/Unix platforms assume a nominal command set
         } else {

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/OrangePiCmds.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/OrangePiCmds.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.common.hardware.metrics.cmds;
+
+import org.photonvision.common.configuration.HardwareConfig;
+
+public class OrangePiCmds extends LinuxCmds {
+    /** Applies pi-specific commands, ignoring any input configuration */
+    public void initCmds(HardwareConfig config) {
+        super.initCmds(config);
+
+        // CPU Temperature
+        /* The RK3588 chip has 7 thermal zones that can be accessed via:
+         *       /sys/class/thermal/thermal_zoneX/temp
+         * where X is an interger from 0 to 6.
+         *
+         * || Zone || Location    || Comments                                                ||
+         * |    0  |  soc         |  soc thermal (near the center of the chip)                |
+         * |    1  |  bigcore0    |  CPU Big Core A76_0/1 (CPU4 and CPU5)                     |
+         * |    2  |  bigcore1    |  CPU Big Core A76_2/3 (CPU6 and CPU7)                     |
+         * |    3  |  littlecore  |  CPU Small Core A55_0/1/2/3 (CPU0, CPU1, CPU2, and CPU3)  |
+         * |    4  |  center      |  also called PD_CENTER                                    |
+         * |    5  |  gpu         |  GPU                                                      |
+         * |    6  |  npu         |  NPU                                                      |
+         *
+         * Sources:
+         *   - http://forum.armsom.org/t/topic/51/3
+         *   - https://lore.kernel.org/lkml/7276280.TLKafQO6qx@archbook/
+         */
+        cpuTemperatureCommand =
+                "cat /sys/class/thermal/thermal_zone1/temp | awk '{printf \"%.1f\", $1/1000}'";
+
+        // cpuThrottleReasonCmd =
+        //         "if   ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x01 )) != 0x00 )); then echo \"LOW VOLTAGE\"; "
+        //                 + " elif ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x08 )) != 0x00 )); then echo \"HIGH TEMP\"; "
+        //                 + " elif ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x10000 )) != 0x00 )); then echo \"Prev. Low Voltage\"; "
+        //                 + " elif ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x80000 )) != 0x00 )); then echo \"Prev. High Temp\"; "
+        //                 + " else echo \"None\"; fi";
+
+        // // GPU
+        // gpuMemoryCommand = "vcgencmd get_mem gpu | grep -Eo '[0-9]+'";
+        // gpuMemUsageCommand = "vcgencmd get_mem malloc | grep -Eo '[0-9]+'";
+    }
+}

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/RK3588Cmds.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/RK3588Cmds.java
@@ -44,16 +44,5 @@ public class RK3588Cmds extends LinuxCmds {
          */
         cpuTemperatureCommand =
                 "cat /sys/class/thermal/thermal_zone1/temp | awk '{printf \"%.1f\", $1/1000}'";
-
-        // cpuThrottleReasonCmd =
-        //         "if   ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x01 )) != 0x00 )); then echo \"LOW VOLTAGE\"; "
-        //                 + " elif ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x08 )) != 0x00 )); then echo \"HIGH TEMP\"; "
-        //                 + " elif ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x10000 )) != 0x00 )); then echo \"Prev. Low Voltage\"; "
-        //                 + " elif ((  $(( $(vcgencmd get_throttled | grep -Eo 0x[0-9a-fA-F]*) & 0x80000 )) != 0x00 )); then echo \"Prev. High Temp\"; "
-        //                 + " else echo \"None\"; fi";
-
-        // // GPU
-        // gpuMemoryCommand = "vcgencmd get_mem gpu | grep -Eo '[0-9]+'";
-        // gpuMemUsageCommand = "vcgencmd get_mem malloc | grep -Eo '[0-9]+'";
     }
 }

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/RK3588Cmds.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/RK3588Cmds.java
@@ -19,7 +19,7 @@ package org.photonvision.common.hardware.metrics.cmds;
 
 import org.photonvision.common.configuration.HardwareConfig;
 
-public class OrangePiCmds extends LinuxCmds {
+public class RK3588Cmds extends LinuxCmds {
     /** Applies pi-specific commands, ignoring any input configuration */
     public void initCmds(HardwareConfig config) {
         super.initCmds(config);


### PR DESCRIPTION
This adds temperature monitoring capability for the RK3588 soc used in OrangePi5 and CoolPi4b sbcs.