### PR TITLE
Change camera exposure step to integer

### DIFF
--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -360,7 +360,6 @@ const setSelectedVideoFormat = (format: VideoFormat) => {
               :min="0"
               :max="100"
               :slider-cols="8"
-              :step="0.1"
               @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ cameraExposure: args }, false)"
             />
             <pv-slider

--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -81,7 +81,6 @@ const interactiveCols = computed(() =>
       :min="0"
       :max="100"
       :slider-cols="interactiveCols"
-      :step="0.1"
       @input="(args) => useCameraSettingsStore().changeCurrentPipelineSetting({ cameraExposure: args }, false)"
     />
     <pv-slider


### PR DESCRIPTION
Potentially mitigates [1182](https://github.com/PhotonVision/photonvision/issues/1182), see comment there for more details. Exposure is rounded in the backend anyway, so there is no reason to send several update events for ultimately the same setting.