### PR TITLE
Add a basic syslog appender

### DIFF
--- a/photon-core/build.gradle
+++ b/photon-core/build.gradle
@@ -37,9 +37,6 @@ dependencies {
     // Zip
     implementation 'org.zeroturnaround:zt-zip:1.14'
 
-    // Syslog
-    implementation "com.cloudbees:syslog-java-client:1.1.7"
-
     implementation "org.xerial:sqlite-jdbc:3.41.0.0"
     implementation("org.photonvision:rknn_jni-jni:$rknnVersion:linuxarm64") {
         transitive = false

--- a/photon-core/build.gradle
+++ b/photon-core/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     // Zip
     implementation 'org.zeroturnaround:zt-zip:1.14'
 
+    // Syslog
+    implementation "com.cloudbees:syslog-java-client:1.1.7"
+
     implementation "org.xerial:sqlite-jdbc:3.41.0.0"
     implementation("org.photonvision:rknn_jni-jni:$rknnVersion:linuxarm64") {
         transitive = false

--- a/photon-core/src/main/java/org/photonvision/common/logging/syslog/UdpSyslogClient.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/syslog/UdpSyslogClient.java
@@ -70,7 +70,7 @@ import org.photonvision.common.logging.LogLevel;
         }
 
         String syslogMessage = String.format(
-            "<%d>1 %s %s %s %s %s - %s", 
+            "<%d>1 %s %s %s %s %s - %s",
             getPriority(level),
             timestamp,
             hostname,

--- a/photon-core/src/main/java/org/photonvision/common/logging/syslog/UdpSyslogClient.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/syslog/UdpSyslogClient.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.common.logging.syslog;
+
+import java.io.Closeable;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+import org.photonvision.common.logging.LogLevel;
+
+ public class UdpSyslogClient implements Closeable {
+    private final InetAddress address;
+    private final int port;
+    private final DatagramSocket socket;
+    private final String appName;
+
+    private static final int USER_FACILITY = 1;
+
+    public UdpSyslogClient(String appName, String address, int port) throws UnknownHostException, SocketException {
+        this.port = port;
+        this.appName = appName;
+        this.address = InetAddress.getByName(address);
+        socket = new DatagramSocket();
+    }
+
+    public void sendMessage(String message, LogLevel level) {
+        sendMessage(message, null, null, level);
+    }
+
+    public void sendMessage(String message, String processId, String messageId, LogLevel level) {
+        try {
+            String timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
+    
+            String syslogMessage = String.format(
+                "<%d>1 %s %s %s %s %s - %s", 
+                getPriority(level),
+                timestamp,
+                InetAddress.getLocalHost().getHostName(),
+                appName,
+                processId != null ? processId : "-",
+                messageId != null ? messageId : "-",
+                message);
+    
+            byte[] messageBytes = syslogMessage.getBytes(StandardCharsets.UTF_8);
+    
+            // Send the message using UDP
+            DatagramPacket packet = new DatagramPacket(messageBytes, messageBytes.length, address, port);
+
+            // TODO: Does this need to be concerned with thread safety?
+            socket.send(packet);
+        } catch (Exception e) {} // TODO: Should this log somehow? The other implementation does a simple count of sent messages.
+    }
+
+    private int getPriority(LogLevel level) {
+        int severity;
+        switch (level) {
+            case ERROR: severity = 3; break;
+            case WARN: severity = 4; break;
+            case INFO: severity = 6; break;
+            case DEBUG: severity = 7; break;
+            case TRACE: severity = 7; break;
+            default: severity = 6; break;
+        }
+
+        return USER_FACILITY * 8 + severity;
+    }
+
+    @Override
+    public void close() {
+        try { // TODO: Should this log somehow?, could this cause issues?
+            socket.close();
+        } catch (Exception e) {}
+    }
+}

--- a/photon-lib/src/main/java/org/photonvision/PhotonSyslog.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonSyslog.java
@@ -1,0 +1,148 @@
+package org.photonvision;
+
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+public class PhotonSyslog {
+    // Default Settings
+    private String filepath = "/u/logs/photonvision/photonvision.log";
+    private int maxSizeMb = 4;
+    private int logRotations = 5;
+
+    // Implementation defaults (not configurable)
+    private static final Path SYSLOG_CONFIG_PATH = Paths.get("/etc/syslog-ng.d/photonvision.conf");
+    private static final Path LOGROTATE_CONFIG_PATH = Paths.get("/etc/logrotate.d/photonvision.conf");
+    private static final int PV_PORT = 51414;
+
+    public static PhotonSyslog setupSyslog() {
+        return new PhotonSyslog();
+    }
+
+    public static void disable() {
+        try {
+            Files.deleteIfExists(SYSLOG_CONFIG_PATH);
+            Files.deleteIfExists(LOGROTATE_CONFIG_PATH);
+        } catch (Exception e) {}
+    }
+
+    private PhotonSyslog() {}
+
+    public PhotonSyslog setFilePath(String path) {
+        filepath = path;
+        return this;
+    }
+
+    public PhotonSyslog setMaxSizeMb(int megabytes) {
+        maxSizeMb = megabytes;
+        return this;
+    }
+
+    public PhotonSyslog setLogRotations(int rotations) {
+        logRotations = rotations;
+        return this;
+    }
+
+    public void commit() {
+        String SYSLOG_TMP = "/tmp/pvsyslog.conf";
+        String LOGROTATE_TMP = "/tmp/pvlogrotate.conf";
+        try {
+            var syslogFileOutput = new FileOutputStream(SYSLOG_TMP);
+            var logrotateFileOutput = new FileOutputStream(LOGROTATE_TMP);
+
+            syslogFileOutput.write(SyslogConfigFile.generate(filepath, PV_PORT).getBytes());
+            logrotateFileOutput.write(LogRotateConfigFile.generate(filepath, maxSizeMb, logRotations).getBytes());
+
+            syslogFileOutput.close();
+            logrotateFileOutput.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        if (moveFile(SYSLOG_TMP, SYSLOG_CONFIG_PATH.toString()) != 0) {
+            System.err.println("Failed to move photonvision syslog config.");
+        }
+
+        if (moveFile(LOGROTATE_TMP, LOGROTATE_CONFIG_PATH.toString()) != 0) {
+            System.err.println("Failed to move photonvision syslog logrotate config.");
+        }
+
+        refreshSyslog();
+    }
+
+    private int execAdmin(String... command) {
+        String[] args = new String[command.length + 2];
+        args[0] = "ssh";
+        args[1] = "admin@localhost";
+        System.arraycopy(command, 0, args, 2, command.length);  
+        return exec(args);
+    }
+
+    private int exec(String... command) {
+        ProcessBuilder pb = new ProcessBuilder(command);
+
+        int exitCode = 0;
+        try {
+            Process process = pb.start();
+
+            process.waitFor(2, TimeUnit.SECONDS);
+            exitCode = process.exitValue();
+        } catch (Exception e) {
+            e.printStackTrace();
+            exitCode = 1;
+        }
+
+        return exitCode;
+    }
+
+    private void refreshSyslog() {
+        // -HUP signal tells syslog to reload config
+        int exitCode = execAdmin("/usr/bin/killall", "-HUP", "syslog-ng");
+
+        if (exitCode != 0) {
+            System.out.println("Failed to restart syslog-ng service with code " + exitCode);
+        }
+    }
+
+    private int moveFile(String src, String dest) {
+        return execAdmin("mv", src, dest);
+    }
+
+    protected static class SyslogConfigFile {
+        private static final String FILE_TEMPLATE = """
+            @version: 3.8
+            
+            source s_photonvision { tcp(ip(0.0.0.0) port(%d) max-connections(100)); udp(); };
+            destination d_photonvision { file("%s"); };
+            
+            log { source(s_photonvision); destination(d_photonvision); };
+            """;
+
+        private static String generate(String filepath, int port) {
+            return String.format(FILE_TEMPLATE, port, filepath);
+        }
+    }
+
+    protected static class LogRotateConfigFile {
+        private static final String FILE_TEMPLATE = """
+            # Logrotate configuration for photonvision logs
+
+            %s {
+                    su lvuser ni
+                    compresscmd /usr/bin/zip
+                    compressext .zip
+                    postrotate
+                            /usr/bin/killall -HUP syslog-ng
+                    endscript
+                    size %dM
+                    rotate %d
+            }
+            """;
+
+        private static String generate(String logpath, int size, int rotate) {
+            return String.format(FILE_TEMPLATE, logpath, size, rotate);
+        }
+    }
+}

--- a/photon-targeting/src/generated/main/java/org/photonvision/jni/WpilibLoader.java
+++ b/photon-targeting/src/generated/main/java/org/photonvision/jni/WpilibLoader.java
@@ -65,4 +65,8 @@ public class WpilibLoader {
 
         return has_loaded;
     }
+
+    public static boolean hasLoaded() {
+        return has_loaded;
+    }
 }


### PR DESCRIPTION
This commits allows photonvision to push logs to a remote syslog server such as the one on the roboRIO. To enable this on the RIO create a file in /etc/syslog-ng.d/ for example

```
@version: 3.8

source s_net { tcp(ip(0.0.0.0) port(514) max-connections (5000)); udp(); };
destination d_syslog { file("/var/log/remotesyslog"); };

log { source(s_net); destination(d_syslog); };
```

This is experimental. Also I grabbed the first syslog java library I could find. There may be other options if needed.