### PR TITLE
Add missing var to dataclass

### DIFF
--- a/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
+++ b/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
@@ -15,6 +15,8 @@ class PhotonPipelineMetadata:
     # Mirror of the heartbeat entry -- monotonically increasing
     sequenceID: int = -1
 
+    timeSinceLastPong: int = -1
+
     photonStruct: "PhotonPipelineMetadataSerde" = None
 
 


### PR DESCRIPTION
The generated code already has a call to try and unpack this but its a dud because this is missing.

See line 46 [here ](https://github.com/PhotonVision/photonvision/blob/master/photon-lib/py/photonlibpy/generated/PhotonPipelineMetadataSerde.py).

This is also present in the c++/java code [here](https://github.com/PhotonVision/photonvision/blob/master/photon-targeting/src/generated/main/native/include/photon/serde/PhotonPipelineMetadataSerde.h) and [here](https://github.com/PhotonVision/photonvision/blob/master/photon-targeting/src/generated/main/java/org/photonvision/struct/PhotonPipelineMetadataSerde.java)