### PR TITLE
Add QuadThresholdParameters to AprilTag config

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipe.java
@@ -59,6 +59,7 @@ public class AprilTagDetectionPipe
     public void setParams(AprilTagDetectionPipeParams newParams) {
         if (this.params == null || !this.params.equals(newParams)) {
             m_detector.setConfig(newParams.detectorParams);
+            m_detector.setQuadThresholdParameters(newParams.quadParams);
 
             m_detector.clearFamilies();
             m_detector.addFamily(newParams.family.getNativeName());

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipeParams.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipeParams.java
@@ -40,6 +40,7 @@ public class AprilTagDetectionPipeParams {
         int result = 1;
         result = prime * result + ((family == null) ? 0 : family.hashCode());
         result = prime * result + ((detectorParams == null) ? 0 : detectorParams.hashCode());
+        result = prime * result + ((quadParams == null) ? 0 : quadParams.hashCode());
         return result;
     }
 
@@ -50,27 +51,12 @@ public class AprilTagDetectionPipeParams {
         if (getClass() != obj.getClass()) return false;
         AprilTagDetectionPipeParams other = (AprilTagDetectionPipeParams) obj;
         if (family != other.family) return false;
-
-        boolean sameQuadParams = false;
-        boolean sameDetectorParams = false;
         if (detectorParams == null) {
-            if (other.detectorParams == null) {
-                sameDetectorParams = true;
-            } else {
-                return false;
-            }
-        } else {
-            sameDetectorParams = detectorParams.equals(other.detectorParams);
-        }
+            if (other.detectorParams != null) return false;
+        } else if (!detectorParams.equals(other.detectorParams)) return false;
         if (quadParams == null) {
-            if (other.quadParams == null) {
-                sameQuadParams = true;
-            } else {
-                return false;
-            }
-        } else {
-            sameQuadParams = quadParams.equals(other.quadParams);
-        }
-        return (sameDetectorParams) && (sameQuadParams);
+            if (other.quadParams != null) return false;
+        } else if (!quadParams.equals(other.quadParams)) return false;
+        return true;
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipeParams.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipeParams.java
@@ -23,10 +23,12 @@ import org.photonvision.vision.apriltag.AprilTagFamily;
 public class AprilTagDetectionPipeParams {
     public final AprilTagFamily family;
     public final AprilTagDetector.Config detectorParams;
+    public final AprilTagDetector.QuadThresholdParameters quadParams;
 
-    public AprilTagDetectionPipeParams(AprilTagFamily tagFamily, AprilTagDetector.Config config) {
+    public AprilTagDetectionPipeParams(AprilTagFamily tagFamily, AprilTagDetector.Config config, AprilTagDetector.QuadThresholdParameters quadParams) {
         this.family = tagFamily;
         this.detectorParams = config;
+        this.quadParams = quadParams;
     }
 
     @Override
@@ -45,8 +47,28 @@ public class AprilTagDetectionPipeParams {
         if (getClass() != obj.getClass()) return false;
         AprilTagDetectionPipeParams other = (AprilTagDetectionPipeParams) obj;
         if (family != other.family) return false;
+
+        boolean sameQuadParams = false;
+        boolean sameDetectorParams = false;
         if (detectorParams == null) {
-            return other.detectorParams == null;
-        } else return detectorParams.equals(other.detectorParams);
+            if (other.detectorParams == null) {
+                sameDetectorParams = true;
+            } else {
+                return false;
+            }
+        } else {
+            sameDetectorParams = detectorParams.equals(other.detectorParams);
+        }
+        if (quadParams == null) {
+            if (other.quadParams == null) {
+                sameQuadParams = true;
+            } else {
+                return false;
+            }
+        } else {
+            sameQuadParams = quadParams.equals(other.quadParams);
+        }
+        return (sameDetectorParams) && (sameQuadParams);
+
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipeParams.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipeParams.java
@@ -25,7 +25,10 @@ public class AprilTagDetectionPipeParams {
     public final AprilTagDetector.Config detectorParams;
     public final AprilTagDetector.QuadThresholdParameters quadParams;
 
-    public AprilTagDetectionPipeParams(AprilTagFamily tagFamily, AprilTagDetector.Config config, AprilTagDetector.QuadThresholdParameters quadParams) {
+    public AprilTagDetectionPipeParams(
+            AprilTagFamily tagFamily,
+            AprilTagDetector.Config config,
+            AprilTagDetector.QuadThresholdParameters quadParams) {
         this.family = tagFamily;
         this.detectorParams = config;
         this.quadParams = quadParams;
@@ -69,6 +72,5 @@ public class AprilTagDetectionPipeParams {
             sameQuadParams = quadParams.equals(other.quadParams);
         }
         return (sameDetectorParams) && (sameQuadParams);
-
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
@@ -91,8 +91,8 @@ public class AprilTagPipeline extends CVPipeline<CVPipelineResult, AprilTagPipel
         var quadParams = new AprilTagDetector.QuadThresholdParameters();
         quadParams.minClusterPixels = 5;
 
-        aprilTagDetectionPipe.setParams(new AprilTagDetectionPipeParams(settings.tagFamily, config, quadParams));
-
+        aprilTagDetectionPipe.setParams(
+                new AprilTagDetectionPipeParams(settings.tagFamily, config, quadParams));
 
         if (frameStaticProperties.cameraCalibration != null) {
             var cameraMatrix = frameStaticProperties.cameraCalibration.getCameraIntrinsicsMat();

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
@@ -89,7 +89,16 @@ public class AprilTagPipeline extends CVPipeline<CVPipelineResult, AprilTagPipel
         config.quadDecimate = settings.decimate;
 
         var quadParams = new AprilTagDetector.QuadThresholdParameters();
+        // 5 was the default minClusterPixels in WPILib prior to 2025
+        // increasing it causes detection problems when decimate > 1
         quadParams.minClusterPixels = 5;
+        // these are the same as the values in WPILib 2025
+        // setting them here to prevent upstream changes from changing behavior of the detector
+        quadParams.maxNumMaxima = 10;
+        quadParams.criticalAngle = 45 * Math.PI / 180.0;
+        quadParams.maxLineFitMSE = 10.0f;
+        quadParams.minWhiteBlackDiff = 5;
+        quadParams.deglitch = false;
 
         aprilTagDetectionPipe.setParams(
                 new AprilTagDetectionPipeParams(settings.tagFamily, config, quadParams));

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
@@ -87,7 +87,12 @@ public class AprilTagPipeline extends CVPipeline<CVPipelineResult, AprilTagPipel
         config.refineEdges = settings.refineEdges;
         config.quadSigma = (float) settings.blur;
         config.quadDecimate = settings.decimate;
-        aprilTagDetectionPipe.setParams(new AprilTagDetectionPipeParams(settings.tagFamily, config));
+
+        var quadParams = new AprilTagDetector.QuadThresholdParameters();
+        quadParams.minClusterPixels = 5;
+
+        aprilTagDetectionPipe.setParams(new AprilTagDetectionPipeParams(settings.tagFamily, config, quadParams));
+
 
         if (frameStaticProperties.cameraCalibration != null) {
             var cameraMatrix = frameStaticProperties.cameraCalibration.getCameraIntrinsicsMat();


### PR DESCRIPTION
This works around a change made to the default QuadThresholdParameters in the WPILib AprilTagDetector for 2025
https://github.com/wpilibsuite/allwpilib/pull/6847