### PR TITLE
Add slider debounce

### DIFF
--- a/photon-client/src/components/common/pv-slider.vue
+++ b/photon-client/src/components/common/pv-slider.vue
@@ -36,7 +36,6 @@ function debounce(func: (...args: any[]) => void, wait: number) {
 
 const debouncedEmit = debounce((v: number) => {
   emit("input", v);
-  console.log("debouncedEmit", v);
 }, 20);
 
 const localValue = computed({

--- a/photon-client/src/components/common/pv-slider.vue
+++ b/photon-client/src/components/common/pv-slider.vue
@@ -28,7 +28,7 @@ const emit = defineEmits<{
 // Debounce function
 function debounce(func: (...args: any[]) => void, wait: number) {
   let timeout: ReturnType<typeof setTimeout>;
-  return function(...args: any[]) {
+  return function (...args: any[]) {
     clearTimeout(timeout);
     timeout = setTimeout(() => func.apply(this, args), wait);
   };

--- a/photon-client/src/components/common/pv-slider.vue
+++ b/photon-client/src/components/common/pv-slider.vue
@@ -25,9 +25,23 @@ const emit = defineEmits<{
   (e: "input", value: number): void;
 }>();
 
+// Debounce function
+function debounce(func: (...args: any[]) => void, wait: number) {
+  let timeout: ReturnType<typeof setTimeout>;
+  return function(...args: any[]) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(this, args), wait);
+  };
+}
+
+const debouncedEmit = debounce((v: number) => {
+  emit("input", v);
+  console.log("debouncedEmit", v);
+}, 20);
+
 const localValue = computed({
   get: () => props.value,
-  set: (v) => emit("input", parseFloat(v as unknown as string))
+  set: (v) => debouncedEmit(parseFloat(v as unknown as string))
 });
 </script>
 


### PR DESCRIPTION
Sliders for exposure and brightness would spam messages on the backend. This used to cause crashes and can cause it to get quite laggy / delayed. This will add a 20ms debounce which won't send the value to the backend until the value hasn't changed for 20ms.