### PR TITLE
Fix reflective null points

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/target/TrackedTarget.java
+++ b/photon-core/src/main/java/org/photonvision/vision/target/TrackedTarget.java
@@ -441,7 +441,7 @@ public class TrackedTarget implements Releasable {
             }
             {
                 var points = t.getTargetCorners();
-                if(points != null) {
+                if (points != null) {
                     for (Point point : points) {
                         detectedCorners.add(new TargetCorner(point.x, point.y));
                     }

--- a/photon-core/src/main/java/org/photonvision/vision/target/TrackedTarget.java
+++ b/photon-core/src/main/java/org/photonvision/vision/target/TrackedTarget.java
@@ -441,8 +441,10 @@ public class TrackedTarget implements Releasable {
             }
             {
                 var points = t.getTargetCorners();
-                for (Point point : points) {
-                    detectedCorners.add(new TargetCorner(point.x, point.y));
+                if(points != null) {
+                    for (Point point : points) {
+                        detectedCorners.add(new TargetCorner(point.x, point.y));
+                    }
                 }
             }
 


### PR DESCRIPTION
fixes 

[19:02:28] [2024-10-14 23:02:27] [VisionModule - VisionRunner - USBFrameProvider - opencv_Microsoft_LifeCam_HD-3000] [ERROR] java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "points" is null at org.photonvision.vision.target.TrackedTarget.simpleFromTrackedTargets(TrackedTarget.java:444) at org.photonvision.common.dataflow.networktables.NTDataPublisher.accept(NTDataPublisher.java:156) at org.photonvision.common.dataflow.networktables.NTDataPublisher.accept(NTDataPublisher.java:39) at org.photonvision.vision.processes.VisionModule.consumePipelineResult(VisionModule.java:599) at org.photonvision.vision.processes.VisionModule.consumeResult(VisionModule.java:579) at org.photonvision.vision.processes.VisionRunner.update(VisionRunner.java:116) at java.base/java.lang.Thread.run(Thread.java:840)
[19:02:28] [2024-10-14 23:02:28] [VisionModule - VisionRunner - USBFrameProvider - opencv_Microsoft_LifeCam_HD-3000] [ERROR] Exception on loop 4430: Cannot invoke "java.util.List.iterator()" because "points" is null
[19:02:28] [2024-10-14 23:02:28] [VisionModule - VisionRunner - USBFrameProvider - opencv_Microsoft_LifeCam_HD-3000] [ERROR] java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "points" is null at org.photonvision.vision.target.TrackedTarget.simpleFromTrackedTargets(TrackedTarget.java:444) at org.photonvision.common.dataflow.networktables.NTDataPublisher.accept(NTDataPublisher.java:156) at org.photonvision.common.dataflow.networktables.NTDataPublisher.accept(NTDataPublisher.java:39) at org.photonvision.vision.processes.VisionModule.consumePipelineResult(VisionModule.java:599) at org.photonvision.vision.processes.VisionModule.consumeResult(VisionModule.java:579) at org.photonvision.vision.processes.VisionRunner.update(VisionRunner.java:116) at java.base/java.lang.Thread.run(Thread.java:840)