### PR TITLE
Fix error being printed to console on Chrome when navigating UI

### DIFF
--- a/photon-client/src/components/app/photon-camera-stream.vue
+++ b/photon-client/src/components/app/photon-camera-stream.vue
@@ -57,7 +57,7 @@ const handleFullscreenRequest = () => {
 const mjpgStream: any = ref(null);
 onBeforeUnmount(() => {
   if (!mjpgStream.value) return;
-  mjpgStream.value["src"] = null;
+  mjpgStream.value["src"] = "//:0";
 });
 </script>
 


### PR DESCRIPTION
Chrome prints an error to the console when you have `<img src="null" />`

The path `//:0` can be used for an empty image and Chrome will not raise an error.