### PR TITLE
Disable camera orientation option when camera is calibrated

### DIFF
--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -131,13 +131,24 @@ const interactiveCols = computed(() =>
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ cameraBlueGain: args }, false)"
     />
      <!-- Disable camera orientation as stop gap for Issue 1084 until calibration data gets rotated. https://github.com/PhotonVision/photonvision/issues/1084 -->
+    <v-banner
+      v-show="useCameraSettingsStore().isCurrentVideoFormatCalibrated && useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode != 0"
+      rounded
+      dark
+      color="red"
+      text-color="white"
+      class="mt-3"
+      icon="mdi-alert-circle-outline"
+    >
+      Warning! A known bug affects rotation of calibrated camera. Turn off rotation here and rotate using cameraToRobotTransform in your robot code.
+    </v-banner>
     <pv-select
       v-model="useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode"
       label="Orientation"
       tooltip="Rotates the camera stream. Rotation not available when camera has been calibrated."
       :items="cameraRotations"
       :select-cols="interactiveCols"
-      :disabled="useCameraSettingsStore().isCurrentVideoFormatCalibrated" 
+      :disabled="useCameraSettingsStore().isCurrentVideoFormatCalibrated && useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode == 0" 
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ inputImageRotationMode: args }, false)"
     />
     <pv-select

--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -130,13 +130,14 @@ const interactiveCols = computed(() =>
       tooltip="Controls blue automatic white balance gain, which affects how the camera captures colors in different conditions"
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ cameraBlueGain: args }, false)"
     />
+     <!-- Disable camera orientation as stop gap for Issue 1084 until calibration data gets rotated. https://github.com/PhotonVision/photonvision/issues/1084 -->
     <pv-select
       v-model="useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode"
       label="Orientation"
       tooltip="Rotates the camera stream. Rotation not available when camera has been calibrated."
       :items="cameraRotations"
       :select-cols="interactiveCols"
-      :disabled="useCameraSettingsStore().isCurrentVideoFormatCalibrated"
+      :disabled="useCameraSettingsStore().isCurrentVideoFormatCalibrated" 
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ inputImageRotationMode: args }, false)"
     />
     <pv-select

--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -133,9 +133,10 @@ const interactiveCols = computed(() =>
     <pv-select
       v-model="useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode"
       label="Orientation"
-      tooltip="Rotates the camera stream"
+      tooltip="Rotates the camera stream. Rotation not available when camera has been calibrated."
       :items="cameraRotations"
       :select-cols="interactiveCols"
+      :disabled="!useCameraSettingsStore().isCurrentVideoFormatCalibrated"
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ inputImageRotationMode: args }, false)"
     />
     <pv-select

--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -136,7 +136,7 @@ const interactiveCols = computed(() =>
       tooltip="Rotates the camera stream. Rotation not available when camera has been calibrated."
       :items="cameraRotations"
       :select-cols="interactiveCols"
-      :disabled="!useCameraSettingsStore().isCurrentVideoFormatCalibrated"
+      :disabled="useCameraSettingsStore().isCurrentVideoFormatCalibrated"
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ inputImageRotationMode: args }, false)"
     />
     <pv-select

--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -130,9 +130,12 @@ const interactiveCols = computed(() =>
       tooltip="Controls blue automatic white balance gain, which affects how the camera captures colors in different conditions"
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ cameraBlueGain: args }, false)"
     />
-     <!-- Disable camera orientation as stop gap for Issue 1084 until calibration data gets rotated. https://github.com/PhotonVision/photonvision/issues/1084 -->
+    <!-- Disable camera orientation as stop gap for Issue 1084 until calibration data gets rotated. https://github.com/PhotonVision/photonvision/issues/1084 -->
     <v-banner
-      v-show="useCameraSettingsStore().isCurrentVideoFormatCalibrated && useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode != 0"
+      v-show="
+        useCameraSettingsStore().isCurrentVideoFormatCalibrated &&
+        useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode != 0
+      "
       rounded
       dark
       color="red"
@@ -140,7 +143,8 @@ const interactiveCols = computed(() =>
       class="mt-3"
       icon="mdi-alert-circle-outline"
     >
-      Warning! A known bug affects rotation of calibrated camera. Turn off rotation here and rotate using cameraToRobotTransform in your robot code.
+      Warning! A known bug affects rotation of calibrated camera. Turn off rotation here and rotate using
+      cameraToRobotTransform in your robot code.
     </v-banner>
     <pv-select
       v-model="useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode"
@@ -148,7 +152,10 @@ const interactiveCols = computed(() =>
       tooltip="Rotates the camera stream. Rotation not available when camera has been calibrated."
       :items="cameraRotations"
       :select-cols="interactiveCols"
-      :disabled="useCameraSettingsStore().isCurrentVideoFormatCalibrated && useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode == 0" 
+      :disabled="
+        useCameraSettingsStore().isCurrentVideoFormatCalibrated &&
+        useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode == 0
+      "
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ inputImageRotationMode: args }, false)"
     />
     <pv-select


### PR DESCRIPTION
This is a stop gap for issue #1084. The input option is disabled for camera rotation when the active camera has been calibrated based on `useCameraSettingsStore().isCurrentVideoFormatCalibrated`

Long term fix should be to use the rotation data for calibrated camera pipelines. 
