### PR TITLE
Photonlibpy - Best Target Function

### DIFF
--- a/photon-lib/py/photonlibpy/photonPipelineResult.py
+++ b/photon-lib/py/photonlibpy/photonPipelineResult.py
@@ -39,5 +39,10 @@ class PhotonPipelineResult:
     def getTargets(self) -> list[PhotonTrackedTarget]:
         return self.targets
 
+    def getBestTarget(self) -> PhotonTrackedTarget:
+        if not self.hasTargets():
+            return None
+        return self.getTargets()[0]
+
     def hasTargets(self) -> bool:
         return len(self.targets) > 0


### PR DESCRIPTION
A rather simple `getBestTarget()` function for a pipeline result.

The idea to use `.get(0)` comes from the Java version of the library. This implies the assumption that target packets are sent in order. 

I do not have access to a robot at the moment (thus it's a draft), but this matches the behavior of the Java client, so I'm confident it should work.

Vlad & the 5113 software team.