### PR TITLE
CSI Camera null quirks error

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/FileVisionSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/FileVisionSource.java
@@ -44,6 +44,10 @@ public class FileVisionSource extends VisionSource {
                         cameraConfiguration.FOV,
                         FileFrameProvider.MAX_FPS,
                         calibration);
+
+        if (getCameraConfiguration().cameraQuirks == null)
+            getCameraConfiguration().cameraQuirks = QuirkyCamera.DefaultCamera;
+
         settables =
                 new FileSourceSettables(cameraConfiguration, frameProvider.get().frameStaticProperties);
     }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/LibcameraGpuSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/LibcameraGpuSource.java
@@ -41,6 +41,9 @@ public class LibcameraGpuSource extends VisionSource {
                     "GPUAcceleratedPicamSource only accepts CameraConfigurations with type Picam");
         }
 
+        if (getCameraConfiguration().cameraQuirks == null)
+            getCameraConfiguration().cameraQuirks = QuirkyCamera.ZeroCopyPiCamera;
+
         settables = new LibcameraGpuSettables(configuration);
         frameProvider = new LibcameraGpuFrameProvider(settables);
     }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -99,6 +99,9 @@ public class VisionModule {
 
         cameraQuirks = visionSource.getCameraConfiguration().cameraQuirks;
 
+        if (visionSource.getCameraConfiguration().cameraQuirks == null)
+            visionSource.getCameraConfiguration().cameraQuirks = QuirkyCamera.DefaultCamera;
+
         // We don't show gain if the config says it's -1. So check here to make sure it's non-negative
         // if it _is_ supported
         if (cameraQuirks.hasQuirk(CameraQuirk.Gain)) {

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -46,7 +46,6 @@ import org.photonvision.vision.camera.CameraQuirk;
 import org.photonvision.vision.camera.CameraType;
 import org.photonvision.vision.camera.LibcameraGpuSource;
 import org.photonvision.vision.camera.QuirkyCamera;
-import org.photonvision.vision.camera.USBCameraSource;
 import org.photonvision.vision.frame.Frame;
 import org.photonvision.vision.frame.consumer.FileSaveFrameConsumer;
 import org.photonvision.vision.frame.consumer.MJPGFrameConsumer;
@@ -98,14 +97,7 @@ public class VisionModule {
                         visionSource.getSettables().getConfiguration().nickname,
                         LogGroup.VisionModule);
 
-        // Find quirks for the current camera
-        if (visionSource instanceof USBCameraSource) {
-            cameraQuirks = ((USBCameraSource) visionSource).getCameraQuirks();
-        } else if (visionSource instanceof LibcameraGpuSource) {
-            cameraQuirks = QuirkyCamera.ZeroCopyPiCamera;
-        } else {
-            cameraQuirks = QuirkyCamera.DefaultCamera;
-        }
+        cameraQuirks = visionSource.getCameraConfiguration().cameraQuirks;
 
         // We don't show gain if the config says it's -1. So check here to make sure it's non-negative
         // if it _is_ supported

--- a/photon-core/src/test/java/org/photonvision/vision/processes/VisionModuleManagerTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/processes/VisionModuleManagerTest.java
@@ -31,6 +31,7 @@ import org.photonvision.common.configuration.CameraConfiguration;
 import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.dataflow.CVPipelineResultConsumer;
 import org.photonvision.common.util.TestUtils;
+import org.photonvision.vision.camera.QuirkyCamera;
 import org.photonvision.vision.camera.USBCameraSource;
 import org.photonvision.vision.frame.FrameProvider;
 import org.photonvision.vision.frame.FrameStaticProperties;
@@ -49,6 +50,8 @@ public class VisionModuleManagerTest {
         public TestSource(FrameProvider provider, CameraConfiguration cameraConfiguration) {
             super(cameraConfiguration);
             this.provider = provider;
+            if (getCameraConfiguration().cameraQuirks == null)
+                getCameraConfiguration().cameraQuirks = QuirkyCamera.DefaultCamera;
         }
 
         @Override


### PR DESCRIPTION
Camera quirks for CSI cameras are modified later than they should be resulting in some instances being null.