### PR TITLE
Populate CameraSettingsStore with placeholder value if no cameras are present

### DIFF
--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -78,7 +78,7 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
   },
   actions: {
     updateCameraSettingsFromWebsocket(data: WebsocketCameraSettingsUpdate[]) {
-      this.cameras = data.map<CameraSettings>((d) => ({
+      const configuredCameras = data.map<CameraSettings>((d) => ({
         nickname: d.nickname,
         uniqueName: d.uniqueName,
         fov: {
@@ -115,6 +115,7 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
         pipelineSettings: d.currentPipelineSettings,
         cameraQuirks: d.cameraQuirks
       }));
+      this.cameras = configuredCameras.length > 0 ? configuredCameras : [PlaceholderCameraSettings];
     },
     /**
      * Update the configurable camera settings.


### PR DESCRIPTION
When no cameras are connected to a PhotonVision system, initially it will come up with a placeholder camera.

However, the first camera settings update to come over websocket will remove the placeholder entry, so navigation through the UI to other panels immediately breaks the UI.

This change maintains the Placeholder camera settings so long as the websocket returns no camera settings to avoid UI instability.