### PR TITLE
Pipe vision/source telemetry up to UI

### DIFF
--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -290,5 +290,5 @@ Then, run the examples:
 Using the [GitHub CLI](https://cli.github.com/), we can download artifacts from pipelines by run ID and name:
 
 ```
-~/photonvision$ gh run download 11759699679 -n jar-Linux 
+~/photonvision$ gh run download 11759699679 -n jar-Linux
 ```

--- a/photon-client/src/components/app/photon-sidebar.vue
+++ b/photon-client/src/components/app/photon-sidebar.vue
@@ -40,7 +40,7 @@ const mdAndUp = computed<boolean>(() => getCurrentInstance()?.proxy.$vuetify.bre
           <v-icon>mdi-camera</v-icon>
         </v-list-item-icon>
         <v-list-item-content>
-          <v-list-item-title>Cameras</v-list-item-title>
+          <v-list-item-title>Camera</v-list-item-title>
         </v-list-item-content>
       </v-list-item>
       <v-list-item link to="/settings">
@@ -49,6 +49,14 @@ const mdAndUp = computed<boolean>(() => getCurrentInstance()?.proxy.$vuetify.bre
         </v-list-item-icon>
         <v-list-item-content>
           <v-list-item-title>Settings</v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+      <v-list-item link to="/cameraConfigs">
+        <v-list-item-icon>
+          <v-icon>mdi-notebook</v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-title>Camera Configs</v-list-item-title>
         </v-list-item-content>
       </v-list-item>
       <v-list-item link to="/docs">

--- a/photon-client/src/router/index.ts
+++ b/photon-client/src/router/index.ts
@@ -6,6 +6,7 @@ import CameraSettingsView from "@/views/CameraSettingsView.vue";
 import GeneralSettingsView from "@/views/GeneralSettingsView.vue";
 import DocsView from "@/views/DocsView.vue";
 import NotFoundView from "@/views/NotFoundView.vue";
+import CameraMatchingView from "@/views/CameraMatchingView.vue";
 
 Vue.use(VueRouter);
 
@@ -32,6 +33,11 @@ const router = new VueRouter({
       path: "/settings",
       name: "Settings",
       component: GeneralSettingsView
+    },
+    {
+      path: "/cameraConfigs",
+      name: "Camera Configs",
+      component: CameraMatchingView
     },
     {
       path: "/docs",

--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -88,6 +88,8 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
   actions: {
     updateCameraSettingsFromWebsocket(data: WebsocketCameraSettingsUpdate[]) {
       const configuredCameras = data.map<CameraSettings>((d) => ({
+        cameraPath: d.cameraPath,
+
         nickname: d.nickname,
         uniqueName: d.uniqueName,
         fov: {

--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -4,7 +4,8 @@ import type {
   GeneralSettings,
   LightingSettings,
   MetricData,
-  NetworkSettings
+  NetworkSettings,
+  VisionSourceManagerState
 } from "@/types/SettingTypes";
 import { NetworkConnectionType } from "@/types/SettingTypes";
 import { useStateStore } from "@/stores/StateStore";
@@ -17,7 +18,7 @@ interface GeneralSettingsStore {
   network: NetworkSettings;
   lighting: LightingSettings;
   metrics: MetricData;
-  currentFieldLayout: AprilTagFieldLayout;
+  visionSourceManagerState: VisionSourceManagerState;
 }
 
 export const useSettingsStore = defineStore("settings", {
@@ -71,6 +72,10 @@ export const useSettingsStore = defineStore("settings", {
         width: 8.2296
       },
       tags: []
+    },
+    visionSourceManagerState: {
+      knownCameras: [],
+      unmatchedLoadedConfigs: []
     }
   }),
   getters: {
@@ -112,6 +117,8 @@ export const useSettingsStore = defineStore("settings", {
       this.lighting = data.lighting;
       this.network = data.networkSettings;
       this.currentFieldLayout = data.atfl;
+
+      this.visionSourceManagerState = data.visionSourceManagerState;
     },
     updateGeneralSettings(payload: Required<ConfigurableNetworkSettings>) {
       return axios.post("/settings/general", payload);

--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -74,7 +74,17 @@ export const useSettingsStore = defineStore("settings", {
       tags: []
     },
     visionSourceManagerState: {
-      knownCameras: [],
+      knownCameras: [
+        {
+          cameraType: "USBCamera",
+          dev: 1,
+          name: "foobar",
+          otherPaths: ["asdf", "bfdsa"],
+          path: "/some/path",
+          vendorId: 1,
+          productId: 2
+        }
+      ],
       unmatchedLoadedConfigs: []
     }
   }),

--- a/photon-client/src/types/PhotonTrackingTypes.ts
+++ b/photon-client/src/types/PhotonTrackingTypes.ts
@@ -67,6 +67,7 @@ export interface MultitagResult {
 }
 
 export interface PipelineResult {
+  sequenceID: number;
   fps: number;
   latency: number;
   targets: PhotonTarget[];

--- a/photon-client/src/types/SettingTypes.ts
+++ b/photon-client/src/types/SettingTypes.ts
@@ -56,6 +56,24 @@ export type ConfigurableNetworkSettings = Omit<
   "canManage" | "networkInterfaceNames" | "networkingDisabled"
 >;
 
+export interface UiCameraConfiguration {}
+export interface CameraConfiguration {}
+
+export interface PvCameraInfo {
+  cameraType: string; // CameraType -- todo
+  dev: number;
+  path: string;
+  name: string;
+  otherPaths: string[];
+  vendorId: number;
+  productId: number;
+}
+
+export interface VisionSourceManagerState {
+  knownCameras: PvCameraInfo[];
+  unmatchedLoadedConfigs: CameraConfiguration[];
+}
+
 export interface LightingSettings {
   supported: boolean;
   brightness: number;
@@ -173,6 +191,8 @@ export interface QuirkyCamera {
 }
 
 export interface CameraSettings {
+  cameraPath: string;
+
   nickname: string;
   uniqueName: string;
 

--- a/photon-client/src/types/WebsocketDataTypes.ts
+++ b/photon-client/src/types/WebsocketDataTypes.ts
@@ -5,7 +5,8 @@ import type {
   LogLevel,
   MetricData,
   NetworkSettings,
-  QuirkyCamera
+  QuirkyCamera,
+  VisionSourceManagerState
 } from "@/types/SettingTypes";
 import type { ActivePipelineSettings } from "@/types/PipelineTypes";
 import type { AprilTagFieldLayout, PipelineResult } from "@/types/PhotonTrackingTypes";
@@ -21,6 +22,7 @@ export interface WebsocketSettingsUpdate {
   lighting: Required<LightingSettings>;
   networkSettings: NetworkSettings;
   atfl: AprilTagFieldLayout;
+  visionSourceManagerState: VisionSourceManagerState;
 }
 
 export interface WebsocketNumberPair {
@@ -44,7 +46,10 @@ export type WebsocketVideoFormat = Record<
   }
 >;
 
+// Companion to UICameraConfiguration in Java
 export interface WebsocketCameraSettingsUpdate {
+  cameraPath: string;
+
   calibrations: CameraCalibrationResult[];
   currentPipelineIndex: number;
   currentPipelineSettings: ActivePipelineSettings;

--- a/photon-client/src/views/CameraMatchingView.vue
+++ b/photon-client/src/views/CameraMatchingView.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import MetricsCard from "@/components/settings/MetricsCard.vue";
+import { useSettingsStore } from "@/stores/settings/GeneralSettingsStore";
+import { useCameraSettingsStore } from "@/stores/settings/CameraSettingsStore";
+import { inject } from "vue";
+
+const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.mjpg`;
+</script>
+
+<template>
+  <div class="pa-3">
+    <v-card dark class="mb-3 pr-6 pb-3" style="background-color: #006492">
+      <v-card-title style="display: flex; justify-content: space-between">
+        <span>Camera Matching</span>
+      </v-card-title>
+      <span class="ml-3">Active Cameras</span>
+      <v-row class="ml-3 mt-3">
+        <v-col cols="6">
+          <v-card
+            dark
+            class="camera-card pa-4"
+            v-for="(module, index) in useCameraSettingsStore().cameras"
+            :value="index"
+          >
+            <v-card-title class="pb-8">{{ module.nickname }}</v-card-title>
+            <v-card-text>
+              <v-simple-table dense height="100%" class="camera-card-table mt-2">
+                <tbody>
+                  <tr>
+                    <td>Matched Path</td>
+                    <td>
+                      {{ module.cameraPath }}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Streams:</td>
+                    <td>
+                      <a :href="formatUrl(module.stream.inputPort)" target="_blank"> Input Stream </a>/<a
+                        :href="formatUrl(module.stream.outputPort)"
+                        target="_blank"
+                      >
+                        Output Stream
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Pipelines</td>
+                    <td>{{ module.pipelineNicknames.join(", ") }}</td>
+                  </tr>
+                  <tr>
+                    <td>Frames Processed</td>
+                    <td>todo</td>
+                  </tr>
+                  <tr>
+                    <td>Connected?</td>
+                    <td>Via [USB, CSI, totally bjork]</td>
+                  </tr>
+                </tbody>
+              </v-simple-table>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <v-divider style="margin: 12px 0" />
+
+      <v-row class="pt-2 pa-4 ma-0 ml-5 pb-1">
+        <span> USB Cameras </span>
+        <span>
+          Matched cameras: {{ useSettingsStore().visionSourceManagerState.knownCameras }} <br />
+          Unmatched cameras: {{ useSettingsStore().visionSourceManagerState.unmatchedLoadedConfigs }}
+        </span>
+      </v-row>
+    </v-card>
+  </div>
+</template>
+
+<style scoped>
+.camera-card {
+  background-color: #005281 !important;
+}
+.camera-card-table {
+  background-color: #006492 !important;
+}
+</style>

--- a/photon-client/src/views/CameraMatchingView.vue
+++ b/photon-client/src/views/CameraMatchingView.vue
@@ -11,65 +11,107 @@ const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.
   <div class="pa-3">
     <v-card dark class="mb-3 pr-6 pb-3" style="background-color: #006492">
       <v-card-title style="display: flex; justify-content: space-between">
-        <span>Camera Matching</span>
+        <span class="ml-3">Active Vision Modules</span>
       </v-card-title>
-      <span class="ml-3">Active Cameras</span>
-      <v-container fluid>
-        <v-row class="ml-3 mt-3">
-          <v-col>
-            <v-card dark
-              class="camera-card pa-4 mb-4"
-              v-for="(module, index) in useCameraSettingsStore().cameras"
-              :value="index"
-            >
-              <v-card-title class="pb-8">{{ module.nickname }}</v-card-title>
-              <v-card-text>
-                <v-simple-table dense height="100%" class="camera-card-table mt-2">
-                  <tbody>
-                    <tr>
-                      <td>Matched Path</td>
-                      <td>
-                        {{ module.cameraPath }}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Streams:</td>
-                      <td>
-                        <a :href="formatUrl(module.stream.inputPort)" target="_blank"> Input Stream </a>/<a
-                          :href="formatUrl(module.stream.outputPort)"
-                          target="_blank"
-                        >
-                          Output Stream
-                        </a>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>Pipelines</td>
-                      <td>{{ module.pipelineNicknames.join(", ") }}</td>
-                    </tr>
-                    <tr>
-                      <td>Frames Processed</td>
-                      <td>todo</td>
-                    </tr>
-                    <tr>
-                      <td>Connected?</td>
-                      <td>Via [USB, CSI, totally bjork]</td>
-                    </tr>
-                  </tbody>
-                </v-simple-table>
-              </v-card-text>
-            </v-card>
-          </v-col>
-        </v-row>
-      </v-container>
 
-      <v-divider style="margin: 12px 0" />
-
-      <v-row class="pt-2 pa-4 ma-0 ml-5 pb-1">
+      <v-row class="ml-3">
+        <v-card
+          dark
+          class="camera-card pa-4 mb-4 mr-3"
+          v-for="(module, index) in useCameraSettingsStore().cameras"
+          :value="index"
+        >
+          <v-card-title class="pb-8">{{ module.nickname }}</v-card-title>
+          <v-card-text>
+            <v-simple-table dense height="100%" class="camera-card-table mt-2">
+              <tbody>
+                <tr>
+                  <td>Matched Path</td>
+                  <td>
+                    {{ module.cameraPath }}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Streams:</td>
+                  <td>
+                    <a :href="formatUrl(module.stream.inputPort)" target="_blank"> Input Stream </a>/<a
+                      :href="formatUrl(module.stream.outputPort)"
+                      target="_blank"
+                    >
+                      Output Stream
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Pipelines</td>
+                  <td>{{ module.pipelineNicknames.join(", ") }}</td>
+                </tr>
+                <tr>
+                  <td>Frames Processed</td>
+                  <td>todo</td>
+                </tr>
+                <tr>
+                  <td>Connected?</td>
+                  <td>Via [USB, CSI, totally bjork]</td>
+                </tr>
+              </tbody>
+            </v-simple-table>
+          </v-card-text>
+        </v-card>
+      </v-row>
+    </v-card>
+    <v-card dark class="mb-3 pr-6 pb-3" style="background-color: #006492">
+      <v-card-title>
         <span> USB Cameras </span>
-        <span>
-          Unmatched cameras: {{ useSettingsStore().visionSourceManagerState.unmatchedLoadedConfigs }}
-        </span>
+      </v-card-title>
+
+      <v-row class="ml-3">
+        <v-card
+          dark
+          class="camera-card pa-4 mb-4 mr-3"
+          v-for="(camera, index) in useSettingsStore().visionSourceManagerState.knownCameras"
+          :value="index"
+        >
+          <v-card-title class="pb-8">{{ camera.name }}</v-card-title>
+          <v-card-text>
+            <v-simple-table dense height="100%" class="camera-card-table mt-2">
+              <tbody>
+                <tr>
+                  <td>USB Product String Descriptor</td>
+                  <td>
+                    {{ camera.name }}
+                  </td>
+                </tr>
+                <tr>
+                  <td>USB Vendor ID</td>
+                  <td>0x{{ camera.vendorId.toString(16).padStart(4, "0") }}</td>
+                </tr>
+                <tr>
+                  <td>USB Product ID</td>
+                  <td>0x{{ camera.productId.toString(16).padStart(4, "0") }}</td>
+                </tr>
+                <tr>
+                  <td>Type</td>
+                  <td>
+                    {{ camera.cameraType }}
+                  </td>
+                </tr>
+                <tr>
+                  <td>USB Path(s)</td>
+                  <td>
+                    {{ [camera.path].concat(camera.otherPaths).join("\n") }}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Device Number</td>
+                  <td>
+                    {{ camera.dev }}
+                  </td>
+                </tr>
+              </tbody>
+            </v-simple-table>
+          </v-card-text>
+        </v-card>
       </v-row>
     </v-card>
   </div>
@@ -80,6 +122,6 @@ const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.
   background-color: #005281 !important;
 }
 .camera-card-table {
-  background-color: #006492 !important;
+  background-color: #b49b0d !important;
 }
 </style>

--- a/photon-client/src/views/CameraMatchingView.vue
+++ b/photon-client/src/views/CameraMatchingView.vue
@@ -3,6 +3,7 @@ import MetricsCard from "@/components/settings/MetricsCard.vue";
 import { useSettingsStore } from "@/stores/settings/GeneralSettingsStore";
 import { useCameraSettingsStore } from "@/stores/settings/CameraSettingsStore";
 import { inject } from "vue";
+import { useStateStore } from "@/stores/StateStore";
 
 const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.mjpg`;
 </script>
@@ -48,7 +49,12 @@ const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.
                 </tr>
                 <tr>
                   <td>Frames Processed</td>
-                  <td>todo</td>
+                  <td>
+                    {{ useStateStore().backendResults[index].sequenceID }} ({{
+                      useStateStore().backendResults[index].fps
+                    }}
+                    FPS)
+                  </td>
                 </tr>
                 <tr>
                   <td>Connected?</td>
@@ -99,7 +105,13 @@ const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.
                 <tr>
                   <td>USB Path(s)</td>
                   <td>
-                    {{ [camera.path].concat(camera.otherPaths).join("\n") }}
+                    <span
+                      v-for="(path, idx) in [camera.path].concat(camera.otherPaths)"
+                      :key="idx"
+                      style="display: block"
+                    >
+                      {{ path }}
+                    </span>
                   </td>
                 </tr>
                 <tr>

--- a/photon-client/src/views/CameraMatchingView.vue
+++ b/photon-client/src/views/CameraMatchingView.vue
@@ -14,60 +14,60 @@ const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.
         <span>Camera Matching</span>
       </v-card-title>
       <span class="ml-3">Active Cameras</span>
-      <v-row class="ml-3 mt-3">
-        <v-col cols="6">
-          <v-card
-            dark
-            class="camera-card pa-4"
-            v-for="(module, index) in useCameraSettingsStore().cameras"
-            :value="index"
-          >
-            <v-card-title class="pb-8">{{ module.nickname }}</v-card-title>
-            <v-card-text>
-              <v-simple-table dense height="100%" class="camera-card-table mt-2">
-                <tbody>
-                  <tr>
-                    <td>Matched Path</td>
-                    <td>
-                      {{ module.cameraPath }}
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Streams:</td>
-                    <td>
-                      <a :href="formatUrl(module.stream.inputPort)" target="_blank"> Input Stream </a>/<a
-                        :href="formatUrl(module.stream.outputPort)"
-                        target="_blank"
-                      >
-                        Output Stream
-                      </a>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Pipelines</td>
-                    <td>{{ module.pipelineNicknames.join(", ") }}</td>
-                  </tr>
-                  <tr>
-                    <td>Frames Processed</td>
-                    <td>todo</td>
-                  </tr>
-                  <tr>
-                    <td>Connected?</td>
-                    <td>Via [USB, CSI, totally bjork]</td>
-                  </tr>
-                </tbody>
-              </v-simple-table>
-            </v-card-text>
-          </v-card>
-        </v-col>
-      </v-row>
+      <v-container fluid>
+        <v-row class="ml-3 mt-3">
+          <v-col>
+            <v-card dark
+              class="camera-card pa-4 mb-4"
+              v-for="(module, index) in useCameraSettingsStore().cameras"
+              :value="index"
+            >
+              <v-card-title class="pb-8">{{ module.nickname }}</v-card-title>
+              <v-card-text>
+                <v-simple-table dense height="100%" class="camera-card-table mt-2">
+                  <tbody>
+                    <tr>
+                      <td>Matched Path</td>
+                      <td>
+                        {{ module.cameraPath }}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Streams:</td>
+                      <td>
+                        <a :href="formatUrl(module.stream.inputPort)" target="_blank"> Input Stream </a>/<a
+                          :href="formatUrl(module.stream.outputPort)"
+                          target="_blank"
+                        >
+                          Output Stream
+                        </a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Pipelines</td>
+                      <td>{{ module.pipelineNicknames.join(", ") }}</td>
+                    </tr>
+                    <tr>
+                      <td>Frames Processed</td>
+                      <td>todo</td>
+                    </tr>
+                    <tr>
+                      <td>Connected?</td>
+                      <td>Via [USB, CSI, totally bjork]</td>
+                    </tr>
+                  </tbody>
+                </v-simple-table>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
 
       <v-divider style="margin: 12px 0" />
 
       <v-row class="pt-2 pa-4 ma-0 ml-5 pb-1">
         <span> USB Cameras </span>
         <span>
-          Matched cameras: {{ useSettingsStore().visionSourceManagerState.knownCameras }} <br />
           Unmatched cameras: {{ useSettingsStore().visionSourceManagerState.unmatchedLoadedConfigs }}
         </span>
       </v-row>

--- a/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
@@ -198,12 +198,11 @@ public class CameraConfiguration {
     }
 
     /**
-     *  cscore will auto-reconnect to the camera path we give it. v4l does not guarantee that if i
-     *  swap cameras around, the same /dev/videoN ID will be assigned to that camera. So instead
-     *  default to pinning to a particular USB port, or by "path" (appears to be a global identifier
-     *  on Windows).
-     * 
-     * This represents our best guess at an immutable path to detect a camera at.
+     * cscore will auto-reconnect to the camera path we give it. v4l does not guarantee that if i swap
+     * cameras around, the same /dev/videoN ID will be assigned to that camera. So instead default to
+     * pinning to a particular USB port, or by "path" (appears to be a global identifier on Windows).
+     *
+     * <p>This represents our best guess at an immutable path to detect a camera at.
      */
     @JsonIgnore
     public String getUsbPathOrDefault() {

--- a/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/CameraConfiguration.java
@@ -197,6 +197,19 @@ public class CameraConfiguration {
                 + usbVID;
     }
 
+    /**
+     *  cscore will auto-reconnect to the camera path we give it. v4l does not guarantee that if i
+     *  swap cameras around, the same /dev/videoN ID will be assigned to that camera. So instead
+     *  default to pinning to a particular USB port, or by "path" (appears to be a global identifier
+     *  on Windows).
+     * 
+     * This represents our best guess at an immutable path to detect a camera at.
+     */
+    @JsonIgnore
+    public String getUsbPathOrDefault() {
+        return getUSBPath().orElse(path);
+    }
+
     @Override
     public String toString() {
         return "CameraConfiguration [baseName="

--- a/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
@@ -35,6 +35,7 @@ import org.photonvision.vision.camera.QuirkyCamera;
 import org.photonvision.vision.processes.VisionModule;
 import org.photonvision.vision.processes.VisionModuleManager;
 import org.photonvision.vision.processes.VisionSource;
+import org.photonvision.vision.processes.VisionSourceManager;
 
 public class PhotonConfiguration {
     private final HardwareConfig hardwareConfig;
@@ -161,6 +162,8 @@ public class PhotonConfiguration {
         // AprilTagFieldLayout
         settingsSubmap.put("atfl", this.atfl);
 
+        settingsSubmap.put("visionSourceManagerState", VisionSourceManager.getInstance().getState());
+
         map.put(
                 "cameraSettings",
                 VisionModuleManager.getInstance().getModules().stream()
@@ -178,21 +181,22 @@ public class PhotonConfiguration {
     }
 
     public static class UICameraConfiguration {
-        @SuppressWarnings("unused")
-        public double fov;
+        // Path to the camera device. On Linux, this is a special file in /dev/v4l/by-id or /dev/videoN. This is the path we hand to CSCore to do auto-reconnect on
+        public String cameraPath;
 
+        public List<UICameraCalibrationCoefficients> calibrations;
+        public int currentPipelineIndex;
+        public HashMap<String, Object> currentPipelineSettings;
+        public double fov;
+        public int inputStreamPort;
+        public boolean isFovConfigurable = true;
+        public boolean isCSICamera;
         public String nickname;
         public String uniqueName;
-        public HashMap<String, Object> currentPipelineSettings;
-        public int currentPipelineIndex;
+        public int outputStreamPort;
         public List<String> pipelineNicknames;
         public HashMap<Integer, HashMap<String, Object>> videoFormatList;
-        public int outputStreamPort;
-        public int inputStreamPort;
-        public List<UICameraCalibrationCoefficients> calibrations;
-        public boolean isFovConfigurable = true;
         public QuirkyCamera cameraQuirks;
-        public boolean isCSICamera;
         public double minExposureRaw;
         public double maxExposureRaw;
         public double minWhiteBalanceTemp;

--- a/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
@@ -181,7 +181,8 @@ public class PhotonConfiguration {
     }
 
     public static class UICameraConfiguration {
-        // Path to the camera device. On Linux, this is a special file in /dev/v4l/by-id or /dev/videoN. This is the path we hand to CSCore to do auto-reconnect on
+        // Path to the camera device. On Linux, this is a special file in /dev/v4l/by-id or /dev/videoN.
+        // This is the path we hand to CSCore to do auto-reconnect on
         public String cameraPath;
 
         public List<UICameraCalibrationCoefficients> calibrations;

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UIDataPublisher.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UIDataPublisher.java
@@ -46,6 +46,7 @@ public class UIDataPublisher implements CVPipelineResultConsumer {
         if (lastUIResultUpdateTime + 1000.0 / 10.0 > now) return;
 
         var dataMap = new HashMap<String, Object>();
+        dataMap.put("sequenceID", result.sequenceID);
         dataMap.put("fps", result.fps);
         dataMap.put("latency", result.getLatencyMillis());
         var uiTargets = new ArrayList<HashMap<String, Object>>(result.targets.size());

--- a/photon-core/src/main/java/org/photonvision/vision/camera/PvCameraInfo.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/PvCameraInfo.java
@@ -22,16 +22,16 @@ import java.util.Arrays;
 import java.util.Optional;
 import org.photonvision.common.hardware.Platform;
 
-public class CameraInfo extends UsbCameraInfo {
+public class PvCameraInfo extends UsbCameraInfo {
     public final CameraType cameraType;
 
-    public CameraInfo(
+    public PvCameraInfo(
             int dev, String path, String name, String[] otherPaths, int vendorId, int productId) {
         super(dev, path, name, otherPaths, vendorId, productId);
         cameraType = CameraType.UsbCamera;
     }
 
-    public CameraInfo(
+    public PvCameraInfo(
             int dev,
             String path,
             String name,
@@ -43,7 +43,7 @@ public class CameraInfo extends UsbCameraInfo {
         this.cameraType = cameraType;
     }
 
-    public CameraInfo(UsbCameraInfo info) {
+    public PvCameraInfo(UsbCameraInfo info) {
         super(info.dev, info.path, info.name, info.otherPaths, info.vendorId, info.productId);
         cameraType = CameraType.UsbCamera;
     }
@@ -85,7 +85,7 @@ public class CameraInfo extends UsbCameraInfo {
         if (this == obj) return true;
         if (obj == null) return false;
         if (getClass() != obj.getClass()) return false;
-        CameraInfo other = (CameraInfo) obj;
+        PvCameraInfo other = (PvCameraInfo) obj;
 
         // Windows device number is not significant. See
         // https://github.com/wpilibsuite/allwpilib/blob/4b94a64b06057c723d6fcafeb1a45f55a70d179a/cscore/src/main/native/windows/UsbCameraImpl.cpp#L1128

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/USBCameraSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/USBCameraSource.java
@@ -45,11 +45,8 @@ public class USBCameraSource extends VisionSource {
         super(config);
 
         logger = new Logger(USBCameraSource.class, config.nickname, LogGroup.Camera);
-        // cscore will auto-reconnect to the camera path we give it. v4l does not guarantee that if i
-        // swap cameras around, the same /dev/videoN ID will be assigned to that camera. So instead
-        // default to pinning to a particular USB port, or by "path" (appears to be a global identifier)
-        // on Windows.
-        camera = new UsbCamera(config.nickname, config.getUSBPath().orElse(config.path));
+
+        camera = new UsbCamera(config.nickname, config.getUsbPathOrDefault());
         cvSink = CameraServer.getVideo(this.camera);
 
         // set vid/pid if not done already for future matching

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -519,6 +519,7 @@ public class VisionModule {
     public PhotonConfiguration.UICameraConfiguration toUICameraConfig() {
         var ret = new PhotonConfiguration.UICameraConfiguration();
 
+        ret.cameraPath = visionSource.getCameraConfiguration().getUsbPathOrDefault();
         ret.fov = visionSource.getSettables().getFOV();
         ret.isCSICamera = visionSource.getCameraConfiguration().cameraType == CameraType.ZeroCopyPicam;
         ret.nickname = visionSource.getSettables().getConfiguration().nickname;

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModuleManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModuleManager.java
@@ -19,6 +19,7 @@ package org.photonvision.vision.processes;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import org.photonvision.common.configuration.PhotonConfiguration.UICameraConfiguration;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 
@@ -104,5 +105,25 @@ public class VisionModuleManager {
                 v.getCameraConfiguration().streamIndex = idx;
             }
         }
+    }
+
+    public static class UiVmmState {
+        public final List<UICameraConfiguration> visionModules;
+
+        UiVmmState(List<UICameraConfiguration> _v) {
+            this.visionModules = _v;
+        }
+    }
+
+    public UiVmmState getState() {
+        return new UiVmmState(
+                this.visionModules.stream()
+                        .map(VisionModule::toUICameraConfig)
+                        .map(
+                                it -> {
+                                    it.calibrations = null;
+                                    return it;
+                                })
+                        .collect(Collectors.toList()));
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionSourceManager.java
@@ -528,7 +528,8 @@ public class VisionSourceManager {
      * @param allDevices
      * @return list of devices with blacklisted or ignore devices removed.
      */
-    private List<PvCameraInfo> filterAllowedDevices(List<PvCameraInfo> allDevices, Platform platform) {
+    private List<PvCameraInfo> filterAllowedDevices(
+            List<PvCameraInfo> allDevices, Platform platform) {
         List<PvCameraInfo> filteredDevices = new ArrayList<>();
         for (var device : allDevices) {
             if (deviceBlacklist.contains(device.name)) {

--- a/photon-core/src/test/java/org/photonvision/vision/processes/VisionSourceManagerTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/processes/VisionSourceManagerTest.java
@@ -28,8 +28,8 @@ import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.LogLevel;
 import org.photonvision.common.logging.Logger;
-import org.photonvision.vision.camera.CameraInfo;
 import org.photonvision.vision.camera.CameraType;
+import org.photonvision.vision.camera.PvCameraInfo;
 
 public class VisionSourceManagerTest {
     @Test
@@ -37,7 +37,7 @@ public class VisionSourceManagerTest {
         Logger.setLevel(LogGroup.Camera, LogLevel.DEBUG);
 
         var inst = new VisionSourceManager();
-        var cameraInfos = new ArrayList<CameraInfo>();
+        var cameraInfos = new ArrayList<PvCameraInfo>();
         ConfigManager.getInstance().clearConfig();
         ConfigManager.getInstance().load();
 
@@ -62,8 +62,8 @@ public class VisionSourceManagerTest {
         config4.usbVID = 5;
         config4.usbPID = 6;
 
-        CameraInfo info1 =
-                new CameraInfo(0, "dev/video0", "testVideo", new String[] {"/usb/path/0"}, 1, 2);
+        PvCameraInfo info1 =
+                new PvCameraInfo(0, "dev/video0", "testVideo", new String[] {"/usb/path/0"}, 1, 2);
 
         cameraInfos.add(info1);
 
@@ -74,8 +74,8 @@ public class VisionSourceManagerTest {
         assertTrue(inst.knownCameras.contains(info1));
         assertEquals(2, inst.unmatchedLoadedConfigs.size());
 
-        CameraInfo info2 =
-                new CameraInfo(0, "dev/video1", "secondTestVideo", new String[] {"/usb/path/1"}, 2, 3);
+        PvCameraInfo info2 =
+                new PvCameraInfo(0, "dev/video1", "secondTestVideo", new String[] {"/usb/path/1"}, 2, 3);
 
         cameraInfos.add(info2);
 
@@ -88,11 +88,11 @@ public class VisionSourceManagerTest {
         assertTrue(inst.knownCameras.contains(info2));
         assertEquals(2, inst.unmatchedLoadedConfigs.size());
 
-        CameraInfo info3 =
-                new CameraInfo(0, "dev/video2", "thirdTestVideo", new String[] {"by-id/123"}, 3, 4);
+        PvCameraInfo info3 =
+                new PvCameraInfo(0, "dev/video2", "thirdTestVideo", new String[] {"by-id/123"}, 3, 4);
 
-        CameraInfo info4 =
-                new CameraInfo(0, "dev/video3", "fourthTestVideo", new String[] {"by-id/321"}, 5, 6);
+        PvCameraInfo info4 =
+                new PvCameraInfo(0, "dev/video3", "fourthTestVideo", new String[] {"by-id/321"}, 5, 6);
 
         cameraInfos.add(info4);
 
@@ -133,8 +133,8 @@ public class VisionSourceManagerTest {
         assertEquals(cam3.nickname, config3.nickname);
         assertEquals(cam4.nickname, config4.nickname);
 
-        CameraInfo info5 =
-                new CameraInfo(
+        PvCameraInfo info5 =
+                new PvCameraInfo(
                         2,
                         "/dev/video2",
                         "Left Camera",
@@ -149,8 +149,8 @@ public class VisionSourceManagerTest {
 
         assertTrue(inst.knownCameras.contains(info5));
 
-        CameraInfo info6 =
-                new CameraInfo(
+        PvCameraInfo info6 =
+                new PvCameraInfo(
                         3,
                         "dev/video3",
                         "Right Camera",
@@ -168,8 +168,8 @@ public class VisionSourceManagerTest {
         // RPI 5 CSI Tests
 
         // CSI CAMERAS SHOULD NOT BE LOADED LIKE THIS THEY SHOULD GO THROUGH LIBCAM.
-        CameraInfo info7 =
-                new CameraInfo(
+        PvCameraInfo info7 =
+                new PvCameraInfo(
                         4,
                         "dev/video4",
                         "CSICAM-DEV", // Typically rp1-cfe for unit test changed to CSICAM-DEV
@@ -181,8 +181,8 @@ public class VisionSourceManagerTest {
 
         assertTrue(!inst.knownCameras.contains(info7)); // This camera should not be recognized/used.
 
-        CameraInfo info8 =
-                new CameraInfo(
+        PvCameraInfo info8 =
+                new PvCameraInfo(
                         5,
                         "dev/video8",
                         "CSICAM-DEV", // Typically rp1-cfe for unit test changed to CSICAM-DEV
@@ -194,8 +194,8 @@ public class VisionSourceManagerTest {
 
         assertTrue(!inst.knownCameras.contains(info8)); // This camera should not be recognized/used.
 
-        CameraInfo info9 =
-                new CameraInfo(
+        PvCameraInfo info9 =
+                new PvCameraInfo(
                         6,
                         "dev/video9",
                         "CSICAM-DEV", // Typically rp1-cfe for unit test changed to CSICAM-DEV
@@ -210,8 +210,8 @@ public class VisionSourceManagerTest {
         assertEquals(0, inst.unmatchedLoadedConfigs.size());
 
         // RPI LIBCAMERA CSI CAMERA TESTS
-        CameraInfo info10 =
-                new CameraInfo(
+        PvCameraInfo info10 =
+                new PvCameraInfo(
                         -1,
                         "/base/soc/i2c0mux/i2c@0/ov9281@60",
                         "OV9281", // Typically rp1-cfe for unit test changed to CSICAM-DEV
@@ -226,8 +226,8 @@ public class VisionSourceManagerTest {
         assertEquals(7, inst.knownCameras.size());
         assertEquals(0, inst.unmatchedLoadedConfigs.size());
 
-        CameraInfo info11 =
-                new CameraInfo(
+        PvCameraInfo info11 =
+                new PvCameraInfo(
                         -1,
                         "/base/soc/i2c0mux/i2c@1/ov9281@60",
                         "OV9281", // Typically rp1-cfe for unit test changed to CSICAM-DEV
@@ -242,8 +242,8 @@ public class VisionSourceManagerTest {
         assertEquals(8, inst.knownCameras.size());
         assertEquals(0, inst.unmatchedLoadedConfigs.size());
 
-        CameraInfo info12 =
-                new CameraInfo(
+        PvCameraInfo info12 =
+                new PvCameraInfo(
                         -1,
                         " /base/axi/pcie@120000/rp1/i2c@80000/ov5647@36",
                         "Camera Module v1",
@@ -258,8 +258,8 @@ public class VisionSourceManagerTest {
         assertEquals(9, inst.knownCameras.size());
         assertEquals(0, inst.unmatchedLoadedConfigs.size());
 
-        CameraInfo info13 =
-                new CameraInfo(
+        PvCameraInfo info13 =
+                new PvCameraInfo(
                         -1,
                         "/base/axi/pcie@120000/rp1/i2c@88000/imx708@1a",
                         "Camera Module v3",
@@ -319,14 +319,14 @@ public class VisionSourceManagerTest {
 
         // Camera attached to new port, but strict matching disabled
         {
-            CameraInfo info1 =
-                    new CameraInfo(
+            PvCameraInfo info1 =
+                    new PvCameraInfo(
                             0, "/dev/video11", "Arducam OV2311 USB Camera", CAM1_OLD_PATHS, 3141, 25446);
-            CameraInfo info2 =
-                    new CameraInfo(
+            PvCameraInfo info2 =
+                    new PvCameraInfo(
                             0, "/dev/video12", "Arducam OV2311 USB Camera", CAM2_NEW_PATH, 3141, 25446);
 
-            var cameraInfos = new ArrayList<CameraInfo>();
+            var cameraInfos = new ArrayList<PvCameraInfo>();
             cameraInfos.add(info1);
             cameraInfos.add(info2);
             List<VisionSource> ret1 = inst.tryMatchCamImpl(cameraInfos);
@@ -386,14 +386,14 @@ public class VisionSourceManagerTest {
         {
             // Give our cameras new "paths" to fake the windows logic out. this should not
             // affect strict matching
-            CameraInfo info1 =
-                    new CameraInfo(
+            PvCameraInfo info1 =
+                    new PvCameraInfo(
                             0, "/dev/video11", "Arducam OV2311 USB Camera", CAM1_OLD_PATHS, 3141, 25446);
-            CameraInfo info2 =
-                    new CameraInfo(
+            PvCameraInfo info2 =
+                    new PvCameraInfo(
                             0, "/dev/video12", "Arducam OV2311 USB Camera", CAM2_NEW_PATH, 3141, 25446);
 
-            var cameraInfos = new ArrayList<CameraInfo>();
+            var cameraInfos = new ArrayList<PvCameraInfo>();
             cameraInfos.add(info1);
             cameraInfos.add(info2);
             List<VisionSource> ret1 = inst.tryMatchCamImpl(cameraInfos);
@@ -414,14 +414,14 @@ public class VisionSourceManagerTest {
 
         // Now move our camera back
         {
-            CameraInfo info1 =
-                    new CameraInfo(
+            PvCameraInfo info1 =
+                    new PvCameraInfo(
                             0, "/dev/video11", "Arducam OV2311 USB Camera", CAM1_OLD_PATHS, 3141, 25446);
-            CameraInfo info2 =
-                    new CameraInfo(
+            PvCameraInfo info2 =
+                    new PvCameraInfo(
                             0, "/dev/video12", "Arducam OV2311 USB Camera", CAM2_OLD_PATH, 3141, 25446);
 
-            var cameraInfos = new ArrayList<CameraInfo>();
+            var cameraInfos = new ArrayList<PvCameraInfo>();
             cameraInfos.add(info1);
             cameraInfos.add(info2);
             List<VisionSource> ret1 = inst.tryMatchCamImpl(cameraInfos);
@@ -440,15 +440,15 @@ public class VisionSourceManagerTest {
         Logger.setLevel(LogGroup.Camera, LogLevel.DEBUG);
 
         // List of known cameras
-        var cameraInfos = new ArrayList<CameraInfo>();
+        var cameraInfos = new ArrayList<PvCameraInfo>();
 
         var inst = new VisionSourceManager();
         ConfigManager.getInstance().clearConfig();
         ConfigManager.getInstance().load();
         ConfigManager.getInstance().getConfig().getNetworkConfig().matchCamerasOnlyByPath = false;
 
-        CameraInfo info1 =
-                new CameraInfo(
+        PvCameraInfo info1 =
+                new PvCameraInfo(
                         -1,
                         "/base/soc/i2c0mux/i2c@0/ov9281@60",
                         "OV9281", // Typically rp1-cfe for unit test changed to CSICAM-DEV
@@ -457,8 +457,8 @@ public class VisionSourceManagerTest {
                         -1,
                         CameraType.ZeroCopyPicam);
 
-        CameraInfo info2 =
-                new CameraInfo(
+        PvCameraInfo info2 =
+                new PvCameraInfo(
                         -1,
                         "/base/soc/i2c0mux/i2c@1/ov9281@60",
                         "OV9281", // Typically rp1-cfe for unit test changed to CSICAM-DEV
@@ -507,7 +507,7 @@ public class VisionSourceManagerTest {
         Logger.setLevel(LogGroup.Camera, LogLevel.DEBUG);
 
         // List of known cameras
-        var cameraInfos = new ArrayList<CameraInfo>();
+        var cameraInfos = new ArrayList<PvCameraInfo>();
 
         var inst = new VisionSourceManager();
         ConfigManager.getInstance().clearConfig();
@@ -517,8 +517,8 @@ public class VisionSourceManagerTest {
         // Match empty camera infos
         inst.tryMatchCamImpl(cameraInfos);
 
-        CameraInfo info1 =
-                new CameraInfo(0, "/dev/video0", "Arducam OV2311 USB Camera", new String[] {}, 3141, 25446);
+        PvCameraInfo info1 =
+                new PvCameraInfo(0, "/dev/video0", "Arducam OV2311 USB Camera", new String[] {}, 3141, 25446);
 
         cameraInfos.add(info1);
 
@@ -544,7 +544,7 @@ public class VisionSourceManagerTest {
         Logger.setLevel(LogGroup.Camera, LogLevel.DEBUG);
 
         // List of known cameras
-        var cameraInfos = new ArrayList<CameraInfo>();
+        var cameraInfos = new ArrayList<PvCameraInfo>();
 
         var inst = new VisionSourceManager();
         ConfigManager.getInstance().clearConfig();
@@ -554,8 +554,8 @@ public class VisionSourceManagerTest {
         // Match empty camera infos
         inst.tryMatchCamImpl(cameraInfos);
 
-        CameraInfo info1 =
-                new CameraInfo(
+        PvCameraInfo info1 =
+                new PvCameraInfo(
                         0,
                         "/dev/video0",
                         "Arducam OV2311 USB Camera",
@@ -568,8 +568,8 @@ public class VisionSourceManagerTest {
                         },
                         3141,
                         25446);
-        CameraInfo info2 =
-                new CameraInfo(
+        PvCameraInfo info2 =
+                new PvCameraInfo(
                         0,
                         "/dev/video2",
                         "Arducam OV2311 USB Camera",
@@ -611,9 +611,9 @@ public class VisionSourceManagerTest {
         }
 
         // duplicate cameras, same info, new ref
-        var duplicateCameraInfos = new ArrayList<CameraInfo>();
-        CameraInfo info1_dup =
-                new CameraInfo(
+        var duplicateCameraInfos = new ArrayList<PvCameraInfo>();
+        PvCameraInfo info1_dup =
+                new PvCameraInfo(
                         0,
                         "/dev/video0",
                         "Arducam OV2311 USB Camera",
@@ -626,8 +626,8 @@ public class VisionSourceManagerTest {
                         },
                         3141,
                         25446);
-        CameraInfo info2_dup =
-                new CameraInfo(
+        PvCameraInfo info2_dup =
+                new PvCameraInfo(
                         0,
                         "/dev/video2",
                         "Arducam OV2311 USB Camera",
@@ -650,9 +650,9 @@ public class VisionSourceManagerTest {
 
         // duplicate cameras this simulates unplugging one and plugging the other in where v4l assigns
         // the same by-id path to the other camera
-        var duplicateCameraInfos1 = new ArrayList<CameraInfo>();
-        CameraInfo info3_dup =
-                new CameraInfo(
+        var duplicateCameraInfos1 = new ArrayList<PvCameraInfo>();
+        PvCameraInfo info3_dup =
+                new PvCameraInfo(
                         0,
                         "/dev/video0",
                         "Arducam OV2311 USB Camera",
@@ -662,8 +662,8 @@ public class VisionSourceManagerTest {
                         },
                         3141,
                         25446);
-        CameraInfo info4_dup =
-                new CameraInfo(
+        PvCameraInfo info4_dup =
+                new PvCameraInfo(
                         0,
                         "/dev/video2",
                         "Arducam OV2311 USB Camera",

--- a/photon-core/src/test/java/org/photonvision/vision/processes/VisionSourceManagerTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/processes/VisionSourceManagerTest.java
@@ -518,7 +518,8 @@ public class VisionSourceManagerTest {
         inst.tryMatchCamImpl(cameraInfos);
 
         PvCameraInfo info1 =
-                new PvCameraInfo(0, "/dev/video0", "Arducam OV2311 USB Camera", new String[] {}, 3141, 25446);
+                new PvCameraInfo(
+                        0, "/dev/video0", "Arducam OV2311 USB Camera", new String[] {}, 3141, 25446);
 
         cameraInfos.add(info1);
 


### PR DESCRIPTION
# Overview

A currently rather ugly and unhelpful GUI showing USB camera/vision source matching status. I don't love the duplicated data between visionsource and visionmodule telemetry - i just wanna know which VisionModule owns which detected camera. Requires more thought on refactoring the backend, IMO.


https://github.com/user-attachments/assets/b0d00bd4-6f09-4085-a215-d4d8d4ecbc59


