### PR TITLE
Re-set config save default state to true

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -54,7 +54,7 @@ public class ConfigManager {
     // special case flag to disable flushing settings to disk at shutdown. Avoids the jvm shutdown
     // hook overwriting the settings we just uploaded
     private boolean flushOnShutdown = true;
-    private boolean allowWriteTask = false;
+    private boolean allowWriteTask = true;
 
     enum ConfigSaveStrategy {
         SQL,


### PR DESCRIPTION
Previously, no config updates were ever saved out. At all. Oops.