### PR TITLE
[Client] Fix issue with clearing multitag buffer

### DIFF
--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -28,7 +28,7 @@ const calculateStdDev = (values: number[]): number => {
 };
 const resetCurrentBuffer = () => {
   // Need to clear the array in place
-  while (useStateStore().currentMultitagBuffer?.length ?? 0 > 0) {
+  while ((useStateStore().currentMultitagBuffer?.length ?? 0) > 0) {
     useStateStore().currentMultitagBuffer?.pop();
   }
 };

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -28,7 +28,9 @@ const calculateStdDev = (values: number[]): number => {
 };
 const resetCurrentBuffer = () => {
   // Need to clear the array in place
-  while (useStateStore().currentMultitagBuffer?.length != 0) useStateStore().currentMultitagBuffer?.pop();
+  while (useStateStore().currentMultitagBuffer?.length ?? 0 > 0) {
+    useStateStore().currentMultitagBuffer?.pop();
+  }
 };
 </script>
 

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -28,9 +28,7 @@ const calculateStdDev = (values: number[]): number => {
 };
 const resetCurrentBuffer = () => {
   // Need to clear the array in place
-  while ((useStateStore().currentMultitagBuffer?.length ?? 0) > 0) {
-    useStateStore().currentMultitagBuffer?.pop();
-  }
+  if (useStateStore().currentMultitagBuffer) useStateStore().currentMultitagBuffer!.length = 0;
 };
 </script>
 

--- a/photon-client/src/stores/StateStore.ts
+++ b/photon-client/src/stores/StateStore.ts
@@ -84,7 +84,7 @@ export const useStateStore = defineStore("state", {
       return this.backendResults[this.currentCameraIndex.toString()];
     },
     currentMultitagBuffer(): MultitagResult[] | undefined {
-      return this.multitagResultBuffer[this.currentCameraIndex.toString()];
+      return this.multitagResultBuffer[this.currentCameraIndex];
     }
   },
   actions: {

--- a/photon-client/src/stores/StateStore.ts
+++ b/photon-client/src/stores/StateStore.ts
@@ -84,6 +84,7 @@ export const useStateStore = defineStore("state", {
       return this.backendResults[this.currentCameraIndex.toString()];
     },
     currentMultitagBuffer(): MultitagResult[] | undefined {
+      if (!this.multitagResultBuffer[this.currentCameraIndex]) this.multitagResultBuffer[this.currentCameraIndex] = [];
       return this.multitagResultBuffer[this.currentCameraIndex];
     }
   },


### PR DESCRIPTION
The state multitagResultBuffer dictionary uses integer keys, and stringifying the reference key yielded null results. This caused an infinite while loop on "Reset Samples" (null is always != 0) and caused the entire multitag pose standard deviation section to display the nullish-coalesced default values. Fixed the reference and added in a nullish coalescing condition on the suspect while loop to avoid the frontend lockup if this is somehow encountered again in the future

Fixes #1203 