### PR TITLE
Include kernel logs when downloading logs

### DIFF
--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -290,5 +290,5 @@ Then, run the examples:
 Using the [GitHub CLI](https://cli.github.com/), we can download artifacts from pipelines by run ID and name:
 
 ```
-~/photonvision$ gh run download 11759699679 -n jar-Linux 
+~/photonvision$ gh run download 11759699679 -n jar-Linux
 ```

--- a/photon-core/src/main/java/org/photonvision/common/logging/KernelLogLogger.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/KernelLogLogger.java
@@ -18,9 +18,6 @@
 package org.photonvision.common.logging;
 
 import edu.wpi.first.util.RuntimeDetector;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.photonvision.common.util.TimedTaskManager;
 import org.photonvision.jni.QueuedFileLogger;
 
@@ -43,17 +40,6 @@ public class KernelLogLogger {
 
     public KernelLogLogger() {
         if (RuntimeDetector.isLinux()) {
-            logger.info("Listening for klogs on /var/log/dmesg ! Boot logs:");
-
-            try {
-                var bootlog = Files.readAllLines(Path.of("/var/log/dmesg"));
-                for (var line : bootlog) {
-                    logger.log(line, LogLevel.DEBUG);
-                }
-            } catch (IOException e) {
-                logger.error("Couldn't read /var/log/dmesg - not printing boot logs");
-            }
-
             listener = new QueuedFileLogger("/var/log/kern.log");
         } else {
             System.out.println("NOT for klogs");

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -424,10 +424,13 @@ public class RequestHandler {
             ShellExec shell = new ShellExec();
             var tempPath = Files.createTempFile("photonvision-journalctl", ".txt");
             var tempPath2 = Files.createTempFile("photonvision-kernelogs", ".txt");
+            // In the command below:
+            //   dmesg = output all kernel logs since current boot
+            //   cat /var/log/kern.log = output all kernal logs since first boot
             shell.executeBashCommand(
                     "journalctl -u photonvision.service > "
                             + tempPath.toAbsolutePath()
-                            + " && journalctl -k > "
+                            + " && dmesg > "
                             + tempPath2.toAbsolutePath());
 
             while (!shell.isOutputCompleted()) {


### PR DESCRIPTION
Instead of writing the kernel logs to the photonvision logs, this will download them in the same zip file as the photonvision logs.