### PR TITLE
Fix mjpg stream accumulation

### DIFF
--- a/photon-client/src/components/app/photon-camera-stream.vue
+++ b/photon-client/src/components/app/photon-camera-stream.vue
@@ -56,21 +56,14 @@ const handleFullscreenRequest = () => {
 
 const mjpgStream: any = ref(null);
 onBeforeUnmount(() => {
-  if (!mjpgStream.value) return
+  if (!mjpgStream.value) return;
   mjpgStream.value["src"] = null;
 });
 </script>
 
 <template>
   <div class="stream-container">
-    <img
-      :id="id"
-      crossorigin="anonymous"
-      :src="streamSrc"
-      :alt="streamDesc"
-      :style="streamStyle"
-      ref="mjpgStream"
-    />
+    <img :id="id" crossorigin="anonymous" :src="streamSrc" :alt="streamDesc" :style="streamStyle" ref="mjpgStream" />
     <div class="stream-overlay" :style="overlayStyle">
       <pv-icon
         icon-name="mdi-camera-image"

--- a/photon-client/src/components/app/photon-camera-stream.vue
+++ b/photon-client/src/components/app/photon-camera-stream.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject } from "vue";
+import { computed, inject, ref, onBeforeUnmount } from "vue";
 import { useCameraSettingsStore } from "@/stores/settings/CameraSettingsStore";
 import { useStateStore } from "@/stores/StateStore";
 import loadingImage from "@/assets/images/loading.svg";
@@ -53,11 +53,24 @@ const handleFullscreenRequest = () => {
   if (!stream) return;
   stream.requestFullscreen();
 };
+
+const mjpgStream: any = ref(null);
+onBeforeUnmount(() => {
+  if (!mjpgStream.value) return
+  mjpgStream.value["src"] = null;
+});
 </script>
 
 <template>
   <div class="stream-container">
-    <img :id="id" crossorigin="anonymous" :src="streamSrc" :alt="streamDesc" :style="streamStyle" />
+    <img
+      :id="id"
+      crossorigin="anonymous"
+      :src="streamSrc"
+      :alt="streamDesc"
+      :style="streamStyle"
+      ref="mjpgStream"
+    />
     <div class="stream-overlay" :style="overlayStyle">
       <pv-icon
         icon-name="mdi-camera-image"


### PR DESCRIPTION
Fixes bug where switching tabs/etc causes buildup of connected mjpg streams in network, eventually slowing down streams and causing stream failure until refresh. Accomplishes this by directly setting the source of stream elements to null before unmount, allowing chrome/edge to close the connection.

Fixes #1106 