### PR TITLE
Equal only by usb paths

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraInfo.java
@@ -95,7 +95,7 @@ public class CameraInfo extends UsbCameraInfo {
 
         if (!path.equals(other.path)) return false;
         if (!name.equals(other.name)) return false;
-        if (!Arrays.asList(this.otherPaths).containsAll(Arrays.asList(other.otherPaths))) return false;
+        if (!Arrays.asList(this.getUSBPath()).contains(other.getUSBPath())) return false;
         if (vendorId != other.vendorId) return false;
         if (productId != other.productId) return false;
 


### PR DESCRIPTION
This bug would only appear when there are cameras with the same naming. Old config matching would also match using the by-id this was problematic. When one camera is disconnected it would assign the by-id path to the other camera with the 
 same name. When the camera is replugged in it would not be reassigned the by-id path and would fail the camerainfo equals check.

For example:

```
Camera A (other paths contains) :
/dev/v4l/by-path/platform-fc800000.usb-usb-0:1:1.0-video-index0
/dev/v4l/by-id/usb-Arducam_Technology_Co.__Ltd._Arducam_OV9782_USB_Camera_UC852-video-index0

Camera B (other paths contains) :
/dev/v4l/by-path/platform-fc880000.usb-usb-0:1:1.0-video-index0
```


When camera A is unplugged:
```
Camera A (other paths contains) :
(nothing its unplugged)

Camera B (other paths contains) :
/dev/v4l/by-path/platform-fc880000.usb-usb-0:1:1.0-video-index0
/dev/v4l/by-id/usb-Arducam_Technology_Co.__Ltd._Arducam_OV9782_USB_Camera_UC852-video-index0
```

When camera A is plugged in again:
```
Camera A (other paths contains) :
/dev/v4l/by-path/platform-fc800000.usb-usb-0:1:1.0-video-index0

Camera B (other paths contains) :
/dev/v4l/by-path/platform-fc880000.usb-usb-0:1:1.0-video-index0
/dev/v4l/by-id/usb-Arducam_Technology_Co.__Ltd._Arducam_OV9782_USB_Camera_UC852-video-index0

```
