### PR TITLE
Sticky calibration camera display card

### DIFF
--- a/photon-client/src/components/cameras/CamerasView.vue
+++ b/photon-client/src/components/cameras/CamerasView.vue
@@ -157,7 +157,6 @@ th {
     top: 12px;
   }
 }
-
 @media only screen and (min-width: 512px) and (max-width: 960px) {
   .stream-container {
     flex-wrap: nowrap;

--- a/photon-client/src/components/cameras/CamerasView.vue
+++ b/photon-client/src/components/cameras/CamerasView.vue
@@ -151,6 +151,13 @@ th {
   justify-content: center;
 }
 
+@media only screen and (min-width: 960px) {
+  #camera-settings-camera-view-card {
+    position: sticky;
+    top: 12px;
+  }
+}
+
 @media only screen and (min-width: 512px) and (max-width: 960px) {
   .stream-container {
     flex-wrap: nowrap;


### PR DESCRIPTION
When UI is not in stacked mode, sticky the camera display card to the top of the display for easy view during calibration.

Fixes #1160 