### PR TITLE
Improve network management

### DIFF
--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -78,7 +78,7 @@ export const useSettingsStore = defineStore("settings", {
       return this.general.gpuAcceleration !== undefined;
     },
     networkInterfaceNames(): string[] {
-      return this.network.networkInterfaceNames.map((i) => i.connName);
+      return this.network.networkInterfaceNames.map((i) => i.devName);
     }
   },
   actions: {

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.networking.NetworkMode;
-import org.photonvision.common.networking.NetworkUtils;
 import org.photonvision.common.util.file.JacksonUtils;
 
 public class NetworkConfig {
@@ -51,22 +50,13 @@ public class NetworkConfig {
     @JsonIgnore public static final String NM_IP_STRING = "${ipaddr}";
 
     public String networkManagerIface;
+    // TODO: remove these strings if no longer needed
     public String setStaticCommand =
             "nmcli con mod ${interface} ipv4.addresses ${ipaddr}/8 ipv4.method \"manual\" ipv6.method \"disabled\"";
     public String setDHCPcommand =
             "nmcli con mod ${interface} ipv4.method \"auto\" ipv6.method \"disabled\"";
 
     public NetworkConfig() {
-        if (Platform.isLinux()) {
-            // Default to the name of the first Ethernet connection. Otherwise, "Wired connection 1" is a
-            // reasonable guess
-            this.networkManagerIface =
-                    NetworkUtils.getAllWiredInterfaces().stream()
-                            .map(it -> it.connName)
-                            .findFirst()
-                            .orElse("Wired connection 1");
-        }
-
         // We can (usually) manage networking on Linux devices, and if we can, we should try to. Command
         // line inhibitions happen at a level above this class
         setShouldManage(deviceCanManageNetwork());
@@ -112,7 +102,7 @@ public class NetworkConfig {
 
     @JsonIgnore
     public String getPhysicalInterfaceName() {
-        return NetworkUtils.getNMinfoForConnName(this.networkManagerIface).devName;
+        return this.networkManagerIface;
     }
 
     @JsonIgnore

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -49,7 +49,7 @@ public class NetworkConfig {
     @JsonIgnore public static final String NM_IFACE_STRING = "${interface}";
     @JsonIgnore public static final String NM_IP_STRING = "${ipaddr}";
 
-    public String networkManagerIface;
+    public String networkManagerIface = "";
     // TODO: remove these strings if no longer needed
     public String setStaticCommand =
             "nmcli con mod ${interface} ipv4.addresses ${ipaddr}/8 ipv4.method \"manual\" ipv6.method \"disabled\"";

--- a/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
@@ -120,7 +120,7 @@ public class PhotonConfiguration {
 
         // Hack active interfaces into networkSettings
         var netConfigMap = networkConfig.toHashMap();
-        netConfigMap.put("networkInterfaceNames", NetworkUtils.getAllWiredInterfaces());
+        netConfigMap.put("networkInterfaceNames", NetworkUtils.getAllActiveWiredInterfaces());
         netConfigMap.put("networkingDisabled", NetworkManager.getInstance().networkingIsDisabled);
 
         settingsSubmap.put("networkSettings", netConfigMap);

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -17,6 +17,8 @@
 
 package org.photonvision.common.networking;
 
+import java.util.NoSuchElementException;
+
 import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.configuration.NetworkConfig;
 import org.photonvision.common.dataflow.DataChangeDestination;
@@ -78,12 +80,12 @@ public class NetworkManager {
                 // update NetworkConfig with found interface
                 config.networkManagerIface = iFace.devName;
                 ConfigManager.getInstance().requestSave();
-            } catch (Exception e) {
+            } catch (NoSuchElementException e) {
                 // if there are no available interfaces, go with the one from settings
                 logger.warn("No physical interface found. Maybe ethernet isn't connected?");
                 if (config.networkManagerIface.isBlank()) {
                     // if it's also empty, there is nothing to configure
-                    logger.error("No valid network interfaces to manage", e);
+                    logger.error("No valid network interfaces to manage");
                     // TODO: add a thread that monitors the network
                     return;
                 }

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -58,7 +58,7 @@ public class NetworkManager {
         }
 
         if (!PlatformUtils.isRoot()) {
-            logger.error("Cannot manage hostname without root!");
+            logger.error("Cannot manage network without root!");
             return;
         }
 

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -93,7 +93,6 @@ public class NetworkManager {
             setHostname(config.hostname);
         } else {
             logger.warn("Got empty hostname?");
-            // should we force it back to photonvision in this case?
         }
 
         if (config.connectionType == NetworkMode.DHCP) {
@@ -189,7 +188,7 @@ public class NetworkManager {
             }
             // activate it
             logger.info("Activating the DHCP connection " + connName );
-            shell.executeBashCommand("nmcli connection up " + connName, false);
+            shell.executeBashCommand("nmcli connection up \"${connection}\"".replace("${connection}", connName), false);
 
             if (Platform.isRaspberryPi()) {
                 shell.executeBashCommand("dhclient " + config.networkManagerIface, false);
@@ -251,7 +250,7 @@ public class NetworkManager {
             }
             // activate it
             logger.info("Activating the Static connection " + connName );
-            shell.executeBashCommand("nmcli connection up " + connName, false);
+            shell.executeBashCommand("nmcli connection up \"${connection}\"".replace("${connection}", connName), false);
         } catch (Exception e) {
             logger.error("Error while setting static IP!", e);
         }

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -271,7 +271,7 @@ public class NetworkManager {
         Path file = Path.of("/sys/class/net/{device}/carrier".replace("{device}", devName));
         logger.debug("Watching device at path: " + file.toString());
         var last = new Object() {boolean carrier = true;};
-        return () -> 
+        return () ->
         {
             try {
                 boolean carrier = Files.readString(file).trim().equals("1");

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -87,7 +87,7 @@ public class NetworkManager {
             } catch (NoSuchElementException e) {
                 // if there are no available interfaces, go with the one from settings
                 logger.warn("No physical interface found. Maybe ethernet isn't connected?");
-                if (config.networkManagerIface.isBlank()) {
+                if (config.networkManagerIface == null || config.networkManagerIface.isBlank()) {
                     // if it's also empty, there is nothing to configure
                     logger.error("No valid network interfaces to manage");
                     // TODO: add a thread that monitors the network

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -126,8 +126,14 @@ public class NetworkUtils {
     }
 
     public static List<NMDeviceInfo> getAllWiredInterfaces() {
-        return getAllActiveInterfaces().stream()
-                .filter(it -> it.nmType == NMType.NMTYPE_ETHERNET)
+        return getAllInterfaces().stream()
+                .filter(it -> it.nmType.equals(NMType.NMTYPE_ETHERNET))
+                .collect(Collectors.toList());
+    }
+
+    public static List<NMDeviceInfo> getAllActiveWiredInterfaces() {
+        return getAllWiredInterfaces().stream()
+                .filter(it -> !it.connName.isBlank())
                 .collect(Collectors.toList());
     }
 

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -102,13 +102,16 @@ public class NetworkUtils {
                     Pattern.compile("GENERAL.CONNECTION:(.*)\nGENERAL.DEVICE:(.*)\nGENERAL.TYPE:(.*)");
             Matcher matcher = pattern.matcher(out);
             while (matcher.find()) {
-                ret.add(new NMDeviceInfo(matcher.group(1), matcher.group(2), matcher.group(3)));
+                if (!matcher.group(2).equals("lo")) {
+                    // only include non-loopback devices
+                    ret.add(new NMDeviceInfo(matcher.group(1), matcher.group(2), matcher.group(3)));
+                }
             }
         } catch (IOException e) {
-            logger.error("Could not get active NM ifaces!", e);
+            logger.error("Could not get active network interfaces!", e);
         }
 
-        logger.debug("Found network interfaces:\n" + ret);
+        logger.debug("Found network interfaces: " + ret);
 
         allInterfaces = ret;
         return ret;
@@ -135,5 +138,27 @@ public class NetworkUtils {
             }
         }
         return null;
+    }
+
+    public static NMDeviceInfo getNMinfoForDevName(String devName) {
+        for (NMDeviceInfo info : getAllActiveInterfaces()) {
+            if (info.devName.equals(devName)) {
+                return info;
+            }
+        }
+        logger.warn("Could not find a match for network device " + devName);
+        return null;
+    }
+
+    public static boolean connDoesNotExist(String connName) {
+        var shell = new ShellExec(true, true);
+        try {
+            // set nmcli back to DHCP, and re-run dhclient -- this ought to grab a new IP address
+            shell.executeBashCommand("nmcli -f GENERAL.STATE connection show \"" + connName + "\"");
+            return (shell.getExitCode() == 10);
+        } catch (Exception e) {
+            logger.error("Exception from nmcli!");
+        }
+        return false;
     }
 }

--- a/photon-core/src/main/java/org/photonvision/common/util/TimedTaskManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/util/TimedTaskManager.java
@@ -79,4 +79,8 @@ public class TimedTaskManager {
             activeTasks.remove(identifier);
         }
     }
+
+    public boolean taskActive(String identifier) {
+        return activeTasks.containsKey(identifier);
+    }
 }

--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -3,8 +3,8 @@ apply plugin: "java"
 apply plugin: "jacoco"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 wpilibTools.deps.wpilibVersion = wpilibVersion


### PR DESCRIPTION
This PR changes the way that photonvision interacts with nmcli to control networking on the coprocessor. Instead of modifying an existing connection, Photonvision adds new connections for DHCP and Static IP configurations. It then activiates the proper one at startup and any time that the network configuration is changed. 

It also now uses the interface name and not the connection name and it checks that the interface is available before making any changes. If the saved interface is not found, it updates the stored interface name and applies the network settings to the current interface. This should minimize the failure to control the network if the network interface wasn't available when PhotonVision first booted.

One other benefit of not altering the default configuration is that, if PhotonVision fails to run for any reason, the device can be accessed using the original networking configuration.

I've tested this on an OrangePi and so far, it is working very well.

Addresses: #1261 