### PR TITLE
Disable transitive dependency resolution for known bad deps

### DIFF
--- a/photon-core/build.gradle
+++ b/photon-core/build.gradle
@@ -37,9 +37,15 @@ dependencies {
     implementation 'org.zeroturnaround:zt-zip:1.14'
 
     implementation "org.xerial:sqlite-jdbc:3.41.0.0"
-    implementation "org.photonvision:rknn_jni-jni:$rknnVersion:linuxarm64"
-    implementation "org.photonvision:rknn_jni-java:$rknnVersion"
-    implementation "org.photonvision:photon-libcamera-gl-driver-jni:$libcameraDriverVersion:linuxarm64"
+    implementation("org.photonvision:rknn_jni-jni:$rknnVersion:linuxarm64") {
+        transitive = false
+    }
+    implementation("org.photonvision:rknn_jni-java:$rknnVersion") {
+        transitive = false
+    }
+    implementation("org.photonvision:photon-libcamera-gl-driver-jni:$libcameraDriverVersion:linuxarm64") {
+        transitive = false
+    }
     implementation "org.photonvision:photon-libcamera-gl-driver-java:$libcameraDriverVersion"
 
     implementation "org.photonvision:photon-mrcal-java:$mrcalVersion"
@@ -49,7 +55,9 @@ dependencies {
                 "osxx86-64",
                 "osxarm64"
             ])) {
-        implementation "org.photonvision:photon-mrcal-jni:$mrcalVersion:$wpilibNativeName"
+        implementation("org.photonvision:photon-mrcal-jni:$mrcalVersion:$wpilibNativeName") {
+            transitive = false
+        }
     }
 
     testImplementation group: 'org.junit-pioneer' , name: 'junit-pioneer', version: '2.2.0'


### PR DESCRIPTION
This prevents things like rknn-jni asking for 2024.3.2+, and resolving to the latest dev release. 
