### PR TITLE
Automatically detect and report hardware model for most SBCs

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
@@ -151,7 +151,11 @@ public class PhotonConfiguration {
         generalSubmap.put("availableModels", NeuralNetworkModelManager.getInstance().getModels());
         generalSubmap.put(
                 "supportedBackends", NeuralNetworkModelManager.getInstance().getSupportedBackends());
-        generalSubmap.put("hardwareModel", hardwareConfig.deviceName.isEmpty() ? Platform.getHardwareModel() : hardwareConfig.deviceName);
+        generalSubmap.put(
+                "hardwareModel",
+                hardwareConfig.deviceName.isEmpty()
+                        ? Platform.getHardwareModel()
+                        : hardwareConfig.deviceName);
         generalSubmap.put("hardwarePlatform", Platform.getPlatformName());
         settingsSubmap.put("general", generalSubmap);
         // AprilTagFieldLayout

--- a/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/PhotonConfiguration.java
@@ -151,7 +151,7 @@ public class PhotonConfiguration {
         generalSubmap.put("availableModels", NeuralNetworkModelManager.getInstance().getModels());
         generalSubmap.put(
                 "supportedBackends", NeuralNetworkModelManager.getInstance().getSupportedBackends());
-        generalSubmap.put("hardwareModel", hardwareConfig.deviceName);
+        generalSubmap.put("hardwareModel", hardwareConfig.deviceName.isEmpty() ? Platform.getHardwareModel() : hardwareConfig.deviceName);
         generalSubmap.put("hardwarePlatform", Platform.getPlatformName());
         settingsSubmap.put("general", generalSubmap);
         // AprilTagFieldLayout

--- a/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
@@ -60,12 +60,24 @@ public enum Platform {
             true), // Jetson Nano, Jetson TX2
 
     // PhotonVision Supported (Manual build/install)
-    LINUX_ARM64("Linux ARM64", Platform::getLinuxDeviceTreeModel, "linuxarm64", false, OSType.LINUX, true), // ODROID C2, N2
+    LINUX_ARM64(
+            "Linux ARM64",
+            Platform::getLinuxDeviceTreeModel,
+            "linuxarm64",
+            false,
+            OSType.LINUX,
+            true), // ODROID C2, N2
 
     // Completely unsupported
     WINDOWS_32("Windows x86", Platform::getUnknownModel, "windowsx64", false, OSType.WINDOWS, false),
     MACOS("Mac OS", Platform::getUnknownModel, "osxuniversal", false, OSType.MACOS, false),
-    LINUX_ARM32("Linux ARM32", Platform::getUnknownModel, "linuxarm32", false, OSType.LINUX, false), // ODROID XU4, C1+
+    LINUX_ARM32(
+            "Linux ARM32",
+            Platform::getUnknownModel,
+            "linuxarm32",
+            false,
+            OSType.LINUX,
+            false), // ODROID XU4, C1+
     UNKNOWN("Unsupported Platform", Platform::getUnknownModel, "", false, OSType.UNKNOWN, false);
 
     public enum OSType {


### PR DESCRIPTION
ARM-based machines populate the device model into Device Tree. We can use this information to automatically detect and report the hardware model for most Single Board Computers (SBCs). Vendors who want to override this can still do so via the value in the configuration database.