### PR TITLE
Add matching by base-name only (fused off by only by path)

### DIFF
--- a/photon-client/src/components/settings/NetworkingCard.vue
+++ b/photon-client/src/components/settings/NetworkingCard.vue
@@ -281,11 +281,29 @@ watchEffect(() => {
         </v-banner>
         <pv-switch
           v-model="tempSettingsStruct.matchCamerasOnlyByPath"
-          label="Match cameras by-path ONLY"
-          tooltip="ONLY match cameras by the USB port they're plugged into + (basename or USB VID/PID), and never only by the device product string"
+          label="Strictly match ONLY known cameras"
+          tooltip="ONLY match cameras by the USB port they're plugged into + (basename or USB VID/PID), and never only by the device product string. Also disables automatic detection of new cameras."
           class="mt-3 mb-2"
           :label-cols="4"
         />
+        <v-banner
+          v-show="tempSettingsStruct.matchCamerasOnlyByPath"
+          rounded
+          color="red"
+          class="mb-3"
+          text-color="white"
+          icon="mdi-information-outline"
+        >
+          Physical cameras will be strictly matched to camera configurations using physical USB port they are plugged
+          into, in addition to device name and other USB metadata. Additionally, no new cameras are allowed to be added.
+          This setting is useful for guaranteeing that an already known and configured camera can never be matched as an
+          "unknown"/"new" camera, which resets pipelines and calibration data.
+          <p />
+          Cameras will NOT be matched if they change USB ports, and new cameras plugged into this coprocessor will NOT
+          be automatically recognized or configured for vision processing.
+          <p />
+          To add a new camera to this coprocessor, disable this setting, connect the camera, and re-enable.
+        </v-banner>
         <v-divider class="mb-3" />
       </v-form>
       <v-btn

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -41,7 +41,9 @@ public class NetworkConfig {
 
     /**
      * If we should ONLY match cameras by path, and NEVER only by base-name. For now default to false
-     * to preserve old matching logic
+     * to preserve old matching logic.
+     *
+     * <p>This also disables creating new CameraConfigurations for detected "new" cameras.
      */
     public boolean matchCamerasOnlyByPath = false;
 

--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
@@ -101,6 +101,8 @@ public class CameraInfo extends UsbCameraInfo {
                 + vendorId
                 + ", pid="
                 + productId
+                + ", path="
+                + path
                 + ", otherPaths="
                 + Arrays.toString(otherPaths)
                 + "]";

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameraSource.java
@@ -57,8 +57,8 @@ public class USBCameraSource extends VisionSource {
         cvSink = CameraServer.getVideo(this.camera);
 
         // set vid/pid if not done already for future matching
-        if (config.usbVID < 0) config.usbVID = this.camera.getInfo().vendorId;
-        if (config.usbPID < 0) config.usbPID = this.camera.getInfo().productId;
+        if (config.usbVID <= 0) config.usbVID = this.camera.getInfo().vendorId;
+        if (config.usbPID <= 0) config.usbPID = this.camera.getInfo().productId;
 
         if (getCameraConfiguration().cameraQuirks == null)
             getCameraConfiguration().cameraQuirks =

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -317,8 +317,7 @@ public class VisionSourceManager {
             logger.info("Matching by usb port & name & USB VID/PID...");
             cameraConfigurations.addAll(
                     matchCamerasByStrategy(detectedCameraList, unloadedConfigs, true, true, true, false));
-        } else
-            logger.debug("Skipping match by usb port/name/vid/pid, no configs or cameras left to match");
+        }
 
         // On windows, the v4l path is actually useful and tells us the port the camera is physically
         // connected to which is neat
@@ -327,16 +326,22 @@ public class VisionSourceManager {
                 logger.info("Matching by windows-path & USB VID/PID only...");
                 cameraConfigurations.addAll(
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, true));
-            } else
-                logger.debug(
-                        "Skipping matching by windiws-path/name/vid/pid, no configs or cameras left to match");
+            } 
         }
 
         if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
             logger.info("Matching by usb port & USB VID/PID...");
             cameraConfigurations.addAll(
                     matchCamerasByStrategy(detectedCameraList, unloadedConfigs, true, true, false, false));
-        } else logger.debug("Skipping match by port/vid/pid, no configs or cameras left to match");
+        } 
+
+        // Legacy migration -- VID/PID will be unset, so we have to try with our most relaxed strategy
+        // at least once. We _should_ still have a valid USB path (assuming cameras have not moved), so try that first, then fallback to base name only beloow
+        if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
+            logger.info("Matching by base-name & usb port...");
+            cameraConfigurations.addAll(
+                    matchCamerasByStrategy(detectedCameraList, unloadedConfigs, true, false, true, false));
+        }
 
         // handle disabling only-by-base-name matching
         if (!matchCamerasOnlyByPath) {
@@ -344,16 +349,14 @@ public class VisionSourceManager {
                 logger.info("Matching by base-name & USB VID/PID only...");
                 cameraConfigurations.addAll(
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, false));
-            } else
-                logger.debug("Skipping match by base-name/vid/pid, no configs or cameras left to match");
+            } 
 
-            // Legacy migration -- VID/PID will be unset, so we have to try with our most relaxed strategy
-            // at least once
+            // Legacy migration for if no USB VID/PID set
             if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
-                logger.info("Matching by base-name & USB VID/PID only...");
+                logger.info("Matching by base-name only...");
                 cameraConfigurations.addAll(
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, false, true, false));
-            } else logger.debug("Skipping match by base-name ONLY, no configs or cameras left to match");
+            }
         } else logger.info("Skipping match by filepath/vid/pid, disabled by user");
 
         if (detectedCameraList.size() > 0) {

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -361,8 +361,18 @@ public class VisionSourceManager {
         } else logger.info("Skipping match by filepath/vid/pid, disabled by user");
 
         if (detectedCameraList.size() > 0) {
-            cameraConfigurations.addAll(
-                    createConfigsForCameras(detectedCameraList, unloadedConfigs, cameraConfigurations));
+            // handle disabling only-by-base-name matching
+            if (!matchCamerasOnlyByPath) {
+                cameraConfigurations.addAll(
+                        createConfigsForCameras(detectedCameraList, unloadedConfigs, cameraConfigurations));
+            } else {
+                logger.warn(
+                        "Not creating 'new' Photon CameraConfigurations for ["
+                                + detectedCamInfos.stream()
+                                        .map(CameraInfo::toString)
+                                        .collect(Collectors.joining(";"))
+                                + "], disabled by user");
+            }
         }
 
         logger.debug("Matched or created " + cameraConfigurations.size() + " camera configs!");

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -345,7 +345,15 @@ public class VisionSourceManager {
                 cameraConfigurations.addAll(
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, false));
             } else
-                logger.debug("Skipping match by base-name/viid/pid, no configs or cameras left to match");
+                logger.debug("Skipping match by base-name/vid/pid, no configs or cameras left to match");
+            
+            // Legacy migration -- VID/PID will be unset, so we have to try with our most relaxed strategy at least once
+            if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
+                logger.info("Matching by base-name & USB VID/PID only...");
+                cameraConfigurations.addAll(
+                        matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, false, true, false));
+            } else
+                logger.debug("Skipping match by base-name ONLY, no configs or cameras left to match");
         } else logger.info("Skipping match by filepath/vid/pid, disabled by user");
 
         if (detectedCameraList.size() > 0) {

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -326,17 +326,18 @@ public class VisionSourceManager {
                 logger.info("Matching by windows-path & USB VID/PID only...");
                 cameraConfigurations.addAll(
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, true));
-            } 
+            }
         }
 
         if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
             logger.info("Matching by usb port & USB VID/PID...");
             cameraConfigurations.addAll(
                     matchCamerasByStrategy(detectedCameraList, unloadedConfigs, true, true, false, false));
-        } 
+        }
 
         // Legacy migration -- VID/PID will be unset, so we have to try with our most relaxed strategy
-        // at least once. We _should_ still have a valid USB path (assuming cameras have not moved), so try that first, then fallback to base name only beloow
+        // at least once. We _should_ still have a valid USB path (assuming cameras have not moved), so
+        // try that first, then fallback to base name only beloow
         if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
             logger.info("Matching by base-name & usb port...");
             cameraConfigurations.addAll(
@@ -349,7 +350,7 @@ public class VisionSourceManager {
                 logger.info("Matching by base-name & USB VID/PID only...");
                 cameraConfigurations.addAll(
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, false));
-            } 
+            }
 
             // Legacy migration for if no USB VID/PID set
             if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -346,14 +346,14 @@ public class VisionSourceManager {
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, true, true, false));
             } else
                 logger.debug("Skipping match by base-name/vid/pid, no configs or cameras left to match");
-            
-            // Legacy migration -- VID/PID will be unset, so we have to try with our most relaxed strategy at least once
+
+            // Legacy migration -- VID/PID will be unset, so we have to try with our most relaxed strategy
+            // at least once
             if (detectedCameraList.size() > 0 || unloadedConfigs.size() > 0) {
                 logger.info("Matching by base-name & USB VID/PID only...");
                 cameraConfigurations.addAll(
                         matchCamerasByStrategy(detectedCameraList, unloadedConfigs, false, false, true, false));
-            } else
-                logger.debug("Skipping match by base-name ONLY, no configs or cameras left to match");
+            } else logger.debug("Skipping match by base-name ONLY, no configs or cameras left to match");
         } else logger.info("Skipping match by filepath/vid/pid, disabled by user");
 
         if (detectedCameraList.size() > 0) {


### PR DESCRIPTION
When migrating from 2024.2.5 to 6, VID/PID will not be set causing matching to never succeed. New matching output:

```
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [INFO] Detected unmatched physical camera: CameraInfo [cameraType=UsbCamerabaseName=HD Pro Webcam C920, vid=1133, pid=2277, otherPaths=[/dev/v4l/by-id/usb-046d_HD_Pro_Webcam_C920_1AA0F86F-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0]]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [INFO] Detected unmatched physical camera: CameraInfo [cameraType=UsbCamerabaseName=Microsoft LifeCam HD-3000, vid=1118, pid=2064, otherPaths=[/dev/v4l/by-id/usb-Microsoft_Microsoft?_LifeCam_HD-3000-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.4:1.0-video-index0]]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to match 2 unmatched configs...
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [INFO] Matching by usb port & name & USB VID/PID...
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera HD Pro Webcam C920 by strategy (path true vid/pid true basename true path false) with camera config: [baseName=HD Pro Webcam C920, uniqueName=HD_Pro_Webcam_C920, otherPaths=[/dev/v4l/by-id/usb-046d_HD_Pro_Webcam_C920_1AA0F86F-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0], vid=0, pid=0]
[main] INFO io.javalin.Javalin - Listening on http://localhost:5800/
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] No camera found for the config HD Pro Webcam C920
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera Microsoft LifeCam HD-3000 by strategy (path true vid/pid true basename true path false) with camera config: [baseName=Microsoft LifeCam HD-3000, uniqueName=Microsoft_LifeCam_HD-3000, otherPaths=[/dev/v4l/by-id/usb-Microsoft_Microsoft?_LifeCam_HD-3000-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.4:1.0-video-index0], vid=0, pid=0]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] No camera found for the config Microsoft LifeCam HD-3000
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [INFO] Matching by usb port & USB VID/PID...
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera HD Pro Webcam C920 by strategy (path true vid/pid true basename false path false) with camera config: [baseName=HD Pro Webcam C920, uniqueName=HD_Pro_Webcam_C920, otherPaths=[/dev/v4l/by-id/usb-046d_HD_Pro_Webcam_C920_1AA0F86F-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0], vid=0, pid=0]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] No camera found for the config HD Pro Webcam C920
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera Microsoft LifeCam HD-3000 by strategy (path true vid/pid true basename false path false) with camera config: [baseName=Microsoft LifeCam HD-3000, uniqueName=Microsoft_LifeCam_HD-3000, otherPaths=[/dev/v4l/by-id/usb-Microsoft_Microsoft?_LifeCam_HD-3000-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.4:1.0-video-index0], vid=0, pid=0]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] No camera found for the config Microsoft LifeCam HD-3000
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [INFO] Matching by base-name & USB VID/PID only...
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera HD Pro Webcam C920 by strategy (path false vid/pid true basename true path false) with camera config: [baseName=HD Pro Webcam C920, uniqueName=HD_Pro_Webcam_C920, otherPaths=[/dev/v4l/by-id/usb-046d_HD_Pro_Webcam_C920_1AA0F86F-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0], vid=0, pid=0]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] No camera found for the config HD Pro Webcam C920
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera Microsoft LifeCam HD-3000 by strategy (path false vid/pid true basename true path false) with camera config: [baseName=Microsoft LifeCam HD-3000, uniqueName=Microsoft_LifeCam_HD-3000, otherPaths=[/dev/v4l/by-id/usb-Microsoft_Microsoft?_LifeCam_HD-3000-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.4:1.0-video-index0], vid=0, pid=0]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] No camera found for the config Microsoft LifeCam HD-3000
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [INFO] Matching by base-name & USB VID/PID only...
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera HD Pro Webcam C920 by strategy (path false vid/pid false basename true path false) with camera config: [baseName=HD Pro Webcam C920, uniqueName=HD_Pro_Webcam_C920, otherPaths=[/dev/v4l/by-id/usb-046d_HD_Pro_Webcam_C920_1AA0F86F-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0], vid=0, pid=0]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Matched the config for HD Pro Webcam C920 to a physical camera!
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Trying to find a match for loaded camera Microsoft LifeCam HD-3000 by strategy (path false vid/pid false basename true path false) with camera config: [baseName=Microsoft LifeCam HD-3000, uniqueName=Microsoft_LifeCam_HD-3000, otherPaths=[/dev/v4l/by-id/usb-Microsoft_Microsoft?_LifeCam_HD-3000-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.4:1.0-video-index0], vid=0, pid=0]
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Matched the config for Microsoft LifeCam HD-3000 to a physical camera!
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Matched or created 2 camera configs!
[2024-02-17 16:11:06] [Camera - VisionSourceManager] [DEBUG] Creating VisionSource for [baseName=HD Pro Webcam C920, uniqueName=HD_Pro_Webcam_C920, otherPaths=[/dev/v4l/by-id/usb-046d_HD_Pro_Webcam_C920_1AA0F86F-video-index0, /dev/v4l/by-path/platform-fc800000.usb-usb-0:1.3:1.0-video-index0], vid=0, pid=0]
```

Also makes the switch disable creation of new VisionModules
![image](https://github.com/PhotonVision/photonvision/assets/29715865/3e92524b-57ca-4ed8-b7f9-5cc2d2784b23)
![image](https://github.com/PhotonVision/photonvision/assets/29715865/21ba63bd-b1fe-4c28-b6d3-6668dccae850)

