### PR TITLE
photonlibpy: Fix some type check failures

### DIFF
--- a/photon-lib/py/photonlibpy/packet.py
+++ b/photon-lib/py/photonlibpy/packet.py
@@ -16,11 +16,10 @@
 ###############################################################################
 
 import struct
-from typing import Any, Generic, Optional, Protocol, TypeVar
+from typing import Generic, Optional, Protocol, TypeVar
 
 import wpilib
 from wpimath.geometry import Quaternion, Rotation3d, Transform3d, Translation3d
-
 
 T = TypeVar("T")
 

--- a/photon-lib/py/photonlibpy/packet.py
+++ b/photon-lib/py/photonlibpy/packet.py
@@ -16,10 +16,18 @@
 ###############################################################################
 
 import struct
-from typing import Any, Optional, Type
+from typing import Any, Generic, Optional, Protocol, TypeVar
 
 import wpilib
 from wpimath.geometry import Quaternion, Rotation3d, Transform3d, Translation3d
+
+
+T = TypeVar("T")
+
+
+class Serde(Generic[T], Protocol):
+    def pack(self, value: T) -> "Packet": ...
+    def unpack(self, packet: "Packet") -> T: ...
 
 
 class Packet:
@@ -34,9 +42,9 @@ class Packet:
         self.readPos = 0
         self.outOfBytes = False
 
-    def clear(self):
+    def clear(self) -> None:
         """Clears the packet and resets the read and write positions."""
-        self.packetData = [0] * self.size
+        self.packetData = bytes(self.size)
         self.readPos = 0
         self.outOfBytes = False
 
@@ -158,7 +166,7 @@ class Packet:
             ret.append(self.decodeDouble())
         return ret
 
-    def decodeShortList(self) -> list[float]:
+    def decodeShortList(self) -> list[int]:
         """
         * Returns a decoded array of shorts from the packet.
         """
@@ -187,14 +195,14 @@ class Packet:
 
         return Transform3d(translation, rotation)
 
-    def decodeList(self, serde: Type):
+    def decodeList(self, serde: Serde[T]) -> list[T]:
         retList = []
         arr_len = self.decode8()
         for _ in range(arr_len):
             retList.append(serde.unpack(self))
         return retList
 
-    def decodeOptional(self, serde: Type) -> Optional[Any]:
+    def decodeOptional(self, serde: Serde[T]) -> Optional[T]:
         if self.decodeBoolean():
             return serde.unpack(self)
         else:
@@ -281,7 +289,7 @@ class Packet:
         self.encodeDouble(quaternion.Y())
         self.encodeDouble(quaternion.Z())
 
-    def encodeList(self, values: list[Any], serde: Type):
+    def encodeList(self, values: list[T], serde: Serde[T]):
         """
         Encodes a list of items using a specific serializer and appends it to the packet.
         """
@@ -291,7 +299,7 @@ class Packet:
             self.packetData = self.packetData + packed.getData()
             self.size = len(self.packetData)
 
-    def encodeOptional(self, value: Optional[Any], serde: Type):
+    def encodeOptional(self, value: Optional[T], serde: Serde[T]):
         """
         Encodes an optional value using a specific serializer.
         """

--- a/photon-lib/py/photonlibpy/photonCamera.py
+++ b/photon-lib/py/photonlibpy/photonCamera.py
@@ -236,12 +236,13 @@ class PhotonCamera:
 
         remoteUUID = self._rawBytesEntry.getTopic().getProperty("message_uuid")
 
-        if remoteUUID is None or len(remoteUUID) == 0:
+        if not remoteUUID:
             wpilib.reportWarning(
                 f"PhotonVision coprocessor at path {self._path} has not reported a message interface UUID - is your coprocessor's camera started?",
                 True,
             )
 
+        assert isinstance(remoteUUID, str)
         # ntcore hands us a JSON string with leading/trailing quotes - remove those
         remoteUUID = remoteUUID.replace('"', "")
 

--- a/photon-lib/py/photonlibpy/targeting/TargetCorner.py
+++ b/photon-lib/py/photonlibpy/targeting/TargetCorner.py
@@ -1,4 +1,8 @@
 from dataclasses import dataclass
+from typing import ClassVar, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .. import generated
 
 
 @dataclass
@@ -6,4 +10,4 @@ class TargetCorner:
     x: float = 0
     y: float = 9
 
-    photonStruct: "TargetCornerSerde" = None
+    photonStruct: ClassVar["generated.TargetCornerSerde"]

--- a/photon-lib/py/photonlibpy/targeting/TargetCorner.py
+++ b/photon-lib/py/photonlibpy/targeting/TargetCorner.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import ClassVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     from .. import generated

--- a/photon-lib/py/photonlibpy/targeting/multiTargetPNPResult.py
+++ b/photon-lib/py/photonlibpy/targeting/multiTargetPNPResult.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import ClassVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from wpimath.geometry import Transform3d
 

--- a/photon-lib/py/photonlibpy/targeting/multiTargetPNPResult.py
+++ b/photon-lib/py/photonlibpy/targeting/multiTargetPNPResult.py
@@ -1,8 +1,12 @@
 from dataclasses import dataclass, field
+from typing import ClassVar, TYPE_CHECKING
 
 from wpimath.geometry import Transform3d
 
 from ..packet import Packet
+
+if TYPE_CHECKING:
+    from .. import generated
 
 
 @dataclass
@@ -13,7 +17,7 @@ class PnpResult:
     bestReprojErr: float = 0.0
     altReprojErr: float = 0.0
 
-    photonStruct: "PNPResultSerde" = None
+    photonStruct: ClassVar["generated.PnpResultSerde"]
 
 
 @dataclass
@@ -33,4 +37,4 @@ class MultiTargetPNPResult:
                 self.fiducialIDsUsed.append(fidId)
         return packet
 
-    photonStruct: "MultiTargetPNPResultSerde" = None
+    photonStruct: ClassVar["generated.MultiTargetPNPResultSerde"]

--- a/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
+++ b/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import ClassVar, Optional, TYPE_CHECKING
 
 from .multiTargetPNPResult import MultiTargetPNPResult
 from .photonTrackedTarget import PhotonTrackedTarget
+
+if TYPE_CHECKING:
+    from .. import generated
 
 
 @dataclass
@@ -17,7 +20,7 @@ class PhotonPipelineMetadata:
 
     timeSinceLastPong: int = -1
 
-    photonStruct: "PhotonPipelineMetadataSerde" = None
+    photonStruct: ClassVar["generated.PhotonPipelineMetadataSerde"]
 
 
 @dataclass
@@ -57,7 +60,7 @@ class PhotonPipelineResult:
     def hasTargets(self) -> bool:
         return len(self.targets) > 0
 
-    def getBestTarget(self) -> PhotonTrackedTarget:
+    def getBestTarget(self) -> Optional[PhotonTrackedTarget]:
         """
         Returns the best target in this pipeline result. If there are no targets, this method will
         return null. The best target is determined by the target sort mode in the PhotonVision UI.
@@ -66,4 +69,4 @@ class PhotonPipelineResult:
             return None
         return self.getTargets()[0]
 
-    photonStruct: "PhotonPipelineResultSerde" = None
+    photonStruct: ClassVar["generated.PhotonPipelineResultSerde"]

--- a/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
+++ b/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import ClassVar, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar, Optional
 
 from .multiTargetPNPResult import MultiTargetPNPResult
 from .photonTrackedTarget import PhotonTrackedTarget

--- a/photon-lib/py/photonlibpy/targeting/photonTrackedTarget.py
+++ b/photon-lib/py/photonlibpy/targeting/photonTrackedTarget.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import ClassVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from wpimath.geometry import Transform3d
 

--- a/photon-lib/py/photonlibpy/targeting/photonTrackedTarget.py
+++ b/photon-lib/py/photonlibpy/targeting/photonTrackedTarget.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass, field
+from typing import ClassVar, TYPE_CHECKING
 
 from wpimath.geometry import Transform3d
 
 from ..packet import Packet
 from .TargetCorner import TargetCorner
+
+if TYPE_CHECKING:
+    from .. import generated
 
 
 @dataclass
@@ -59,4 +63,4 @@ class PhotonTrackedTarget:
             retList.append(TargetCorner(cx, cy))
         return retList
 
-    photonStruct: "PhotonTrackedTargetSerde" = None
+    photonStruct: ClassVar["generated.PhotonTrackedTargetSerde"]


### PR DESCRIPTION
This fixes a variety of type check failures raised by both mypy and pyright.

I am however unable to make both completely happy here. In particular an entire method doesn't exist, and I don't know what its implementation is supposed to be. The bulk of mypy's complaints stem from the confusion with names of values that are shadowing modules in the `photonlibpy.generated` package.

```console
> npx pyright photonlibpy
/Users/davidv/dev/frc/photonvision/photon-lib/py/photonlibpy/targeting/multiTargetPNPResult.py
  /Users/davidv/dev/frc/photonvision/photon-lib/py/photonlibpy/targeting/multiTargetPNPResult.py:32:28 - error: Cannot access attribute "createFromPacket" for class "PnpResult"
    Attribute "createFromPacket" is unknown (reportAttributeAccessIssue)
1 error, 0 warnings, 0 informations

> mypy photonlibpy
photonlibpy/targeting/multiTargetPNPResult.py:20: error: Module "photonlibpy.generated.PnpResultSerde" is not valid as a type  [valid-type]
photonlibpy/targeting/multiTargetPNPResult.py:20: note: Perhaps you meant to use a protocol matching the module structure?
photonlibpy/targeting/multiTargetPNPResult.py:32: error: "PnpResult" has no attribute "createFromPacket"  [attr-defined]
photonlibpy/targeting/multiTargetPNPResult.py:40: error: Module "photonlibpy.generated.MultiTargetPNPResultSerde" is not valid as a type  [valid-type]
photonlibpy/targeting/multiTargetPNPResult.py:40: note: Perhaps you meant to use a protocol matching the module structure?
photonlibpy/targeting/TargetCorner.py:13: error: Module "photonlibpy.generated.TargetCornerSerde" is not valid as a type  [valid-type]
photonlibpy/targeting/TargetCorner.py:13: note: Perhaps you meant to use a protocol matching the module structure?
photonlibpy/targeting/photonTrackedTarget.py:66: error: Module "photonlibpy.generated.PhotonTrackedTargetSerde" is not valid as a type  [valid-type]
photonlibpy/targeting/photonTrackedTarget.py:66: note: Perhaps you meant to use a protocol matching the module structure?
photonlibpy/targeting/photonPipelineResult.py:23: error: Module "photonlibpy.generated.PhotonPipelineMetadataSerde" is not valid as a type  [valid-type]
photonlibpy/targeting/photonPipelineResult.py:23: note: Perhaps you meant to use a protocol matching the module structure?
photonlibpy/targeting/photonPipelineResult.py:72: error: Module "photonlibpy.generated.PhotonPipelineResultSerde" is not valid as a type  [valid-type]
photonlibpy/targeting/photonPipelineResult.py:72: note: Perhaps you meant to use a protocol matching the module structure?
photonlibpy/generated/PhotonPipelineResultSerde.py:38: error: generated.PhotonPipelineMetadataSerde? has no attribute "pack"  [attr-defined]
photonlibpy/generated/PhotonPipelineResultSerde.py:53: error: generated.PhotonPipelineMetadataSerde? has no attribute "unpack"  [attr-defined]
photonlibpy/generated/MultiTargetPNPResultSerde.py:37: error: generated.PnpResultSerde? has no attribute "pack"  [attr-defined]
photonlibpy/generated/MultiTargetPNPResultSerde.py:48: error: generated.PnpResultSerde? has no attribute "unpack"  [attr-defined]
photonlibpy/photonCamera.py:61: error: generated.PhotonPipelineResultSerde? has no attribute "MESSAGE_VERSION"  [attr-defined]
photonlibpy/photonCamera.py:130: error: generated.PhotonPipelineResultSerde? has no attribute "unpack"  [attr-defined]
photonlibpy/photonCamera.py:149: error: generated.PhotonPipelineResultSerde? has no attribute "unpack"  [attr-defined]
photonlibpy/photonCamera.py:235: error: generated.PhotonPipelineResultSerde? has no attribute "MESSAGE_VERSION"  [attr-defined]
Found 15 errors in 7 files (checked 18 source files)
```