### PR TITLE
Change sim to use 36h11 tags when doing multitag

### DIFF
--- a/photon-lib/src/main/native/include/photon/simulation/PhotonCameraSim.h
+++ b/photon-lib/src/main/native/include/photon/simulation/PhotonCameraSim.h
@@ -365,7 +365,7 @@ class PhotonCameraSim {
       std::sort(usedIds.begin(), usedIds.end());
       PNPResult pnpResult = VisionEstimation::EstimateCamPosePNP(
           prop.GetIntrinsics(), prop.GetDistCoeffs(), detectableTgts, tagLayout,
-          kAprilTag16h5);
+          kAprilTag36h11);
       multiTagResults = MultiTargetPNPResult{pnpResult, usedIds};
     }
 


### PR DESCRIPTION
This fixes #1313 

Before: 
![before](https://github.com/PhotonVision/photonvision/assets/6174102/44687436-8305-4b29-9824-77bd34b806c5)

After:
![afterchange](https://github.com/PhotonVision/photonvision/assets/6174102/5ae89522-5519-42d1-b771-53ae47f6f0b5)

