### PR TITLE
Stop type hinting members as optional in PhotonTrackedTarget

### DIFF
--- a/photon-lib/py/photonlibpy/targeting/photonTrackedTarget.py
+++ b/photon-lib/py/photonlibpy/targeting/photonTrackedTarget.py
@@ -13,8 +13,8 @@ class PhotonTrackedTarget:
     fiducialId: int = -1
     bestCameraToTarget: Transform3d = field(default_factory=Transform3d)
     altCameraToTarget: Transform3d = field(default_factory=Transform3d)
-    minAreaRectCorners: list[TargetCorner] | None = None
-    detectedCorners: list[TargetCorner] | None = None
+    minAreaRectCorners: list[TargetCorner] = field(default_factory=list[TargetCorner])
+    detectedCorners: list[TargetCorner] = field(default_factory=list[TargetCorner])
     poseAmbiguity: float = 0.0
 
     def getYaw(self) -> float:
@@ -35,10 +35,10 @@ class PhotonTrackedTarget:
     def getPoseAmbiguity(self) -> float:
         return self.poseAmbiguity
 
-    def getMinAreaRectCorners(self) -> list[TargetCorner] | None:
+    def getMinAreaRectCorners(self) -> list[TargetCorner]:
         return self.minAreaRectCorners
 
-    def getDetectedCorners(self) -> list[TargetCorner] | None:
+    def getDetectedCorners(self) -> list[TargetCorner]:
         return self.detectedCorners
 
     def getBestCameraToTarget(self) -> Transform3d:


### PR DESCRIPTION
This has spun off from the conversation in #1535. List types should never be optional if sent to NT because an empty list conveys the same thing.

The equivalent C++ struct takes the same approach with empty vectors rather than an optional vector.

```C++
struct PhotonTrackedTarget_PhotonStruct {
  double yaw;
  double pitch;
  double area;
  double skew;
  int32_t fiducialId;
  int32_t objDetectId;
  float objDetectConf;
  frc::Transform3d bestCameraToTarget;
  frc::Transform3d altCameraToTarget;
  double poseAmbiguity;
  std::vector<photon::TargetCorner> minAreaRectCorners;
  std::vector<photon::TargetCorner> detectedCorners;

  friend bool operator==(PhotonTrackedTarget_PhotonStruct const&,
                         PhotonTrackedTarget_PhotonStruct const&) = default;
};
```

A quick ctrl+F of the codebase indicates these things are only used in simulation or as a part of code that still doesn't exist within Python. That makes this change pretty benign and I think it should be sent in. Once this gets merged, I can remove the edge case and note in #1535, and we will be one step closer to getting simulation in Python!