### PR TITLE
Fix large calibration datasets crashes

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -51,8 +51,7 @@ public class ConfigManager {
     private final Thread settingsSaveThread;
     private long saveRequestTimestamp = -1;
 
-    // special case flag to disable flushing settings to disk at shutdown. Avoids
-    // the jvm shutdown
+    // special case flag to disable flushing settings to disk at shutdown. Avoids the jvm shutdown
     // hook overwriting the settings we just uploaded
     private boolean flushOnShutdown = true;
 
@@ -62,9 +61,8 @@ public class ConfigManager {
         ATOMIC_ZIP
     }
 
-    // This logic decides which kind of ConfigManager we load as the default. If we
-    // want
-    // to switch back to the legacy config manager, change this constant
+    // This logic decides which kind of ConfigManager we load as the default. If we want to switch
+    // back to the legacy config manager, change this constant
     private static final ConfigSaveStrategy m_saveStrat = ConfigSaveStrategy.SQL;
 
     public static ConfigManager getInstance() {
@@ -114,21 +112,18 @@ public class ConfigManager {
             } catch (IOException e) {
                 logger.error("Exception moving cameras to cameras_bak!", e);
 
-                // Try to just copy from cams to cams-bak instead of moving? Windows sometimes
-                // needs us to
+                // Try to just copy from cams to cams-bak instead of moving? Windows sometimes needs us to
                 // do that
                 try {
                     org.apache.commons.io.FileUtils.copyDirectory(maybeCams, maybeCamsBak);
                 } catch (IOException e1) {
-                    // So we can't move to cams_bak, and we can't copy and delete either? We just
-                    // have to give
+                    // So we can't move to cams_bak, and we can't copy and delete either? We just have to give
                     // up here on preserving the old folder
                     logger.error("Exception while backup-copying cameras to cameras_bak!", e);
                     e1.printStackTrace();
                 }
 
-                // Delete the directory because we were successfully able to load the config but
-                // were unable
+                // Delete the directory because we were successfully able to load the config but were unable
                 // to save or copy the folder.
                 if (maybeCams.exists()) FileUtils.deleteDirectory(maybeCams.toPath());
             }

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -30,7 +30,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.List;
-
 import org.opencv.core.Size;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
@@ -252,7 +251,9 @@ public class ConfigManager {
     }
 
     public Path getCalibrationImageSavePath(Size frameSize) {
-        var imgFilePath = Path.of(configDirectoryFile.toString(), "calibration","imgs",frameSize.toString()).toFile();
+        var imgFilePath =
+                Path.of(configDirectoryFile.toString(), "calibration", "imgs", frameSize.toString())
+                        .toFile();
         if (!imgFilePath.exists()) imgFilePath.mkdirs();
         return imgFilePath.toPath();
     }

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -51,7 +51,8 @@ public class ConfigManager {
     private final Thread settingsSaveThread;
     private long saveRequestTimestamp = -1;
 
-    // special case flag to disable flushing settings to disk at shutdown. Avoids the jvm shutdown
+    // special case flag to disable flushing settings to disk at shutdown. Avoids
+    // the jvm shutdown
     // hook overwriting the settings we just uploaded
     private boolean flushOnShutdown = true;
 
@@ -61,7 +62,8 @@ public class ConfigManager {
         ATOMIC_ZIP
     }
 
-    // This logic decides which kind of ConfigManager we load as the default. If we want
+    // This logic decides which kind of ConfigManager we load as the default. If we
+    // want
     // to switch back to the legacy config manager, change this constant
     private static final ConfigSaveStrategy m_saveStrat = ConfigSaveStrategy.SQL;
 
@@ -112,18 +114,21 @@ public class ConfigManager {
             } catch (IOException e) {
                 logger.error("Exception moving cameras to cameras_bak!", e);
 
-                // Try to just copy from cams to cams-bak instead of moving? Windows sometimes needs us to
+                // Try to just copy from cams to cams-bak instead of moving? Windows sometimes
+                // needs us to
                 // do that
                 try {
                     org.apache.commons.io.FileUtils.copyDirectory(maybeCams, maybeCamsBak);
                 } catch (IOException e1) {
-                    // So we can't move to cams_bak, and we can't copy and delete either? We just have to give
+                    // So we can't move to cams_bak, and we can't copy and delete either? We just
+                    // have to give
                     // up here on preserving the old folder
                     logger.error("Exception while backup-copying cameras to cameras_bak!", e);
                     e1.printStackTrace();
                 }
 
-                // Delete the directory because we were successfully able to load the config but were unable
+                // Delete the directory because we were successfully able to load the config but
+                // were unable
                 // to save or copy the folder.
                 if (maybeCams.exists()) FileUtils.deleteDirectory(maybeCams.toPath());
             }
@@ -255,8 +260,8 @@ public class ConfigManager {
                 Path.of(
                                 configDirectoryFile.toString(),
                                 "calibration",
-                                "imgs",
                                 uniqueCameraName,
+                                "imgs",
                                 frameSize.toString())
                         .toFile();
         if (!imgFilePath.exists()) imgFilePath.mkdirs();

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -30,6 +30,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.List;
+
+import org.opencv.core.Size;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 import org.photonvision.common.util.file.FileUtils;
@@ -245,6 +247,12 @@ public class ConfigManager {
 
     public Path getImageSavePath() {
         var imgFilePath = Path.of(configDirectoryFile.toString(), "imgSaves").toFile();
+        if (!imgFilePath.exists()) imgFilePath.mkdirs();
+        return imgFilePath.toPath();
+    }
+
+    public Path getCalibrationImageSavePath(Size frameSize) {
+        var imgFilePath = Path.of(configDirectoryFile.toString(), "calibration","imgs",frameSize.toString()).toFile();
         if (!imgFilePath.exists()) imgFilePath.mkdirs();
         return imgFilePath.toPath();
     }

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -250,9 +250,9 @@ public class ConfigManager {
         return imgFilePath.toPath();
     }
 
-    public Path getCalibrationImageSavePath(Size frameSize) {
+    public Path getCalibrationImageSavePath(Size frameSize, String uniqueCameraName) {
         var imgFilePath =
-                Path.of(configDirectoryFile.toString(), "calibration", "imgs", frameSize.toString())
+                Path.of(configDirectoryFile.toString(), "calibration", "imgs", uniqueCameraName, frameSize.toString())
                         .toFile();
         if (!imgFilePath.exists()) imgFilePath.mkdirs();
         return imgFilePath.toPath();

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -252,7 +252,12 @@ public class ConfigManager {
 
     public Path getCalibrationImageSavePath(Size frameSize, String uniqueCameraName) {
         var imgFilePath =
-                Path.of(configDirectoryFile.toString(), "calibration", "imgs", uniqueCameraName, frameSize.toString())
+                Path.of(
+                                configDirectoryFile.toString(),
+                                "calibration",
+                                "imgs",
+                                uniqueCameraName,
+                                frameSize.toString())
                         .toFile();
         if (!imgFilePath.exists()) imgFilePath.mkdirs();
         return imgFilePath.toPath();

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
@@ -133,7 +133,11 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
     @Override
     public void accept(CVPipelineResult result) {
         CVPipelineResult acceptedResult;
-        if (result instanceof CalibrationPipelineResult)
+        if (result
+                instanceof
+                CalibrationPipelineResult) // If the data is from a calibration pipeline, override the list
+            // of targets to be null to prevent the data from being sent and
+            // continue to post blank/zero data to the network tables
             acceptedResult =
                     new CVPipelineResult(
                             result.sequenceID,

--- a/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
+++ b/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
@@ -20,7 +20,6 @@ package org.photonvision.vision.calibration;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.geometry.Pose3d;
-
 import java.nio.file.Path;
 import java.util.List;
 import org.opencv.core.Point;

--- a/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
+++ b/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.opencv.core.Point;
 import org.opencv.core.Point3;
 
+// Ignore the previous calibration data that was stored in the json file.
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class BoardObservation implements Cloneable {
     // Expected feature 3d location in the camera frame

--- a/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
+++ b/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
@@ -20,6 +20,8 @@ package org.photonvision.vision.calibration;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.geometry.Pose3d;
+
+import java.nio.file.Path;
 import java.util.List;
 import org.opencv.core.Point;
 import org.opencv.core.Point3;
@@ -48,8 +50,8 @@ public final class BoardObservation implements Cloneable {
     @JsonProperty("snapshotName")
     public String snapshotName;
 
-    @JsonProperty("snapshotData")
-    public JsonImageMat snapshotData;
+    @JsonProperty("snapshotDataLocation")
+    public Path snapshotDataLocation;
 
     @JsonCreator
     public BoardObservation(
@@ -59,14 +61,14 @@ public final class BoardObservation implements Cloneable {
             @JsonProperty("optimisedCameraToObject") Pose3d optimisedCameraToObject,
             @JsonProperty("includeObservationInCalibration") boolean includeObservationInCalibration,
             @JsonProperty("snapshotName") String snapshotName,
-            @JsonProperty("snapshotData") JsonImageMat snapshotData) {
+            @JsonProperty("snapshotDataLocation") Path snapshotDataLocation) {
         this.locationInObjectSpace = locationInObjectSpace;
         this.locationInImageSpace = locationInImageSpace;
         this.reprojectionErrors = reprojectionErrors;
         this.optimisedCameraToObject = optimisedCameraToObject;
         this.includeObservationInCalibration = includeObservationInCalibration;
         this.snapshotName = snapshotName;
-        this.snapshotData = snapshotData;
+        this.snapshotDataLocation = snapshotDataLocation;
     }
 
     @Override
@@ -83,8 +85,8 @@ public final class BoardObservation implements Cloneable {
                 + includeObservationInCalibration
                 + ", snapshotName="
                 + snapshotName
-                + ", snapshotData="
-                + snapshotData
+                + ", snapshotDataLocation="
+                + snapshotDataLocation
                 + "]";
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
+++ b/photon-core/src/main/java/org/photonvision/vision/calibration/BoardObservation.java
@@ -18,6 +18,7 @@
 package org.photonvision.vision.calibration;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.geometry.Pose3d;
 import java.nio.file.Path;
@@ -25,6 +26,7 @@ import java.util.List;
 import org.opencv.core.Point;
 import org.opencv.core.Point3;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class BoardObservation implements Cloneable {
     // Expected feature 3d location in the camera frame
     @JsonProperty("locationInObjectSpace")

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
@@ -333,7 +333,7 @@ public class Calibrate3dPipe
         try {
             FileUtils.cleanDirectory(
                     ConfigManager.getInstance()
-                            .getCalibrationImageSavePath(in.get(0).inputImage.size())
+                            .getCalibrationImageSavePath(in.get(0).inputImage.size(), params.uniqueCameraName)
                             .toFile());
         } catch (Exception e) {
             logger.error("Failed to clean calibration image directory", e);
@@ -406,7 +406,7 @@ public class Calibrate3dPipe
                 image_path =
                         Paths.get(
                                 ConfigManager.getInstance()
-                                        .getCalibrationImageSavePath(inputImage.size())
+                                        .getCalibrationImageSavePath(inputImage.size(), params.uniqueCameraName)
                                         .toString(),
                                 snapshotName);
                 Imgcodecs.imwrite(image_path.toString(), inputImage);
@@ -455,13 +455,15 @@ public class Calibrate3dPipe
         public double squareSize;
 
         public boolean useMrCal;
+        public String uniqueCameraName;
 
         public CalibratePipeParams(
-                int boardHeightSquares, int boardWidthSquares, double squareSize, boolean usemrcal) {
+                int boardHeightSquares, int boardWidthSquares, double squareSize, boolean usemrcal, String uniqueCameraName) {
             this.boardHeight = boardHeightSquares - 1;
             this.boardWidth = boardWidthSquares - 1;
             this.squareSize = squareSize;
             this.useMrCal = usemrcal;
+            this.uniqueCameraName = uniqueCameraName;
         }
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.apache.commons.io.FileUtils;
 import org.opencv.calib3d.Calib3d;
 import org.opencv.core.*;
@@ -38,7 +37,6 @@ import org.photonvision.mrcal.MrCalJNILoader;
 import org.photonvision.vision.calibration.BoardObservation;
 import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
 import org.photonvision.vision.calibration.CameraLensModel;
-import org.photonvision.vision.calibration.JsonImageMat;
 import org.photonvision.vision.calibration.JsonMatOfDouble;
 import org.photonvision.vision.frame.FrameStaticProperties;
 import org.photonvision.vision.pipe.CVPipe;
@@ -297,8 +295,6 @@ public class Calibrate3dPipe
             tvecs.add(tvec);
         }
 
-
-
         List<BoardObservation> observations =
                 createObservations(
                         in,
@@ -333,9 +329,12 @@ public class Calibrate3dPipe
         List<Mat> imgPts = in.stream().map(it -> it.imagePoints).collect(Collectors.toList());
 
         // Clear the calibration image folder of any old images before we save the new ones.
-        
+
         try {
-            FileUtils.cleanDirectory(ConfigManager.getInstance().getCalibrationImageSavePath(in.get(0).inputImage.size()).toFile());
+            FileUtils.cleanDirectory(
+                    ConfigManager.getInstance()
+                            .getCalibrationImageSavePath(in.get(0).inputImage.size())
+                            .toFile());
         } catch (Exception e) {
             logger.error("Failed to clean calibration image directory", e);
         }
@@ -404,7 +403,12 @@ public class Calibrate3dPipe
             Path image_path = null;
             String snapshotName = "img" + i + ".png";
             if (inputImage != null) {
-                image_path = Paths.get(ConfigManager.getInstance().getCalibrationImageSavePath(inputImage.size()).toString(), snapshotName);
+                image_path =
+                        Paths.get(
+                                ConfigManager.getInstance()
+                                        .getCalibrationImageSavePath(inputImage.size())
+                                        .toString(),
+                                snapshotName);
                 Imgcodecs.imwrite(image_path.toString(), inputImage);
             }
 

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Calibrate3dPipe.java
@@ -458,7 +458,11 @@ public class Calibrate3dPipe
         public String uniqueCameraName;
 
         public CalibratePipeParams(
-                int boardHeightSquares, int boardWidthSquares, double squareSize, boolean usemrcal, String uniqueCameraName) {
+                int boardHeightSquares,
+                int boardWidthSquares,
+                double squareSize,
+                boolean usemrcal,
+                String uniqueCameraName) {
             this.boardHeight = boardHeightSquares - 1;
             this.boardWidth = boardWidthSquares - 1;
             this.squareSize = squareSize;

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -99,7 +99,11 @@ public class Calibrate3dPipeline
 
         Calibrate3dPipe.CalibratePipeParams calibratePipeParams =
                 new Calibrate3dPipe.CalibratePipeParams(
-                        settings.boardHeight, settings.boardWidth, settings.gridSize, settings.useMrCal, uniqueCameraName);
+                        settings.boardHeight,
+                        settings.boardWidth,
+                        settings.gridSize,
+                        settings.useMrCal,
+                        uniqueCameraName);
         calibrate3dPipe.setParams(calibratePipeParams);
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -18,6 +18,7 @@
 package org.photonvision.vision.pipeline;
 
 import edu.wpi.first.math.util.Units;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -69,18 +70,15 @@ public class Calibrate3dPipeline
 
     private static final FrameThresholdType PROCESSING_TYPE = FrameThresholdType.NONE;
 
-    private final String uniqueCameraName;
-
-    public Calibrate3dPipeline(String uniqueCameraName) {
-        this(12, uniqueCameraName);
+    public Calibrate3dPipeline() {
+        this(12);
     }
 
-    public Calibrate3dPipeline(int minSnapshots, String uniqueCameraName) {
+    public Calibrate3dPipeline(int minSnapshots) {
         super(PROCESSING_TYPE);
         this.settings = new Calibration3dPipelineSettings();
         this.foundCornersList = new ArrayList<>();
         this.minSnapshots = minSnapshots;
-        this.uniqueCameraName = uniqueCameraName;
     }
 
     @Override
@@ -99,11 +97,7 @@ public class Calibrate3dPipeline
 
         Calibrate3dPipe.CalibratePipeParams calibratePipeParams =
                 new Calibrate3dPipe.CalibratePipeParams(
-                        settings.boardHeight,
-                        settings.boardWidth,
-                        settings.gridSize,
-                        settings.useMrCal,
-                        uniqueCameraName);
+                        settings.boardHeight, settings.boardWidth, settings.gridSize, settings.useMrCal);
         calibrate3dPipe.setParams(calibratePipeParams);
     }
 
@@ -181,7 +175,7 @@ public class Calibrate3dPipeline
         return foundCornersList.size() >= minSnapshots;
     }
 
-    public CameraCalibrationCoefficients tryCalibration() {
+    public CameraCalibrationCoefficients tryCalibration(Path imageSavePath) {
         if (!hasEnough()) {
             logger.info(
                     "Not enough snapshots! Only got "
@@ -200,7 +194,8 @@ public class Calibrate3dPipeline
          * and returns the corresponding image and object points
          */
         calibrationOutput =
-                calibrate3dPipe.run(new CalibrationInput(foundCornersList, frameStaticProperties));
+                calibrate3dPipe.run(
+                        new CalibrationInput(foundCornersList, frameStaticProperties, imageSavePath));
 
         this.calibrating = false;
 

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -69,15 +69,18 @@ public class Calibrate3dPipeline
 
     private static final FrameThresholdType PROCESSING_TYPE = FrameThresholdType.NONE;
 
-    public Calibrate3dPipeline(String uniqueName) {
-        this(12, uniqueName);
+    private final String uniqueCameraName;
+
+    public Calibrate3dPipeline(String uniqueCameraName) {
+        this(12, uniqueCameraName);
     }
 
-    public Calibrate3dPipeline(int minSnapshots, String uniqueName) {
+    public Calibrate3dPipeline(int minSnapshots, String uniqueCameraName) {
         super(PROCESSING_TYPE);
         this.settings = new Calibration3dPipelineSettings();
         this.foundCornersList = new ArrayList<>();
         this.minSnapshots = minSnapshots;
+        this.uniqueCameraName = uniqueCameraName;
     }
 
     @Override
@@ -96,7 +99,7 @@ public class Calibrate3dPipeline
 
         Calibrate3dPipe.CalibratePipeParams calibratePipeParams =
                 new Calibrate3dPipe.CalibratePipeParams(
-                        settings.boardHeight, settings.boardWidth, settings.gridSize, settings.useMrCal);
+                        settings.boardHeight, settings.boardWidth, settings.gridSize, settings.useMrCal, uniqueCameraName);
         calibrate3dPipe.setParams(calibratePipeParams);
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
@@ -60,7 +60,6 @@ public class PipelineManager {
     PipelineManager(
             DriverModePipelineSettings driverSettings,
             List<CVPipelineSettings> userPipelines,
-            String uniqueName,
             int defaultIndex) {
         this.userPipelineSettings = new ArrayList<>(userPipelines);
         // This is to respect the default res idx for vendor cameras
@@ -69,7 +68,7 @@ public class PipelineManager {
 
         if (userPipelines.isEmpty()) addPipeline(PipelineType.Reflective);
 
-        calibration3dPipeline = new Calibrate3dPipeline(uniqueName);
+        calibration3dPipeline = new Calibrate3dPipeline();
 
         // We know that at this stage, VisionRunner hasn't yet started so we're good to
         // do this from
@@ -79,11 +78,7 @@ public class PipelineManager {
     }
 
     public PipelineManager(CameraConfiguration config) {
-        this(
-                config.driveModeSettings,
-                config.pipelineSettings,
-                config.uniqueName,
-                config.currentPipelineIndex);
+        this(config.driveModeSettings, config.pipelineSettings, config.currentPipelineIndex);
     }
 
     /**

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -54,7 +54,6 @@ import org.photonvision.vision.pipeline.OutputStreamPipeline;
 import org.photonvision.vision.pipeline.ReflectivePipelineSettings;
 import org.photonvision.vision.pipeline.UICalibrationData;
 import org.photonvision.vision.pipeline.result.CVPipelineResult;
-import org.photonvision.vision.pipeline.result.CalibrationPipelineResult;
 import org.photonvision.vision.target.TargetModel;
 import org.photonvision.vision.target.TrackedTarget;
 
@@ -593,10 +592,7 @@ public class VisionModule {
 
     private void consumePipelineResult(CVPipelineResult result) {
         for (var dataConsumer : resultConsumers) {
-            if (!(result instanceof CalibrationPipelineResult)
-                    && !(dataConsumer instanceof NTDataPublisher)) {
-                dataConsumer.accept(result);
-            }
+            dataConsumer.accept(result);
         }
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -54,6 +54,7 @@ import org.photonvision.vision.pipeline.OutputStreamPipeline;
 import org.photonvision.vision.pipeline.ReflectivePipelineSettings;
 import org.photonvision.vision.pipeline.UICalibrationData;
 import org.photonvision.vision.pipeline.result.CVPipelineResult;
+import org.photonvision.vision.pipeline.result.CalibrationPipelineResult;
 import org.photonvision.vision.target.TargetModel;
 import org.photonvision.vision.target.TrackedTarget;
 
@@ -592,7 +593,10 @@ public class VisionModule {
 
     private void consumePipelineResult(CVPipelineResult result) {
         for (var dataConsumer : resultConsumers) {
-            dataConsumer.accept(result);
+            if (!(result instanceof CalibrationPipelineResult)
+                    && !(dataConsumer instanceof NTDataPublisher)) {
+                dataConsumer.accept(result);
+            }
         }
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -105,8 +105,7 @@ public class VisionModule {
             visionSource.getCameraConfiguration().cameraQuirks = QuirkyCamera.DefaultCamera;
 
         // We don't show gain if the config says it's -1. So check here to make sure
-        // it's non-negative
-        // if it _is_ supported
+        // it's non-negative if it _is_ supported
         if (cameraQuirks.hasQuirk(CameraQuirk.Gain)) {
             pipelineManager.userPipelineSettings.forEach(
                     it -> {

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -388,7 +388,12 @@ public class VisionModule {
     }
 
     public CameraCalibrationCoefficients endCalibration() {
-        var ret = pipelineManager.calibration3dPipeline.tryCalibration();
+        var ret =
+                pipelineManager.calibration3dPipeline.tryCalibration(
+                        ConfigManager.getInstance()
+                                .getCalibrationImageSavePath(
+                                        pipelineManager.calibration3dPipeline.getSettings().resolution,
+                                        visionSource.getCameraConfiguration().uniqueName));
         pipelineManager.setCalibrationMode(false);
 
         setPipeline(pipelineManager.getRequestedIndex());

--- a/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/pipeline/Calibrate3dPipeTest.java
@@ -32,6 +32,7 @@ import org.opencv.calib3d.Calib3d;
 import org.opencv.core.Mat;
 import org.opencv.core.Size;
 import org.opencv.imgcodecs.Imgcodecs;
+import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.LogLevel;
 import org.photonvision.common.logging.Logger;
@@ -215,8 +216,7 @@ public class Calibrate3dPipeTest {
 
         assertTrue(directoryListing.length >= 12);
 
-        Calibrate3dPipeline calibration3dPipeline =
-                new Calibrate3dPipeline(10, "test_calibration_common");
+        Calibrate3dPipeline calibration3dPipeline = new Calibrate3dPipeline(10);
         calibration3dPipeline.getSettings().boardType = boardType;
         calibration3dPipeline.getSettings().markerSize = markerSize;
         calibration3dPipeline.getSettings().tagFamily = tagFamily;
@@ -253,7 +253,9 @@ public class Calibrate3dPipeTest {
                         .map(it -> it.imagePoints)
                         .allMatch(it -> it.width() > 0 && it.height() > 0));
 
-        var cal = calibration3dPipeline.tryCalibration();
+        var cal =
+                calibration3dPipeline.tryCalibration(
+                        ConfigManager.getInstance().getCalibrationImageSavePath(imgRes, "Calibration_Test"));
         calibration3dPipeline.finishCalibration();
 
         // visuallyDebugDistortion(directoryListing, imgRes, cal );

--- a/photon-core/src/test/java/org/photonvision/vision/processes/PipelineManagerTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/processes/PipelineManagerTest.java
@@ -30,7 +30,7 @@ public class PipelineManagerTest {
     public void testUniqueName() {
         TestUtils.loadLibraries();
         PipelineManager manager =
-                new PipelineManager(new DriverModePipelineSettings(), List.of(), "meme_name", -1);
+                new PipelineManager(new DriverModePipelineSettings(), List.of(), -1);
         manager.addPipeline(PipelineType.Reflective, "Another");
 
         // We now have ["New Pipeline", "Another"]

--- a/photon-core/src/test/java/org/photonvision/vision/processes/PipelineManagerTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/processes/PipelineManagerTest.java
@@ -29,8 +29,7 @@ public class PipelineManagerTest {
     @Test
     public void testUniqueName() {
         TestUtils.loadLibraries();
-        PipelineManager manager =
-                new PipelineManager(new DriverModePipelineSettings(), List.of(), -1);
+        PipelineManager manager = new PipelineManager(new DriverModePipelineSettings(), List.of(), -1);
         manager.addPipeline(PipelineType.Reflective, "Another");
 
         // We now have ["New Pipeline", "Another"]

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -581,10 +581,11 @@ public class RequestHandler {
         // encode as jpeg to save even more space. reduces size of a 1280p image from 300k to 25k
         var jpegBytes = new MatOfByte();
         Mat img = null;
-        try{
-            img = Imgcodecs.imread(calList.observations.get(observationIdx).snapshotDataLocation.toString());
-        }
-        catch (Exception e){
+        try {
+            img =
+                    Imgcodecs.imread(
+                            calList.observations.get(observationIdx).snapshotDataLocation.toString());
+        } catch (Exception e) {
             ctx.status(500);
             ctx.result("Unable to read calibration image");
             return;
@@ -595,11 +596,7 @@ public class RequestHandler {
             return;
         }
 
-        Imgcodecs.imencode(
-                ".jpg",
-                img,
-                jpegBytes,
-                new MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, 60));
+        Imgcodecs.imencode(".jpg", img, jpegBytes, new MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, 60));
 
         ctx.result(jpegBytes.toArray());
         jpegBytes.release();

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -582,7 +582,6 @@ public class RequestHandler {
         Imgcodecs.imencode(
                 ".jpg",
                 Imgcodecs.imread(calList.observations.get(observationIdx).snapshotDataLocation.toString()),
-                // calList.observations.get(observationIdx).snapshotData.getAsMat(),
                 jpegBytes,
                 new MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, 60));
 

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Optional;
 import javax.imageio.ImageIO;
 import org.apache.commons.io.FileUtils;
+import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
 import org.opencv.core.MatOfInt;
 import org.opencv.imgcodecs.Imgcodecs;
@@ -579,9 +580,24 @@ public class RequestHandler {
 
         // encode as jpeg to save even more space. reduces size of a 1280p image from 300k to 25k
         var jpegBytes = new MatOfByte();
+        Mat img = null;
+        try{
+            img = Imgcodecs.imread(calList.observations.get(observationIdx).snapshotDataLocation.toString());
+        }
+        catch (Exception e){
+            ctx.status(500);
+            ctx.result("Unable to read calibration image");
+            return;
+        }
+        if (img == null || img.empty()) {
+            ctx.status(500);
+            ctx.result("Unable to read calibration image");
+            return;
+        }
+
         Imgcodecs.imencode(
                 ".jpg",
-                Imgcodecs.imread(calList.observations.get(observationIdx).snapshotDataLocation.toString()),
+                img,
                 jpegBytes,
                 new MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, 60));
 

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -581,7 +581,8 @@ public class RequestHandler {
         var jpegBytes = new MatOfByte();
         Imgcodecs.imencode(
                 ".jpg",
-                calList.observations.get(observationIdx).snapshotData.getAsMat(),
+                Imgcodecs.imread(calList.observations.get(observationIdx).snapshotDataLocation.toString()),
+                // calList.observations.get(observationIdx).snapshotData.getAsMat(),
                 jpegBytes,
                 new MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, 60));
 


### PR DESCRIPTION
The target list in networktables is limited to 127 items. When you capture more than 127 calibration images it breaks this limit and errors out and dies. Do not publish calibration targets to nt.