### PR TITLE
Remove extra println that was used for debugging

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/Server.java
+++ b/photon-server/src/main/java/org/photonvision/server/Server.java
@@ -138,7 +138,6 @@ public class Server {
         app.post("/api/calibration/importFromData", RequestHandler::onDataCalibrationImportRequest);
 
         app.start(port);
-        System.out.println("hi");
     }
 
     /**


### PR DESCRIPTION
I'm assuming that Matt didn't mean to leave this in the release. If he did, just ignore this PR.