### PR TITLE
Actually properly match cameras by name fr this time

### DIFF
--- a/photon-client/src/components/settings/NetworkingCard.vue
+++ b/photon-client/src/components/settings/NetworkingCard.vue
@@ -7,7 +7,6 @@ import PvSwitch from "@/components/common/pv-switch.vue";
 import PvSelect from "@/components/common/pv-select.vue";
 import { type ConfigurableNetworkSettings, NetworkConnectionType } from "@/types/SettingTypes";
 import { useStateStore } from "@/stores/StateStore";
-import { VDivider } from "vuetify/lib";
 
 // Copy object to remove reference to store
 const tempSettingsStruct = ref<ConfigurableNetworkSettings>(Object.assign({}, useSettingsStore().network));

--- a/photon-client/src/components/settings/NetworkingCard.vue
+++ b/photon-client/src/components/settings/NetworkingCard.vue
@@ -60,7 +60,7 @@ const settingsHaveChanged = (): boolean => {
     a.shouldPublishProto !== b.shouldPublishProto ||
     a.networkManagerIface !== b.networkManagerIface ||
     a.setStaticCommand !== b.setStaticCommand ||
-    a.setDHCPcommand !== b.setDHCPcommand  ||
+    a.setDHCPcommand !== b.setDHCPcommand ||
     a.matchCamerasOnlyByPath !== b.matchCamerasOnlyByPath
   );
 };
@@ -287,7 +287,7 @@ watchEffect(() => {
           class="mt-3 mb-2"
           :label-cols="4"
         />
-        <v-divider class="mb-3"/>
+        <v-divider class="mb-3" />
       </v-form>
       <v-btn
         color="accent"

--- a/photon-client/src/components/settings/NetworkingCard.vue
+++ b/photon-client/src/components/settings/NetworkingCard.vue
@@ -7,6 +7,7 @@ import PvSwitch from "@/components/common/pv-switch.vue";
 import PvSelect from "@/components/common/pv-select.vue";
 import { type ConfigurableNetworkSettings, NetworkConnectionType } from "@/types/SettingTypes";
 import { useStateStore } from "@/stores/StateStore";
+import { VDivider } from "vuetify/lib";
 
 // Copy object to remove reference to store
 const tempSettingsStruct = ref<ConfigurableNetworkSettings>(Object.assign({}, useSettingsStore().network));
@@ -59,7 +60,8 @@ const settingsHaveChanged = (): boolean => {
     a.shouldPublishProto !== b.shouldPublishProto ||
     a.networkManagerIface !== b.networkManagerIface ||
     a.setStaticCommand !== b.setStaticCommand ||
-    a.setDHCPcommand !== b.setDHCPcommand
+    a.setDHCPcommand !== b.setDHCPcommand  ||
+    a.matchCamerasOnlyByPath !== b.matchCamerasOnlyByPath
   );
 };
 
@@ -77,6 +79,7 @@ const saveGeneralSettings = () => {
     setStaticCommand: tempSettingsStruct.value.setStaticCommand || "",
     shouldManage: tempSettingsStruct.value.shouldManage,
     shouldPublishProto: tempSettingsStruct.value.shouldPublishProto,
+    matchCamerasOnlyByPath: tempSettingsStruct.value.matchCamerasOnlyByPath,
     staticIp: tempSettingsStruct.value.staticIp
   };
 
@@ -137,6 +140,8 @@ watchEffect(() => {
 
 <template>
   <v-card dark class="mb-3 pr-6 pb-3" style="background-color: #006492">
+    <v-card-title>Global Settings</v-card-title>
+    <v-divider />
     <v-card-title>Networking</v-card-title>
     <div class="ml-5">
       <v-form ref="form" v-model="settingsValid">
@@ -254,6 +259,9 @@ watchEffect(() => {
         >
           This mode is intended for debugging; it should be off for proper usage. PhotonLib will NOT work!
         </v-banner>
+
+        <v-divider />
+        <v-card-title>Miscellaneous</v-card-title>
         <pv-switch
           v-model="tempSettingsStruct.shouldPublishProto"
           label="Also Publish Protobuf"
@@ -272,6 +280,14 @@ watchEffect(() => {
           This mode is intended for debugging; it should be off for field use. You may notice a performance hit by using
           this mode.
         </v-banner>
+        <pv-switch
+          v-model="tempSettingsStruct.matchCamerasOnlyByPath"
+          label="Match cameras by-path ONLY"
+          tooltip="ONLY match cameras by the USB port they're plugged into + (basename or USB VID/PID), and never only by the device product string"
+          class="mt-3 mb-2"
+          :label-cols="4"
+        />
+        <v-divider class="mb-3"/>
       </v-form>
       <v-btn
         color="accent"

--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -28,7 +28,7 @@ export const useSettingsStore = defineStore("settings", {
       hardwareModel: undefined,
       hardwarePlatform: undefined,
       mrCalWorking: true,
-      rknnSupported: false
+      rknnSupported: false,
     },
     network: {
       ntServerAddress: "",
@@ -44,7 +44,9 @@ export const useSettingsStore = defineStore("settings", {
           connName: "Example Wired Connection",
           devName: "eth0"
         }
-      ]
+      ],
+      networkingDisabled: false,
+      matchCamerasOnlyByPath: false,
     },
     lighting: {
       supported: true,
@@ -103,7 +105,7 @@ export const useSettingsStore = defineStore("settings", {
         hardwarePlatform: data.general.hardwarePlatform || undefined,
         gpuAcceleration: data.general.gpuAcceleration || undefined,
         mrCalWorking: data.general.mrCalWorking,
-        rknnSupported: data.general.rknnSupported
+        rknnSupported: data.general.rknnSupported,
       };
       this.lighting = data.lighting;
       this.network = data.networkSettings;

--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -28,7 +28,7 @@ export const useSettingsStore = defineStore("settings", {
       hardwareModel: undefined,
       hardwarePlatform: undefined,
       mrCalWorking: true,
-      rknnSupported: false,
+      rknnSupported: false
     },
     network: {
       ntServerAddress: "",
@@ -46,7 +46,7 @@ export const useSettingsStore = defineStore("settings", {
         }
       ],
       networkingDisabled: false,
-      matchCamerasOnlyByPath: false,
+      matchCamerasOnlyByPath: false
     },
     lighting: {
       supported: true,
@@ -105,7 +105,7 @@ export const useSettingsStore = defineStore("settings", {
         hardwarePlatform: data.general.hardwarePlatform || undefined,
         gpuAcceleration: data.general.gpuAcceleration || undefined,
         mrCalWorking: data.general.mrCalWorking,
-        rknnSupported: data.general.rknnSupported,
+        rknnSupported: data.general.rknnSupported
       };
       this.lighting = data.lighting;
       this.network = data.networkSettings;

--- a/photon-client/src/types/SettingTypes.ts
+++ b/photon-client/src/types/SettingTypes.ts
@@ -47,6 +47,7 @@ export interface NetworkSettings {
   setDHCPcommand?: string;
   networkInterfaceNames: NetworkInterfaceType[];
   networkingDisabled: boolean;
+  matchCamerasOnlyByPath: boolean;
 }
 
 export type ConfigurableNetworkSettings = Omit<

--- a/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
@@ -95,32 +95,6 @@ public class CameraConfiguration {
                         + path);
     }
 
-    // public CameraConfiguration(
-    //         @JsonProperty("baseName") String baseName,
-    //         @JsonProperty("uniqueName") String uniqueName,
-    //         @JsonProperty("nickname") String nickname,
-    //         @JsonProperty("FOV") double FOV,
-    //         @JsonProperty("path") String path,
-    //         @JsonProperty("cameraType") CameraType cameraType,
-    //         @JsonProperty("cameraQuirks") QuirkyCamera cameraQuirks,
-    //         @JsonProperty("calibration") List<CameraCalibrationCoefficients> calibrations,
-    //         @JsonProperty("currentPipelineIndex") int currentPipelineIndex
-    //         ) {
-    //             this(
-    //         baseName,
-    //         uniqueName,
-    //         nickname,
-    //         FOV,
-    //         path,
-    //         cameraType,
-    //         cameraQuirks,
-    //         calibrations,
-    //         currentPipelineIndex,
-    //         // no VID/PID set, try some invalid defaults
-    //         -1, -1
-    //             );
-    //         }
-
     @JsonCreator
     public CameraConfiguration(
             @JsonProperty("baseName") String baseName,

--- a/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
@@ -55,6 +54,7 @@ public class CameraConfiguration {
 
     @JsonProperty("usbVID")
     public int usbVID = -1;
+
     @JsonProperty("usbPID")
     public int usbPID = -1;
 
@@ -115,7 +115,7 @@ public class CameraConfiguration {
     //         cameraType,
     //         cameraQuirks,
     //         calibrations,
-    //         currentPipelineIndex, 
+    //         currentPipelineIndex,
     //         // no VID/PID set, try some invalid defaults
     //         -1, -1
     //             );
@@ -133,8 +133,7 @@ public class CameraConfiguration {
             @JsonProperty("calibration") List<CameraCalibrationCoefficients> calibrations,
             @JsonProperty("currentPipelineIndex") int currentPipelineIndex,
             @JsonProperty("usbVID") int usbVID,
-            @JsonProperty("usbPID") int usbPID
-            ) {
+            @JsonProperty("usbPID") int usbPID) {
         this.baseName = baseName;
         this.uniqueName = uniqueName;
         this.nickname = nickname;
@@ -144,8 +143,8 @@ public class CameraConfiguration {
         this.cameraQuirks = cameraQuirks;
         this.calibrations = calibrations != null ? calibrations : new ArrayList<>();
         this.currentPipelineIndex = currentPipelineIndex;
-        this.usbPID = usbPID
-        ; this.usbVID = usbVID;
+        this.usbPID = usbPID;
+        this.usbVID = usbVID;
 
         logger.debug(
                 "Creating camera configuration for "
@@ -195,14 +194,14 @@ public class CameraConfiguration {
     }
 
     /**
-     * Get a unique descriptor of the USB port this camera is attached to. EG 
+     * Get a unique descriptor of the USB port this camera is attached to. EG
      * "/dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0"
+     *
      * @return
      */
     @JsonIgnore
     public Optional<String> getUSBPath() {
-        return Arrays.stream(otherPaths).filter(path -> path.contains("/by-path/"))
-            .findFirst(); 
+        return Arrays.stream(otherPaths).filter(path -> path.contains("/by-path/")).findFirst();
     }
 
     @Override

--- a/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
@@ -50,6 +52,11 @@ public class CameraConfiguration {
     public QuirkyCamera cameraQuirks;
 
     @JsonIgnore public String[] otherPaths = {};
+
+    @JsonProperty("usbVID")
+    public int usbVID = -1;
+    @JsonProperty("usbPID")
+    public int usbPID = -1;
 
     public CameraType cameraType = CameraType.UsbCamera;
     public double FOV = 70;
@@ -88,6 +95,32 @@ public class CameraConfiguration {
                         + path);
     }
 
+    // public CameraConfiguration(
+    //         @JsonProperty("baseName") String baseName,
+    //         @JsonProperty("uniqueName") String uniqueName,
+    //         @JsonProperty("nickname") String nickname,
+    //         @JsonProperty("FOV") double FOV,
+    //         @JsonProperty("path") String path,
+    //         @JsonProperty("cameraType") CameraType cameraType,
+    //         @JsonProperty("cameraQuirks") QuirkyCamera cameraQuirks,
+    //         @JsonProperty("calibration") List<CameraCalibrationCoefficients> calibrations,
+    //         @JsonProperty("currentPipelineIndex") int currentPipelineIndex
+    //         ) {
+    //             this(
+    //         baseName,
+    //         uniqueName,
+    //         nickname,
+    //         FOV,
+    //         path,
+    //         cameraType,
+    //         cameraQuirks,
+    //         calibrations,
+    //         currentPipelineIndex, 
+    //         // no VID/PID set, try some invalid defaults
+    //         -1, -1
+    //             );
+    //         }
+
     @JsonCreator
     public CameraConfiguration(
             @JsonProperty("baseName") String baseName,
@@ -98,7 +131,10 @@ public class CameraConfiguration {
             @JsonProperty("cameraType") CameraType cameraType,
             @JsonProperty("cameraQuirks") QuirkyCamera cameraQuirks,
             @JsonProperty("calibration") List<CameraCalibrationCoefficients> calibrations,
-            @JsonProperty("currentPipelineIndex") int currentPipelineIndex) {
+            @JsonProperty("currentPipelineIndex") int currentPipelineIndex,
+            @JsonProperty("usbVID") int usbVID,
+            @JsonProperty("usbPID") int usbPID
+            ) {
         this.baseName = baseName;
         this.uniqueName = uniqueName;
         this.nickname = nickname;
@@ -108,6 +144,8 @@ public class CameraConfiguration {
         this.cameraQuirks = cameraQuirks;
         this.calibrations = calibrations != null ? calibrations : new ArrayList<>();
         this.currentPipelineIndex = currentPipelineIndex;
+        this.usbPID = usbPID
+        ; this.usbVID = usbVID;
 
         logger.debug(
                 "Creating camera configuration for "
@@ -154,6 +192,17 @@ public class CameraConfiguration {
                 .findAny()
                 .ifPresent(calibrations::remove);
         calibrations.add(calibration);
+    }
+
+    /**
+     * Get a unique descriptor of the USB port this camera is attached to. EG 
+     * "/dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0"
+     * @return
+     */
+    @JsonIgnore
+    public Optional<String> getUSBPath() {
+        return Arrays.stream(otherPaths).filter(path -> path.contains("/by-path/"))
+            .findFirst(); 
     }
 
     @Override

--- a/photon-core/src/main/java/org/photonvision/common/configuration/HardwareSettings.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/HardwareSettings.java
@@ -30,15 +30,11 @@ public class HardwareSettings {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
         HardwareSettings other = (HardwareSettings) obj;
-        if (ledBrightnessPercentage != other.ledBrightnessPercentage)
-            return false;
+        if (ledBrightnessPercentage != other.ledBrightnessPercentage) return false;
         return true;
     }
 

--- a/photon-core/src/main/java/org/photonvision/common/configuration/HardwareSettings.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/HardwareSettings.java
@@ -21,6 +21,28 @@ public class HardwareSettings {
     public int ledBrightnessPercentage = 100;
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ledBrightnessPercentage;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HardwareSettings other = (HardwareSettings) obj;
+        if (ledBrightnessPercentage != other.ledBrightnessPercentage)
+            return false;
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "HardwareSettings [ledBrightnessPercentage=" + ledBrightnessPercentage + "]";
     }

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -40,7 +40,8 @@ public class NetworkConfig {
     public boolean shouldPublishProto = false;
 
     /**
-     * If we should ONLY match cameras by path, and NEVER only by base-name. For now default to false to preserve old matching logic
+     * If we should ONLY match cameras by path, and NEVER only by base-name. For now default to false
+     * to preserve old matching logic
      */
     public boolean matchCamerasOnlyByPath = false;
 

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -39,6 +39,11 @@ public class NetworkConfig {
     public boolean shouldManage;
     public boolean shouldPublishProto = false;
 
+    /**
+     * If we should ONLY match cameras by path, and NEVER only by base-name. For now default to false to preserve old matching logic
+     */
+    public boolean matchCamerasOnlyByPath = false;
+
     @JsonIgnore public static final String NM_IFACE_STRING = "${interface}";
     @JsonIgnore public static final String NM_IP_STRING = "${ipaddr}";
 
@@ -76,7 +81,8 @@ public class NetworkConfig {
             @JsonProperty("shouldPublishProto") boolean shouldPublishProto,
             @JsonProperty("networkManagerIface") String networkManagerIface,
             @JsonProperty("setStaticCommand") String setStaticCommand,
-            @JsonProperty("setDHCPcommand") String setDHCPcommand) {
+            @JsonProperty("setDHCPcommand") String setDHCPcommand,
+            @JsonProperty("matchCamerasOnlyByPath") boolean matchCamerasOnlyByPath) {
         this.ntServerAddress = ntServerAddress;
         this.connectionType = connectionType;
         this.staticIp = staticIp;
@@ -86,6 +92,7 @@ public class NetworkConfig {
         this.networkManagerIface = networkManagerIface;
         this.setStaticCommand = setStaticCommand;
         this.setDHCPcommand = setDHCPcommand;
+        this.matchCamerasOnlyByPath = matchCamerasOnlyByPath;
         setShouldManage(shouldManage);
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
@@ -70,13 +70,13 @@ public class CameraInfo extends UsbCameraInfo {
     }
 
     /**
-     * Get a unique descriptor of the USB port this camera is attached to. EG 
+     * Get a unique descriptor of the USB port this camera is attached to. EG
      * "/dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0"
+     *
      * @return
      */
     public Optional<String> getUSBPath() {
-        return Arrays.stream(otherPaths).filter(path -> path.contains("/by-path/"))
-            .findFirst(); 
+        return Arrays.stream(otherPaths).filter(path -> path.contains("/by-path/")).findFirst();
     }
 
     @Override

--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
@@ -19,6 +19,7 @@ package org.photonvision.vision.camera;
 
 import edu.wpi.first.cscore.UsbCameraInfo;
 import java.util.Arrays;
+import java.util.Optional;
 
 public class CameraInfo extends UsbCameraInfo {
     public final CameraType cameraType;
@@ -66,6 +67,16 @@ public class CameraInfo extends UsbCameraInfo {
      */
     public String getHumanReadableName() {
         return getBaseName().replaceAll(" ", "_");
+    }
+
+    /**
+     * Get a unique descriptor of the USB port this camera is attached to. EG 
+     * "/dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0"
+     * @return
+     */
+    public Optional<String> getUSBPath() {
+        return Arrays.stream(otherPaths).filter(path -> path.contains("/by-path/"))
+            .findFirst(); 
     }
 
     @Override

--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
@@ -90,4 +90,19 @@ public class CameraInfo extends UsbCameraInfo {
                 && productId == other.productId
                 && vendorId == other.vendorId;
     }
+
+    @Override
+    public String toString() {
+        return "CameraInfo [cameraType="
+                + cameraType
+                + "baseName="
+                + getBaseName()
+                + "vid="
+                + vendorId
+                + "pid="
+                + productId
+                + "otherPaths="
+                + Arrays.toString(otherPaths)
+                + "]";
+    }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
@@ -97,11 +97,11 @@ public class CameraInfo extends UsbCameraInfo {
                 + cameraType
                 + "baseName="
                 + getBaseName()
-                + "vid="
+                + ", vid="
                 + vendorId
-                + "pid="
+                + ", pid="
                 + productId
-                + "otherPaths="
+                + ", otherPaths="
                 + Arrays.toString(otherPaths)
                 + "]";
     }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -49,7 +49,11 @@ public class USBCameraSource extends VisionSource {
         super(config);
 
         logger = new Logger(USBCameraSource.class, config.nickname, LogGroup.Camera);
-        camera = new UsbCamera(config.nickname, config.path);
+        // cscore will auto-reconnect to the camera path we give it. v4l does not guarantee that if i
+        // swap cameras around, the same /dev/videoN ID will be assigned to that camera. So instead
+        // default to pinning to a particular USB port, or by "path" (appears to be a global identifier)
+        // on Windows.
+        camera = new UsbCamera(config.nickname, config.getUSBPath().orElse(config.path));
         cvSink = CameraServer.getVideo(this.camera);
 
         // set vid/pid if not done already for future matching

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -52,6 +52,10 @@ public class USBCameraSource extends VisionSource {
         camera = new UsbCamera(config.nickname, config.path);
         cvSink = CameraServer.getVideo(this.camera);
 
+        // set vid/pid if not done already for future matching
+        if (config.usbVID < 0) config.usbVID = this.camera.getInfo().vendorId;
+        if (config.usbPID < 0) config.usbPID = this.camera.getInfo().productId;
+
         if (getCameraConfiguration().cameraQuirks == null)
             getCameraConfiguration().cameraQuirks =
                     QuirkyCamera.getQuirkyCamera(

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -233,24 +233,35 @@ public class VisionSourceManager {
         ArrayList<CameraConfiguration> unloadedConfigs =
                 new ArrayList<CameraConfiguration>(loadedCamConfigs);
 
-        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0)
+        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) 
+        {
+            logger.info("Matching by usb port & name...");
             cameraConfigurations.addAll(matchByPathAndName(detectedCameraList, unloadedConfigs));
-        else logger.debug("Skipping matchByPath no configs or cameras left to match");
+        }
+        else logger.debug("Skipping matchByPathAndName, no configs or cameras left to match");
 
         if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0)
+        {
+            logger.info("Matching by usb port & USB VID/PID...");
             cameraConfigurations.addAll(matchByPathAndVIDPID(detectedCameraList, unloadedConfigs));
-        else logger.debug("Skipping matchByPath no configs or cameras left to match");
+        }
+        else logger.debug("Skipping match by port/vid/pid, no configs or cameras left to match");
 
         // handle disabling only-by-base-name matching
         if (!ConfigManager.getInstance().getConfig().getNetworkConfig().matchCamerasOnlyByPath) {
             if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0)
+            {
+                logger.info("Matching by base-name ONLY...");
                 cameraConfigurations.addAll(matchByBaseName(detectedCameraList, unloadedConfigs));
-            else logger.debug("Skipping matchByName no configs or cameras left to match");
-        } else logger.debug("Skipping matchByName, disabled by user");
+            }
+            else logger.debug("Skipping matchByName, no configs or cameras left to match");
+        } else logger.info("Skipping matchByName, disabled by user");
 
         if (detectedCameraList.size() > 0)
+            {
             cameraConfigurations.addAll(
                     createConfigsForCameras(detectedCameraList, unloadedConfigs, cameraConfigurations));
+        }
 
         logger.debug("Matched or created " + cameraConfigurations.size() + " camera configs!");
         return cameraConfigurations;

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -431,7 +431,7 @@ public class VisionSourceManager {
             String uniqueName = info.getHumanReadableName();
 
             int suffix = 0;
-            while (containsName(loadedConfigs, uniqueName) || containsName(uniqueName)) {
+            while (containsName(loadedConfigs, uniqueName) || containsName(uniqueName) || containsName(loadedCamConfigs, uniqueName)) {
                 suffix++;
                 uniqueName = String.format("%s (%d)", uniqueName, suffix);
             }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -269,7 +269,6 @@ public class VisionSourceManager {
      *
      * @param detectedCamInfos Information about currently connected USB cameras.
      * @param loadedCamConfigs The USB {@link CameraConfiguration}s loaded from disk.
-     * @param matchCamerasOnlyByPath If we should never try to match only by (base name, vid, pid)
      * @return the matched configurations.
      */
     public List<CameraConfiguration> matchCameras(

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -420,7 +420,7 @@ public class VisionSourceManager {
     // them here.
     private List<CameraConfiguration> createConfigsForCameras(
             List<CameraInfo> detectedCameraList,
-            List<CameraConfiguration> loadedCamConfigs,
+            List<CameraConfiguration> unloadedCamConfigs,
             List<CameraConfiguration> loadedConfigs) {
         List<CameraConfiguration> ret = new ArrayList<CameraConfiguration>();
         logger.debug(
@@ -431,7 +431,7 @@ public class VisionSourceManager {
             String uniqueName = info.getHumanReadableName();
 
             int suffix = 0;
-            while (containsName(loadedConfigs, uniqueName) || containsName(uniqueName) || containsName(loadedCamConfigs, uniqueName)) {
+            while (containsName(loadedConfigs, uniqueName) || containsName(uniqueName) || containsName(unloadedCamConfigs, uniqueName)) {
                 suffix++;
                 uniqueName = String.format("%s (%d)", uniqueName, suffix);
             }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -234,7 +234,6 @@ public class VisionSourceManager {
             boolean checkVidPid,
             boolean checkBaseName,
             boolean checkPath) {
-
         if (checkUSBPath && savedConfig.getUSBPath().isEmpty()) {
             logger.debug(
                     "WARN: Camera has empty USB path, but asked to match by name: "
@@ -319,7 +318,20 @@ public class VisionSourceManager {
             logger.info("Matching by usb port & name & USB VID/PID...");
             cameraConfigurations.addAll(
                     matchCamerasByStrategy(detectedCameraList, unloadedConfigs, true, true, true, false));
-        } else logger.debug("Skipping matchByPathAndName, no configs or cameras left to match");
+        } else
+            logger.debug("Skipping match by usb port/name/vid/pid, no configs or cameras left to match");
+
+        // On windows, the v4l path is actually useful and tells us the port the camera is physically
+        // connected to which is neat
+        if (Platform.isWindows()) {
+            if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
+                logger.info("Matching by windows-path & USB VID/PID only...");
+                cameraConfigurations.addAll(
+                        matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, true));
+            } else
+                logger.debug(
+                        "Skipping matching by windiws-path/name/vid/pid, no configs or cameras left to match");
+        }
 
         if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
             logger.info("Matching by usb port & USB VID/PID...");
@@ -335,12 +347,6 @@ public class VisionSourceManager {
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, false));
             } else
                 logger.debug("Skipping match by base-name/viid/pid, no configs or cameras left to match");
-
-            if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
-                logger.info("Matching by v4l-path & USB VID/PID only...");
-                cameraConfigurations.addAll(
-                        matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, false, true));
-            } else logger.debug("Skipping matchByName, no configs or cameras left to match");
         } else logger.info("Skipping match by filepath/vid/pid, disabled by user");
 
         if (detectedCameraList.size() > 0) {
@@ -373,7 +379,6 @@ public class VisionSourceManager {
             boolean checkVidPid,
             boolean checkBaseName,
             boolean checkPath) {
-
         List<CameraConfiguration> ret = new ArrayList<CameraConfiguration>();
         List<CameraConfiguration> unloadedConfigsCopy =
                 new ArrayList<CameraConfiguration>(unloadedConfigs);

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -27,7 +27,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.photonvision.common.configuration.CameraConfiguration;
 import org.photonvision.common.configuration.ConfigManager;
-import org.photonvision.common.configuration.PhotonConfiguration;
 import org.photonvision.common.dataflow.DataChangeService;
 import org.photonvision.common.dataflow.events.OutgoingUIEvent;
 import org.photonvision.common.hardware.Platform;
@@ -233,33 +232,25 @@ public class VisionSourceManager {
         ArrayList<CameraConfiguration> unloadedConfigs =
                 new ArrayList<CameraConfiguration>(loadedCamConfigs);
 
-        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) 
-        {
+        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
             logger.info("Matching by usb port & name...");
             cameraConfigurations.addAll(matchByPathAndName(detectedCameraList, unloadedConfigs));
-        }
-        else logger.debug("Skipping matchByPathAndName, no configs or cameras left to match");
+        } else logger.debug("Skipping matchByPathAndName, no configs or cameras left to match");
 
-        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0)
-        {
+        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
             logger.info("Matching by usb port & USB VID/PID...");
             cameraConfigurations.addAll(matchByPathAndVIDPID(detectedCameraList, unloadedConfigs));
-        }
-        else logger.debug("Skipping match by port/vid/pid, no configs or cameras left to match");
+        } else logger.debug("Skipping match by port/vid/pid, no configs or cameras left to match");
 
         // handle disabling only-by-base-name matching
-        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0)
-        {
+        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
             if (!ConfigManager.getInstance().getConfig().getNetworkConfig().matchCamerasOnlyByPath) {
                 logger.info("Matching by base-name ONLY...");
                 cameraConfigurations.addAll(matchByBaseName(detectedCameraList, unloadedConfigs));
-            }
-            else logger.info("Skipping matchByName, disabled by user");
-        } 
-        else logger.debug("Skipping matchByName, no configs or cameras left to match");
+            } else logger.info("Skipping matchByName, disabled by user");
+        } else logger.debug("Skipping matchByName, no configs or cameras left to match");
 
-        if (detectedCameraList.size() > 0)
-            {
+        if (detectedCameraList.size() > 0) {
             cameraConfigurations.addAll(
                     createConfigsForCameras(detectedCameraList, unloadedConfigs, cameraConfigurations));
         }
@@ -269,7 +260,10 @@ public class VisionSourceManager {
     }
 
     /**
-     * Match cameras using linux USB port path and by base name (USB product string, including renaming if applied by arducam renamer utility). This should allow multiple usb cameras with the same name to still be matched (which is why I avoid /dev/v4l/by-id)
+     * Match cameras using linux USB port path and by base name (USB product string, including
+     * renaming if applied by arducam renamer utility). This should allow multiple usb cameras with
+     * the same name to still be matched (which is why I avoid /dev/v4l/by-id)
+     *
      * @param detectedCamInfos
      * @param unloadedConfigs
      * @return
@@ -296,20 +290,21 @@ public class VisionSourceManager {
                     var path = pathOpt.get();
 
                     logger.debug(
-                            String.format("Trying to find a match for loaded camera "
-                                    + config.baseName
-                                    + " with USB path,basename "
-                                    + path + ", " + config.baseName));
-                    
-                    // want: usb port path, base name, to match
-                    Predicate<CameraInfo> matches = (CameraInfo physicalCamera) -> physicalCamera.getUSBPath().equals(config.getUSBPath()) && 
-                        physicalCamera.getBaseName().equals(config.baseName);
+                            String.format(
+                                    "Trying to find a match for loaded camera "
+                                            + config.baseName
+                                            + " with USB path,basename "
+                                            + path
+                                            + ", "
+                                            + config.baseName));
 
-                    cameraInfo =
-                            detectedCamInfos.stream()
-                                    .filter(matches)
-                                    .findFirst()
-                                    .orElse(null);
+                    // want: usb port path, base name, to match
+                    Predicate<CameraInfo> matches =
+                            (CameraInfo physicalCamera) ->
+                                    physicalCamera.getUSBPath().equals(config.getUSBPath())
+                                            && physicalCamera.getBaseName().equals(config.baseName);
+
+                    cameraInfo = detectedCamInfos.stream().filter(matches).findFirst().orElse(null);
 
                     // If we actually matched a camera to a config, remove that camera from the list
                     // and add it to the output
@@ -328,7 +323,9 @@ public class VisionSourceManager {
     }
 
     /**
-     * Match cameras using linux USB port path and by USB VID/PID. This would mean that an identical model of camera plugged into the same USB port would be matched even if the product string differs.
+     * Match cameras using linux USB port path and by USB VID/PID. This would mean that an identical
+     * model of camera plugged into the same USB port would be matched even if the product string
+     * differs.
      */
     private List<CameraConfiguration> matchByPathAndVIDPID(
             List<CameraInfo> detectedCamInfos, List<CameraConfiguration> unloadedConfigs) {
@@ -352,21 +349,26 @@ public class VisionSourceManager {
                     var path = pathOpt.get();
 
                     logger.debug(
-                            String.format("Trying to find a match for loaded camera "
-                                    + config.baseName
-                                    + " with USB path,basename,vid,pid "
-                                    + path + ", " + config.baseName + "," + config.usbVID + "," +config.usbPID));
-                    
-                    // want: usb port path, base name, to match
-                    Predicate<CameraInfo> matches = (CameraInfo physicalCamera) -> physicalCamera.getUSBPath().equals(config.getUSBPath()) && 
-                        physicalCamera.vendorId == config.usbVID && 
-                        physicalCamera.productId == config.usbPID;
+                            String.format(
+                                    "Trying to find a match for loaded camera "
+                                            + config.baseName
+                                            + " with USB path,basename,vid,pid "
+                                            + path
+                                            + ", "
+                                            + config.baseName
+                                            + ","
+                                            + config.usbVID
+                                            + ","
+                                            + config.usbPID));
 
-                    cameraInfo =
-                            detectedCamInfos.stream()
-                                    .filter(matches)
-                                    .findFirst()
-                                    .orElse(null);
+                    // want: usb port path, base name, to match
+                    Predicate<CameraInfo> matches =
+                            (CameraInfo physicalCamera) ->
+                                    physicalCamera.getUSBPath().equals(config.getUSBPath())
+                                            && physicalCamera.vendorId == config.usbVID
+                                            && physicalCamera.productId == config.usbPID;
+
+                    cameraInfo = detectedCamInfos.stream().filter(matches).findFirst().orElse(null);
 
                     // If we actually matched a camera to a config, remove that camera from the list
                     // and add it to the output
@@ -431,7 +433,9 @@ public class VisionSourceManager {
             String uniqueName = info.getHumanReadableName();
 
             int suffix = 0;
-            while (containsName(loadedConfigs, uniqueName) || containsName(uniqueName) || containsName(unloadedCamConfigs, uniqueName)) {
+            while (containsName(loadedConfigs, uniqueName)
+                    || containsName(uniqueName)
+                    || containsName(unloadedCamConfigs, uniqueName)) {
                 suffix++;
                 uniqueName = String.format("%s (%d)", uniqueName, suffix);
             }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -248,14 +248,15 @@ public class VisionSourceManager {
         else logger.debug("Skipping match by port/vid/pid, no configs or cameras left to match");
 
         // handle disabling only-by-base-name matching
-        if (!ConfigManager.getInstance().getConfig().getNetworkConfig().matchCamerasOnlyByPath) {
-            if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0)
-            {
+        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0)
+        {
+            if (!ConfigManager.getInstance().getConfig().getNetworkConfig().matchCamerasOnlyByPath) {
                 logger.info("Matching by base-name ONLY...");
                 cameraConfigurations.addAll(matchByBaseName(detectedCameraList, unloadedConfigs));
             }
-            else logger.debug("Skipping matchByName, no configs or cameras left to match");
-        } else logger.info("Skipping matchByName, disabled by user");
+            else logger.info("Skipping matchByName, disabled by user");
+        } 
+        else logger.debug("Skipping matchByName, no configs or cameras left to match");
 
         if (detectedCameraList.size() > 0)
             {
@@ -317,6 +318,8 @@ public class VisionSourceManager {
                         ret.add(mergeInfoIntoConfig(config, cameraInfo));
                         detectedCamInfos.remove(cameraInfo);
                         unloadedConfigs.remove(config);
+                    } else {
+                        logger.debug("No camera found for the config " + config.baseName);
                     }
                 }
             }
@@ -372,6 +375,8 @@ public class VisionSourceManager {
                         ret.add(mergeInfoIntoConfig(config, cameraInfo));
                         detectedCamInfos.remove(cameraInfo);
                         unloadedConfigs.remove(config);
+                    } else {
+                        logger.debug("No camera found for the config " + config.baseName);
                     }
                 }
             }
@@ -404,6 +409,8 @@ public class VisionSourceManager {
                 ret.add(mergeInfoIntoConfig(config, cameraInfo));
                 detectedCamInfos.remove(cameraInfo);
                 unloadedConfigs.remove(config);
+            } else {
+                logger.debug("No camera found for the config " + config.baseName);
             }
         }
         return ret;

--- a/photon-core/src/test/java/org/photonvision/common/configuration/ConfigTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/configuration/ConfigTest.java
@@ -139,8 +139,29 @@ public class ConfigTest {
         writer.write(str);
         writer.flush();
         writer.close();
-        Assertions.assertDoesNotThrow(
-                () -> JacksonUtils.deserialize(tempFile.toPath(), CameraConfiguration.class));
+        CameraConfiguration result = JacksonUtils.deserialize(tempFile.toPath(), CameraConfiguration.class);
+
+        tempFile.delete();
+    }
+
+    @Test
+    public void testJacksonAddUSBVIDPID() throws IOException {
+        var str =
+                "{\"baseName\":\"aaaaaa\",\"uniqueName\":\"aaaaaa\",\"nickname\":\"aaaaaa\",\"FOV\":70.0,\"path\":\"dev/vid\",\"cameraType\":\"UsbCamera\",\"currentPipelineIndex\":0,\"camPitch\":{\"radians\":0.0},\"calibrations\":[], \"usbVID\":3, \"usbPID\":4, \"cameraLEDs\":[]}";
+        File tempFile = File.createTempFile("test", ".json");
+        tempFile.deleteOnExit();
+        var writer = new FileWriter(tempFile);
+        writer.write(str);
+        writer.flush();
+        writer.close();
+        
+        try {
+                CameraConfiguration result = JacksonUtils.deserialize(tempFile.toPath(), CameraConfiguration.class);
+                String ser = JacksonUtils.serializeToString(result); 
+                System.out.println(ser);
+        } catch (Exception e) {
+                e.printStackTrace();
+        }
 
         tempFile.delete();
     }

--- a/photon-core/src/test/java/org/photonvision/common/configuration/ConfigTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/configuration/ConfigTest.java
@@ -139,7 +139,8 @@ public class ConfigTest {
         writer.write(str);
         writer.flush();
         writer.close();
-        CameraConfiguration result = JacksonUtils.deserialize(tempFile.toPath(), CameraConfiguration.class);
+        CameraConfiguration result =
+                JacksonUtils.deserialize(tempFile.toPath(), CameraConfiguration.class);
 
         tempFile.delete();
     }
@@ -154,13 +155,14 @@ public class ConfigTest {
         writer.write(str);
         writer.flush();
         writer.close();
-        
+
         try {
-                CameraConfiguration result = JacksonUtils.deserialize(tempFile.toPath(), CameraConfiguration.class);
-                String ser = JacksonUtils.serializeToString(result); 
-                System.out.println(ser);
+            CameraConfiguration result =
+                    JacksonUtils.deserialize(tempFile.toPath(), CameraConfiguration.class);
+            String ser = JacksonUtils.serializeToString(result);
+            System.out.println(ser);
         } catch (Exception e) {
-                e.printStackTrace();
+            e.printStackTrace();
         }
 
         tempFile.delete();

--- a/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
@@ -84,7 +84,7 @@ public class SQLConfigTest {
                         CameraType.UsbCamera,
                         QuirkyCamera.getQuirkyCamera(-1, -1),
                         List.of(),
-                        0);
+                        0, -1, -1);
         testcamcfg.pipelineSettings =
                 List.of(
                         new ReflectivePipelineSettings(),

--- a/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
@@ -84,7 +84,9 @@ public class SQLConfigTest {
                         CameraType.UsbCamera,
                         QuirkyCamera.getQuirkyCamera(-1, -1),
                         List.of(),
-                        0, -1, -1);
+                        0,
+                        -1,
+                        -1);
         testcamcfg.pipelineSettings =
                 List.of(
                         new ReflectivePipelineSettings(),

--- a/photon-core/src/test/java/org/photonvision/vision/processes/VisionSourceManagerTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/processes/VisionSourceManagerTest.java
@@ -24,14 +24,20 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import org.photonvision.common.configuration.CameraConfiguration;
 import org.photonvision.common.configuration.ConfigManager;
+import org.photonvision.common.logging.LogGroup;
+import org.photonvision.common.logging.LogLevel;
+import org.photonvision.common.logging.Logger;
 import org.photonvision.vision.camera.CameraInfo;
 import org.photonvision.vision.camera.CameraType;
 
 public class VisionSourceManagerTest {
     @Test
     public void visionSourceTest() {
+        Logger.setLevel(LogGroup.Camera, LogLevel.DEBUG);
+
         var inst = new VisionSourceManager();
         var cameraInfos = new ArrayList<CameraInfo>();
+        ConfigManager.getInstance().clearConfig();
         ConfigManager.getInstance().load();
 
         inst.tryMatchCamImpl(cameraInfos);
@@ -43,6 +49,8 @@ public class VisionSourceManagerTest {
                         "thirdTestVideo",
                         "dev/video1",
                         new String[] {"by-id/123"});
+        config3.usbVID = 3;
+        config3.usbPID = 4;
         var config4 =
                 new CameraConfiguration(
                         "fourthTestVideo",
@@ -50,6 +58,8 @@ public class VisionSourceManagerTest {
                         "fourthTestVideo",
                         "dev/video2",
                         new String[] {"by-id/321"});
+        config4.usbVID = 5;
+        config4.usbPID = 6;
 
         CameraInfo info1 = new CameraInfo(0, "dev/video0", "testVideo", new String[0], 1, 2);
 


### PR DESCRIPTION
Our current code matches cameras in this order (which I think is objectively wrong and stupid)

- by-id (/dev/v4l/by-id/product-string)
- by path (/dev/videoN)
- product string/name, but ascii only
- asks cscore to reconnect to cameras using `path`, which on linux is actually /dev/videoN. This isn't guaranteed to stick to a camera if you replug them weirdly at runtime.

This is silly and does not consider the actual physical usb port. I propose instead, in this order:

- By physical usb port path and base name
- by physical usb port path and USB VID/PID
- By base name only (with a toggle switch to disable this, and create a new VisionModule instead)
- Give cscore /dev/video/by-path on Linux systems, pinning Photon USBCameras to a particular usb port once created.