### PR TITLE
Fixed Python code block being in C++ block

### DIFF
--- a/docs/source/docs/programming/photonlib/controlling-led.md
+++ b/docs/source/docs/programming/photonlib/controlling-led.md
@@ -14,7 +14,7 @@ You can control the vision LEDs of supported hardware via PhotonLib using the `s
       // Blink the LEDs.
       camera.SetLED(photonlib::VisionLEDMode::kBlink);
 
-    .. code-block:: Python
+   .. code-block:: Python
 
         # Coming Soon!
 ```

--- a/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
+++ b/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
@@ -62,7 +62,7 @@ You can also get the pipeline latency from a pipeline result using the `getLaten
       // Get the pipeline latency.
       units::second_t latency = result.GetLatency();
 
-    .. code-block:: Python
+   .. code-block:: Python
 
         # Coming Soon!
 ```

--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -24,7 +24,7 @@ The API documentation can be found in here: [Java](https://github.wpilib.org/all
       // The parameter for LoadAPrilTagLayoutField will be different depending on the game.
       frc::AprilTagFieldLayout aprilTagFieldLayout = frc::LoadAprilTagLayoutField(frc::AprilTagField::k2024Crescendo);
 
-    .. code-block:: Python
+   .. code-block:: Python
 
         # Coming Soon!
 
@@ -81,7 +81,7 @@ The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (s
       photonlib::RobotPoseEstimator estimator(
           aprilTags, photonlib::CLOSEST_TO_REFERENCE_POSE, cameras);
 
-    .. code-block:: Python
+   .. code-block:: Python
 
         kRobotToCam = wpimath.geometry.Transform3d(
             wpimath.geometry.Translation3d(0.5, 0.0, 0.5),
@@ -123,7 +123,9 @@ Calling `update()` on your `PhotonPoseEstimator` will return an `EstimatedRobotP
         }
       }
 
-    .. code-block:: Python
+   .. code-block:: Python
+
+      # Coming Soon!
 
 
 


### PR DESCRIPTION
In a few programming doc pages, there is a missing indentation so Python code example ends up being at the bottom of C++ example. There is also an empty Python example where I added # Coming Soon!