### PR TITLE
ChArUco: adjust detector params, hide unused

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/DrawCalibrationPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/DrawCalibrationPipe.java
@@ -56,6 +56,11 @@ public class DrawCalibrationPipe
         int i = 0;
         for (var target : in.getRight()) {
             for (var c : target.getTargetCorners()) {
+                if (c.x < 0 || c.y < 0) {
+                    // Skip if the corner is less than zero
+                    continue;
+                }
+
                 c =
                         new Point(
                                 c.x / params.divisor.value.doubleValue(), c.y / params.divisor.value.doubleValue());

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/FindBoardCornersPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/FindBoardCornersPipe.java
@@ -116,6 +116,11 @@ public class FindBoardCornersPipe
                             Objdetect.getPredefinedDictionary(params.tagFamily.getValue()));
             board.setLegacyPattern(params.useOldPattern);
             detector = new CharucoDetector(board);
+            detector.getDetectorParameters().set_adaptiveThreshConstant(10);
+            detector.getDetectorParameters().set_adaptiveThreshWinSizeMin(11);
+            detector.getDetectorParameters().set_adaptiveThreshWinSizeStep(40);
+            detector.getDetectorParameters().set_adaptiveThreshWinSizeMax(91);
+
         } else {
             logger.error("Can't create pattern for unknown board type " + params.type);
         }


### PR DESCRIPTION
There are a few values for thresholds that we can set to help with the detection of aruco markers. Additionally, when an aruco marker is not detected during calibration it puts a dot in the top left of the image at (-1,-1). We don't need to display those.