### PR TITLE
Fix aruco draw

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Draw3dArucoPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/Draw3dArucoPipe.java
@@ -30,6 +30,7 @@ public class Draw3dArucoPipe extends Draw3dTargetsPipe {
                 FrameDivisor divisor) {
             super(shouldDraw, cameraCalibrationCoefficients, targetModel, divisor);
             this.shouldDrawHull = false;
+            this.redistortPoints = true;
         }
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/OutputStreamPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/OutputStreamPipeline.java
@@ -24,7 +24,6 @@ import org.photonvision.vision.frame.FrameStaticProperties;
 import org.photonvision.vision.opencv.DualOffsetValues;
 import org.photonvision.vision.pipe.impl.*;
 import org.photonvision.vision.pipeline.result.CVPipelineResult;
-import org.photonvision.vision.target.TargetModel;
 import org.photonvision.vision.target.TrackedTarget;
 
 /**
@@ -108,7 +107,7 @@ public class OutputStreamPipeline {
                 new Draw3dArucoPipe.Draw3dArucoParams(
                         settings.outputShouldDraw,
                         frameStaticProperties.cameraCalibration,
-                        TargetModel.kAprilTag6in_16h5,
+                        settings.targetModel,
                         settings.streamingFrameDivisor);
         draw3dArucoPipe.setParams(draw3dArucoParams);
 


### PR DESCRIPTION
Someone hard-coded the 16h5 model. Additionally, the April tag pipeline redistorts the points before drawing them, so let's do that as well.