### PR TITLE
 Remove nonsensical includes

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,3 @@
 include 'photon-targeting'
-include 'photon-core'
-include 'photon-server'
 include 'photon-lib'
 include 'photon-docs'


### PR DESCRIPTION
Having these in the root settings.gradle means they are subprojects but
the settings.gradles in these folders shows they aren't