### PR TITLE
Revert "Warn when getBestCameraToTarget returns 0, 0, 0"

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/target/TrackedTarget.java
+++ b/photon-core/src/main/java/org/photonvision/vision/target/TrackedTarget.java
@@ -19,7 +19,6 @@ package org.photonvision.vision.target;
 import edu.wpi.first.apriltag.AprilTagDetection;
 import edu.wpi.first.apriltag.AprilTagPoseEstimate;
 import edu.wpi.first.math.geometry.Transform3d;
-import edu.wpi.first.wpilibj.DriverStation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -365,9 +364,6 @@ public class TrackedTarget implements Releasable {
     }
 
     public Transform3d getBestCameraToTarget3d() {
-        if (m_bestCameraToTarget3d.equals(new Transform3d())) {
-            DriverStation.reportWarning("3d mode is not enabled.", false);
-        }
         return m_bestCameraToTarget3d;
     }
 

--- a/photon-targeting/src/main/native/include/photon/targeting/PhotonTrackedTarget.h
+++ b/photon-targeting/src/main/native/include/photon/targeting/PhotonTrackedTarget.h
@@ -22,7 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include <frc/Errors.h>
 #include <frc/geometry/Transform3d.h>
 #include <wpi/SmallVector.h>
 
@@ -139,12 +138,7 @@ class PhotonTrackedTarget {
    * reprojection error is the ambiguity, which is between 0 and 1.
    * @return The pose of the target relative to the robot.
    */
-  frc::Transform3d GetBestCameraToTarget() const {
-    if (bestCameraToTarget == frc::Transform3d()) {
-      FRC_ReportError(frc::warn::Warning, "3d mode is not enabled");
-    }
-    return bestCameraToTarget;
-  }
+  frc::Transform3d GetBestCameraToTarget() const { return bestCameraToTarget; }
 
   /**
    * Get the transform that maps camera space (X = forward, Y = left, Z = up) to


### PR DESCRIPTION
Reverts PhotonVision/photonvision#1334 . photon itself was calling into the HAL https://github.com/PhotonVision/photonvision/pull/1350/files#diff-4135f5230372b5a6cd4d1224d3f60dd9ec8a4aabc49c8b50f216de74deb4b1f3
which statically initializes the HAL in mode 0 (try if not initialized yet) https://github.com/wpilibsuite/allwpilib/blob/3a0ee5c9a7666e180383fc0d6eb11a89a6122547/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java#L421
which then restarts timing https://github.com/wpilibsuite/allwpilib/blob/3a0ee5c9a7666e180383fc0d6eb11a89a6122547/hal/src/main/native/sim/HAL.cpp#L362

Defering proper implementation due to the large quantity of shared code between photon-lib and actual code, and the difficulty of telling if we're on a rio or simulator or on a coprocessor running photon. 