### PR TITLE
Reduce pipeline use-after-free errors

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionRunner.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionRunner.java
@@ -101,13 +101,17 @@ public class VisionRunner {
                 continue;
             }
 
-            // There's no guarantee the processing type change will occur this tick, so pipelines should
-            // check themselves
-            try {
-                var pipelineResult = pipeline.run(frame, cameraQuirks);
-                pipelineResultConsumer.accept(pipelineResult);
-            } catch (Exception ex) {
-                logger.error("Exception on loop " + loopCount, ex);
+            // If the pipeline has changed while we are getting our frame we should scrap that frame it
+            // may result in incorrect frame settings like hsv values
+            if (pipeline == pipelineSupplier.get()) {
+                // There's no guarantee the processing type change will occur this tick, so pipelines should
+                // check themselves
+                try {
+                    var pipelineResult = pipeline.run(frame, cameraQuirks);
+                    pipelineResultConsumer.accept(pipelineResult);
+                } catch (Exception ex) {
+                    logger.error("Exception on loop " + loopCount, ex);
+                }
             }
 
             loopCount++;


### PR DESCRIPTION
Always check to see if the pipeline has changed while we were grabbing the frame and if it was, skip the pipeline run.