### PR TITLE
Fix mac released jar naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,22 +195,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          - os: ubuntu-latest
             artifact-name: Win64
             architecture: x64
-            arch-override: none
-          - os: macos-latest
+            arch-override: winx64
+          - os: ubuntu-latest
             artifact-name: macOS
             architecture: x64
-            arch-override: none
+            arch-override: macx64
           - os: ubuntu-latest
-            artifact-name: Linux
-            architecture: x64
-            arch-override: none
-          - os: macos-latest
             artifact-name: macOSArm
             architecture: x64
             arch-override: macarm64
+          - os: ubuntu-latest
+            artifact-name: Linux
+            architecture: x64
+            arch-override: linuxx64
           - os: ubuntu-latest
             artifact-name: LinuxArm64
             architecture: x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Gradle Build
         run: |
           chmod +x gradlew
-          ./gradlew build -x check --max-workers 2
+          ./gradlew photon-targeting:build photon-core:build photon-server:build -x check --max-workers 2
       - name: Gradle Tests
         run: ./gradlew testHeadless -i --max-workers 1 --stacktrace
       - name: Gradle Coverage
@@ -195,15 +195,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: windows-latest
             artifact-name: Win64
             architecture: x64
             arch-override: winx64
-          - os: ubuntu-latest
+          - os: macos-latest
             artifact-name: macOS
             architecture: x64
             arch-override: macx64
-          - os: ubuntu-latest
+          - os: macos-latest
             artifact-name: macOSArm
             architecture: x64
             arch-override: macarm64
@@ -228,6 +228,7 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+          architecture: ${{ matrix.architecture }}
       - run: |
           rm -rf photon-server/src/main/resources/web/*
           mkdir -p photon-server/src/main/resources/web/docs


### PR DESCRIPTION
Proof it works: https://github.com/mcm001/photonvision/actions/runs/9293484120