### PR TITLE
Add v4l utils to installation script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,6 +132,10 @@ fi
 echo "Installing additional math packages"
 apt-get install --yes libcholmod3 liblapack3 libsuitesparseconfig5
 
+echo "Installing v4l-utils..."
+apt-get install --yes v4l-utils
+echo "v4l-utils installation complete."
+
 echo "Downloading latest stable release of PhotonVision..."
 mkdir -p /opt/photonvision
 cd /opt/photonvision


### PR DESCRIPTION
This PR adds the v4l-utils package to the installation script. The reasoning behind this is that many folks would like to use v4l2-ctl but it's not installed by default, and it's a bit of a hassle to add when your coprocessor is on the robot, without an easy way to access the internet.

Note that the installed size of the package is 2028 KB.

