### PR TITLE
Enable link-local in parallel with DHCP

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -169,27 +169,27 @@ public class NetworkManager {
         String connName = "dhcp-" + config.networkManagerIface;
 
         String addDHCPcommand = """
-            nmcli connection add
+            nmcli connection ${action}
             con-name "${connection}"
             ifname "${interface}"
             type ethernet
-            autoconnect no
+            autoconnect yes
             ipv4.method auto
+            ipv4.dhcp-timeout infinity
+            ipv4.link-local enabled
             ipv6.method disabled
             """;
         addDHCPcommand = addDHCPcommand.replaceAll("[\\n]", " ");
 
         var shell = new ShellExec();
         try {
-            if (NetworkUtils.connDoesNotExist(connName)) {
-                // create connection
-                logger.info("Creating the DHCP connection " + connName );
-                shell.executeBashCommand(
-                    addDHCPcommand
-                        .replace("${connection}", connName)
-                        .replace("${interface}", config.networkManagerIface)
-                    );
-            }
+            logger.info("Updating the DHCP connection " + connName );
+            shell.executeBashCommand("nmcli connection add " +
+            addDHCPcommand
+                .replace("${action}", NetworkUtils.connExists(connName) ? "add" : "modify")
+                .replace("${connection}", connName)
+                .replace("${interface}", config.networkManagerIface)
+            );            
             // activate it
             logger.info("Activating the DHCP connection " + connName );
             shell.executeBashCommand("nmcli connection up \"${connection}\"".replace("${connection}", connName), false);

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -172,7 +172,7 @@ public class NetworkUtils {
         var shell = new ShellExec(true, true);
         try {
             // set nmcli back to DHCP, and re-run dhclient -- this ought to grab a new IP address
-            shell.executeBashCommand("nmcli -f GENERAL.STATE connection show \"" + connName + "\"");
+            shell.executeBashCommand("nmcli -g GENERAL.STATE connection show \"" + connName + "\"");
             return (shell.getExitCode() == 10);
         } catch (Exception e) {
             logger.error("Exception from nmcli!");

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -156,18 +156,6 @@ public class NetworkUtils {
         return null;
     }
 
-    public static boolean connExists(String connName) {
-        var shell = new ShellExec(true, true);
-        try {
-            // set nmcli back to DHCP, and re-run dhclient -- this ought to grab a new IP address
-            shell.executeBashCommand("nmcli -g GENERAL.STATE connection show \"" + connName + "\"");
-            return (shell.getExitCode() == 0);
-        } catch (Exception e) {
-            logger.error("Exception from nmcli!");
-        }
-        return false;
-    }
-
     public static boolean connDoesNotExist(String connName) {
         var shell = new ShellExec(true, true);
         try {

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -159,7 +159,6 @@ public class NetworkUtils {
     public static boolean connDoesNotExist(String connName) {
         var shell = new ShellExec(true, true);
         try {
-            // set nmcli back to DHCP, and re-run dhclient -- this ought to grab a new IP address
             shell.executeBashCommand("nmcli -g GENERAL.STATE connection show \"" + connName + "\"");
             return (shell.getExitCode() == 10);
         } catch (Exception e) {

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -156,6 +156,18 @@ public class NetworkUtils {
         return null;
     }
 
+    public static boolean connExists(String connName) {
+        var shell = new ShellExec(true, true);
+        try {
+            // set nmcli back to DHCP, and re-run dhclient -- this ought to grab a new IP address
+            shell.executeBashCommand("nmcli -g GENERAL.STATE connection show \"" + connName + "\"");
+            return (shell.getExitCode() == 0);
+        } catch (Exception e) {
+            logger.error("Exception from nmcli!");
+        }
+        return false;
+    }
+
     public static boolean connDoesNotExist(String connName) {
         var shell = new ShellExec(true, true);
         try {


### PR DESCRIPTION
This update to the DHCP connection settings allows IPv4 link local connection when waiting for a DHCP response. Once it get the DHCP response the IP settings will be set by the DHCP server. 

I've tested this using a direct Ethernet connection between my Win11 laptop and the coprocessor. I've tested with an OrangePi5 and a RaspberryPi4.

I'd appreciate others giving this a try and letting me know if it works or causes problems.