### PR TITLE
Fix videomode is null

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
@@ -186,7 +186,8 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
 
     @Override
     public VideoMode getCurrentVideoMode() {
-        return camera.getVideoMode(); // This returns the current video mode even if the camera is disconnected
+        return camera
+                .getVideoMode(); // This returns the current video mode even if the camera is disconnected
     }
 
     @Override
@@ -196,8 +197,7 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
                 logger.error("Got a null video mode! Doing nothing...");
                 return;
             }
-            if(camera.setVideoMode(videoMode))
-                logger.debug("Failed to set video mode!");
+            if (camera.setVideoMode(videoMode)) logger.debug("Failed to set video mode!");
         } catch (Exception e) {
             logger.error("Failed to set video mode!", e);
         }

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
@@ -186,7 +186,7 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
 
     @Override
     public VideoMode getCurrentVideoMode() {
-        return camera.isConnected() ? camera.getVideoMode() : null;
+        return camera.getVideoMode(); // This returns the current video mode even if the camera is disconnected
     }
 
     @Override
@@ -196,7 +196,8 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
                 logger.error("Got a null video mode! Doing nothing...");
                 return;
             }
-            camera.setVideoMode(videoMode);
+            if(camera.setVideoMode(videoMode))
+                logger.debug("Failed to set video mode!");
         } catch (Exception e) {
             logger.error("Failed to set video mode!", e);
         }


### PR DESCRIPTION
There is a weird edge case at least with arducam/broken arducams/used arducams where cscore will see it when pv starts but not be able to connect to it. If we always read out the "current" video mode instead of null when it is disconnected things will work. If the camera is disconnected while we try to change the video mode when we get the current video mode it will tell us what we wanted to set it to. Then when the camera reconnects it will be in that video mode.