### PR TITLE
Fix cpp and java photoncamera names in "Aim at Target" example

### DIFF
--- a/photonlib-cpp-examples/aimattarget/src/main/include/Robot.h
+++ b/photonlib-cpp-examples/aimattarget/src/main/include/Robot.h
@@ -39,8 +39,8 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override;
 
  private:
-  // Change this to match the name of your camera
-  photon::PhotonCamera camera{"photonvision"};
+  // Change this to match the name of your camera as shown in the web UI
+  photon::PhotonCamera camera{"YOUR_CAMERA_NAME_HERE"};
   // PID constants should be tuned per robot
   frc::PIDController controller{.1, 0, 0};
 

--- a/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
+++ b/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
@@ -48,8 +48,8 @@ public class Robot extends TimedRobot {
     // How far from the target we want to be
     final double GOAL_RANGE_METERS = Units.feetToMeters(3);
 
-    // Change this to match the name of your camera
-    PhotonCamera camera = new PhotonCamera("photonvision");
+    // Change this to match the name of your camera as shown in the web UI
+    PhotonCamera camera = new PhotonCamera("YOUR_CAMERA_NAME_HERE");
 
     // PID constants should be tuned per robot
     final double LINEAR_P = 0.1;


### PR DESCRIPTION
Required for https://github.com/PhotonVision/photonvision-docs/pull/342