### PR TITLE
Opencv cal: CALIB_USE_LU and use camera focal length guess

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipeline.java
@@ -36,6 +36,7 @@ import org.photonvision.vision.frame.FrameThresholdType;
 import org.photonvision.vision.opencv.CVMat;
 import org.photonvision.vision.opencv.ImageRotationMode;
 import org.photonvision.vision.pipe.CVPipe.CVPipeResult;
+import org.photonvision.vision.pipe.impl.Calibrate3dPipe.CalibrationInput;
 import org.photonvision.vision.pipe.impl.FindBoardCornersPipe.FindBoardCornersPipeResult;
 import org.photonvision.vision.pipeline.CVPipeline;
 import org.photonvision.vision.pipeline.Calibration3dPipelineSettings;
@@ -176,7 +177,8 @@ public class Calibrate3dPipeline
 
         /*Pass the board corners to the pipe, which will check again to see if all boards are valid
         and returns the corresponding image and object points*/
-        calibrationOutput = calibrate3dPipe.run(foundCornersList);
+        calibrationOutput =
+                calibrate3dPipe.run(new CalibrationInput(foundCornersList, frameStaticProperties));
 
         this.calibrating = false;
 

--- a/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
@@ -93,13 +93,6 @@ public class Calibrate3dPipeTest {
         calibrateSquaresCommon(dataset.size, dir, dataset.boardSize, useMrCal);
     }
 
-    @Test
-    public void testWillBoard() throws IOException {
-        String base = TestUtils.getSquaresBoardImagesPath().toAbsolutePath().toString();
-        File dir = Path.of("/home/matt/mrcal_will_debug/imgs/").toFile();
-        calibrateSquaresCommon(new Size(1600, 1200), dir, new Size(19, 14), true);
-    }
-
     public static void calibrateSquaresCommon(
             Size imgRes, File rootFolder, Size boardDim, boolean useMrCal) {
         calibrateSquaresCommon(

--- a/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
@@ -90,6 +91,13 @@ public class Calibrate3dPipeTest {
         String base = TestUtils.getSquaresBoardImagesPath().toAbsolutePath().toString();
         File dir = Path.of(base, dataset.path).toFile();
         calibrateSquaresCommon(dataset.size, dir, dataset.boardSize, useMrCal);
+    }
+
+    @Test
+    public void testWillBoard() throws IOException {
+        String base = TestUtils.getSquaresBoardImagesPath().toAbsolutePath().toString();
+        File dir = Path.of("/home/matt/mrcal_will_debug/imgs/").toFile();
+        calibrateSquaresCommon(new Size(1600, 1200), dir, new Size(19, 14), true);
     }
 
     public static void calibrateSquaresCommon(

--- a/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;


### PR DESCRIPTION
Dramatically improves solver time using my Ryzen 7700x and the dataset from https://github.com/PhotonVision/photonvision/issues/1240
```
Stock opencv:
    [2024-03-08 19:03:30] [General - Calibrate3dPipe] [INFO] CALIBRATION SUCCESS for res 1600x1200 in 9900.080838ms! camMatrix: 
    [896.0524827415276, 0.0, 827.9908371459426, 0.0, 897.4056057247211, 666.1828560048147, 0.0, 0.0, 1.0]
    distortionCoeffs:
    [0.05165556287657939, -0.08763299022335444, 4.935165405259787E-4, 0.0013342756098722178, 0.02709672171966562]

Opencv LU + intrinsic guess:
    [2024-03-08 19:05:15] [General - Calibrate3dPipe] [INFO] CALIBRATION SUCCESS for res 1600x1200 in 1732.432354ms! camMatrix: 
    [896.0524827297648, 0.0, 827.9908371251007, 0.0, 897.4056057173642, 666.1828560328339, 0.0, 0.0, 1.0]
    distortionCoeffs:
    [0.05165556290747567, -0.08763299032803912, 4.935165484352966E-4, 0.00133427560330307, 0.02709672181272145]

Mrcal:
    [2024-03-08 19:21:48] [General - Calibrate3dPipe] [INFO] CALIBRATION SUCCESS for res 1600x1200 in 1233.728177ms! camMatrix: 
    [898.2524856375802, 0.0, 828.0988713770921, 0.0, 899.1859818108287, 663.703347890306, 0.0, 0.0, 1.0]
    distortionCoeffs:
    [0.020746802609847566, -0.04652638800253273, -2.2580568777091502E-4, 0.001298334674530682, 0.08268622473771806, -0.030413043601033536, 0.034333736625036054, 0.06199332714424279]
```
