### PR TITLE
Adds a comment to the systemd service noting the location of the java path as a runtime environmental variable

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -169,7 +169,6 @@ Nice=-10
 # look up the right values for your CPU
 # AllowedCPUs=4-7
 
-
 ExecStart=/usr/bin/java -Xmx512m -jar /opt/photonvision/photonvision.jar
 ExecStop=/bin/systemctl kill photonvision
 Type=simple

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -162,11 +162,13 @@ Description=Service that runs PhotonVision
 
 [Service]
 WorkingDirectory=/opt/photonvision
+# Optionally use: Environment=PATH=/path/to/java, generally this will be in /usr/bin/java. 
 # Run photonvision at "nice" -10, which is higher priority than standard
 Nice=-10
 # for non-uniform CPUs, like big.LITTLE, you want to select the big cores
 # look up the right values for your CPU
 # AllowedCPUs=4-7
+
 
 ExecStart=/usr/bin/java -Xmx512m -jar /opt/photonvision/photonvision.jar
 ExecStop=/bin/systemctl kill photonvision


### PR DESCRIPTION
Resolves #1151 

Because the systemd service config in the install script does not contain the PATH of the java executable, the service fails to start. Opting to add this as a comment as paths pointing to a JRE install aren't _always_ in /usr/bin/java 