### PR TITLE
Mark generated files as generated in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,3 +35,7 @@
 *.so binary
 *.dll binary
 *.webp binary
+
+photon-lib/src/generate/** linguist-generated
+photon-lib/src/generated/** linguist-generated
+shared/PhotonVersion.cpp linguist-generated


### PR DESCRIPTION
This tells git the files are generated, mostly useful for avoiding clogging up git diffs making reviewing code easier. 