### PR TITLE
Copy mat before running Rknn detect to hopefully mitigate #1182

### DIFF
--- a/photon-core/src/main/java/org/photonvision/jni/RknnDetectorJNI.java
+++ b/photon-core/src/main/java/org/photonvision/jni/RknnDetectorJNI.java
@@ -96,7 +96,10 @@ public class RknnDetectorJNI extends PhotonJNICommon {
                 // been called. This would mean objPointer would be invalid which would call everything to
                 // explode.
                 if (objPointer > 0) {
-                    ret = RknnJNI.detect(objPointer, in.getMat().getNativeObjAddr(), nmsThresh, boxThresh);
+                    CVMat inCopy = new CVMat();
+                    inCopy.copyTo(in);
+                    ret = RknnJNI.detect(objPointer, inCopy.getMat().getNativeObjAddr(), nmsThresh, boxThresh);
+                    inCopy.release();
                 } else {
                     logger.warn("Detect called after destroy -- giving up");
                     return List.of();

--- a/photon-core/src/main/java/org/photonvision/jni/RknnDetectorJNI.java
+++ b/photon-core/src/main/java/org/photonvision/jni/RknnDetectorJNI.java
@@ -98,7 +98,8 @@ public class RknnDetectorJNI extends PhotonJNICommon {
                 if (objPointer > 0) {
                     CVMat inCopy = new CVMat();
                     inCopy.copyTo(in);
-                    ret = RknnJNI.detect(objPointer, inCopy.getMat().getNativeObjAddr(), nmsThresh, boxThresh);
+                    ret =
+                            RknnJNI.detect(objPointer, inCopy.getMat().getNativeObjAddr(), nmsThresh, boxThresh);
                     inCopy.release();
                 } else {
                     logger.warn("Detect called after destroy -- giving up");


### PR DESCRIPTION
This change is an educated guess based on the following:
- When the Object Detection Pipeline crashes, there is a kernel paging request error on the console and dmesg.
- Restarting PV doesn't work because the camera reports that it is in use even though lsof and fuser show nothing. The camera LED stays on
- StackOverflow (and similar) discussions of the dmesg error usually involve device drivers improperly accessing kernel memory

So, if the camera get hosed when we pass its buffer to the Rknn detection, maybe creating a copy first will avoid the issue. After making this change, I could not reproduce the issue using the same method that previously caused the crash.

I also ran detection over a couple hours and did not observe memory growth in the process.

Way too much discussion and detail in this [thread on Discord](https://discord.com/channels/725836368059826228/1217876918779510865).