### PR TITLE
Fix windows NPEs around exposure+klogs

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/logging/KernelLogLogger.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/KernelLogLogger.java
@@ -65,6 +65,10 @@ public class KernelLogLogger {
     }
 
     public void outputNewPrintks() {
+        if (listener == null) {
+            return;
+        }
+
         for (var msg : listener.getNewlines()) {
             // We currently set all logs to debug regardless of their actual level
             logger.log(msg, LogLevel.DEBUG);

--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
@@ -96,9 +96,12 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
         var autoExpProp = findProperty("exposure_auto", "auto_exposure");
 
         exposureAbsProp = expProp.get();
-        autoExposureProp = autoExpProp.get();
         this.minExposure = exposureAbsProp.getMin();
         this.maxExposure = exposureAbsProp.getMax();
+
+        if (autoExpProp.isPresent()) {
+            autoExposureProp = autoExpProp.get();
+        }
     }
 
     public void setAllCamDefaults() {
@@ -169,7 +172,7 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
             softSet("auto_exposure_bias", 0);
             softSet("iso_sensitivity_auto", 0); // Disable auto ISO adjustment
             softSet("iso_sensitivity", 0); // Manual ISO adjustment
-            autoExposureProp.set(PROP_AUTO_EXPOSURE_DISABLED);
+            if (autoExposureProp != null) autoExposureProp.set(PROP_AUTO_EXPOSURE_DISABLED);
 
             // Most cameras leave exposure time absolute at the last value from their AE
             // algorithm.
@@ -199,7 +202,7 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
     public void setExposureRaw(double exposureRaw) {
         if (exposureRaw >= 0.0) {
             try {
-                autoExposureProp.set(PROP_AUTO_EXPOSURE_DISABLED);
+                if (autoExposureProp != null) autoExposureProp.set(PROP_AUTO_EXPOSURE_DISABLED);
 
                 int propVal = (int) MathUtil.clamp(exposureRaw, minExposure, maxExposure);
 


### PR DESCRIPTION
Various NPEs that can be hit on Windows with my OV2311 that prevent Photon from working.