### PR TITLE
Remove wpilibc dependency from vendordep JSON

### DIFF
--- a/photon-lib/src/generate/photonlib.json.in
+++ b/photon-lib/src/generate/photonlib.json.in
@@ -11,19 +11,6 @@
   "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/photonlib-json/1.0/photonlib-json-1.0.json",
   "jniDependencies": [
     {
-      "groupId": "edu.wpi.first.wpilibc",
-      "artifactId": "wpilibc-cpp",
-      "version": "${wpilib_version}",
-      "skipInvalidPlatforms": true,
-      "isJar": false,
-      "validPlatforms": [
-        "windowsx86-64",
-        "linuxathena",
-        "linuxx86-64",
-        "osxuniversal"
-      ]
-    },
-    {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
       "version": "${photon_version}",


### PR DESCRIPTION
JNI shouldn't be linking to wpilibc (cause it also loads things that wpilibj loads.) Although, I think this is just downloading wpilibc, but either way, it shouldn't be a JNI dependency.