### PR TITLE
Fix photon-targetting being a seperate project

### DIFF
--- a/photon-targeting/build.gradle
+++ b/photon-targeting/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'edu.wpi.first.WpilibTools' version '1.3.0'
-}
-
 ext {
     nativeName = "photontargeting"
 }
@@ -9,6 +5,7 @@ ext {
 apply plugin: 'cpp'
 apply plugin: 'google-test-test-suite'
 apply plugin: 'edu.wpi.first.NativeUtils'
+apply plugin: 'edu.wpi.first.WpilibTools'
 apply plugin: 'edu.wpi.first.GradleJni'
 
 apply from: "${rootDir}/shared/config.gradle"

--- a/photon-targeting/settings.gradle
+++ b/photon-targeting/settings.gradle
@@ -1,6 +1,0 @@
-pluginManagement {
-    repositories {
-        mavenLocal()
-        gradlePluginPortal()
-    }
-}


### PR DESCRIPTION
The settings.gradle means that this is a seperate project which is wrong, we want to treat it as a subproject as its included in the root settings.gradle.