### PR TITLE
Fix apriltag detection draw bug

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/AdvancedPipelineSettings.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/AdvancedPipelineSettings.java
@@ -80,7 +80,7 @@ public class AdvancedPipelineSettings extends CVPipelineSettings {
 
     // 3d settings
     public boolean solvePNPEnabled = false;
-    public TargetModel targetModel = TargetModel.k2020HighGoalOuter;
+    @SuppressSettingCopy public TargetModel targetModel = TargetModel.k2020HighGoalOuter;
 
     // Corner detection settings
     public CornerDetectionPipe.DetectionStrategy cornerDetectionStrategy =

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/CVPipelineSettings.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/CVPipelineSettings.java
@@ -36,8 +36,8 @@ import org.photonvision.vision.opencv.ImageRotationMode;
     @JsonSubTypes.Type(value = ObjectDetectionPipelineSettings.class)
 })
 public class CVPipelineSettings implements Cloneable {
-    public int pipelineIndex = 0;
-    public PipelineType pipelineType = PipelineType.DriverMode;
+    @SuppressSettingCopy public int pipelineIndex = 0;
+    @SuppressSettingCopy public PipelineType pipelineType = PipelineType.DriverMode;
     public ImageRotationMode inputImageRotationMode = ImageRotationMode.DEG_0;
     public String pipelineNickname = "New Pipeline";
     public boolean cameraAutoExposure = false;

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/CVPipelineSettings.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/CVPipelineSettings.java
@@ -36,7 +36,7 @@ import org.photonvision.vision.opencv.ImageRotationMode;
     @JsonSubTypes.Type(value = ObjectDetectionPipelineSettings.class)
 })
 public class CVPipelineSettings implements Cloneable {
-    @SuppressSettingCopy public int pipelineIndex = 0;
+    public int pipelineIndex = 0;
     @SuppressSettingCopy public PipelineType pipelineType = PipelineType.DriverMode;
     public ImageRotationMode inputImageRotationMode = ImageRotationMode.DEG_0;
     public String pipelineNickname = "New Pipeline";

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/SuppressSettingCopy.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/SuppressSettingCopy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.vision.pipeline;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+/** This annotation is used to suppress copying the settings from one pipeline to the next */
+public @interface SuppressSettingCopy {}

--- a/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
@@ -518,6 +518,10 @@ public class PipelineManager {
         // Copy all fields from AdvancedPipelineSettings/its superclasses from old to new
         try {
             for (Field field : getAllFields(AdvancedPipelineSettings.class)) {
+                if (field.isAnnotationPresent(SuppressSettingCopy.class)) {
+                    // Skip fields that are annotated with SuppressSettingCopy
+                    continue;
+                }
                 Object value = field.get(oldSettings);
                 logger.debug("setting " + field.getName() + " to " + value);
                 field.set(newSettings, value);
@@ -527,10 +531,6 @@ public class PipelineManager {
         }
 
         logger.info("Adding new pipe of type " + type + " at idx " + idx);
-
-        // type gets overritten by reflction hackery above
-        newSettings.pipelineIndex = idx;
-        newSettings.pipelineType = type;
 
         userPipelineSettings.set(idx, newSettings);
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
@@ -531,7 +531,6 @@ public class PipelineManager {
         }
 
         logger.info("Adding new pipe of type " + type + " at idx " + idx);
-        newSettings.pipelineIndex = idx;
 
         userPipelineSettings.set(idx, newSettings);
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
@@ -531,6 +531,7 @@ public class PipelineManager {
         }
 
         logger.info("Adding new pipe of type " + type + " at idx " + idx);
+        newSettings.pipelineIndex = idx;
 
         userPipelineSettings.set(idx, newSettings);
 


### PR DESCRIPTION
We accidentally copied more settings then we wanted. This adds an annotation that we can mark variables with that will prevent them from being copied when we switch pipeline types.