### PR TITLE
[photon-targeting] Fix JNI loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,20 @@ jobs:
           name: built-client
           path: photon-client/dist/
   build-examples:
-    name: "Build Examples"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2022
+            architecture: x64
+          - os: macos-14
+            architecture: aarch64
+          - os: ubuntu-22.04
+
+    name: "Photonlib - Build Examples - ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
     name: "Photonlib - Build Examples - ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
 
-    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish photonlib to maven local
         run: |
           chmod +x gradlew
-          ./gradlew publishtomavenlocal -x check
+          ./gradlew photon-targeting:publishtomavenlocal photon-lib:publishtomavenlocal -x check
       - name: Build Java examples
         working-directory: photonlib-java-examples
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,13 +66,13 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew copyPhotonlib -x check
-          ./gradlew build -x check
+          ./gradlew build
       - name: Build C++ examples
         working-directory: photonlib-cpp-examples
         run: |
           chmod +x gradlew
           ./gradlew copyPhotonlib -x check
-          ./gradlew build -x check
+          ./gradlew build
   build-gradle:
     name: "Gradle Build"
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,7 +597,7 @@ jobs:
 
   dispatch:
     name: dispatch
-    needs: [build-photonlib-vendorjson]
+    needs: [build-photonlib-vendorjson, release]
     runs-on: ubuntu-22.04
     steps:
       - uses: peter-evans/repository-dispatch@v3

--- a/photon-lib/build.gradle
+++ b/photon-lib/build.gradle
@@ -88,6 +88,7 @@ model {
                 }
                 if(project.hasProperty('includePhotonTargeting')) {
                     lib project: ':photon-targeting', library: 'photontargeting', linkage: 'shared'
+                    lib project: ':photon-targeting', library: 'photontargetingJNI', linkage: 'shared'
                 }
             }
 

--- a/photon-lib/src/generate/photonlib.json.in
+++ b/photon-lib/src/generate/photonlib.json.in
@@ -41,7 +41,7 @@
       "artifactId": "photontargeting-jni",
       "version": "${photon_version}",
       "skipInvalidPlatforms": true,
-      "isJar": false,
+      "isJar": true,
       "validPlatforms": [
         "windowsx86-64",
         "linuxathena",

--- a/photon-lib/src/generate/photonlib.json.in
+++ b/photon-lib/src/generate/photonlib.json.in
@@ -41,7 +41,7 @@
       "artifactId": "photontargeting-jni",
       "version": "${photon_version}",
       "skipInvalidPlatforms": true,
-      "isJar": true,
+      "isJar": false,
       "validPlatforms": [
         "windowsx86-64",
         "linuxathena",

--- a/photon-targeting/build.gradle
+++ b/photon-targeting/build.gradle
@@ -146,6 +146,8 @@ model {
             }
 
             binaries.all {
+                lib library: nativeName, linkage: 'shared'
+                lib library: "${nativeName}JNI", linkage: 'shared'
                 it.tasks.withType(CppCompile) {
                     it.dependsOn generateProto
                 }

--- a/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
+++ b/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
@@ -17,7 +17,6 @@
 
 package org.photonvision.jni;
 
-import edu.wpi.first.util.RuntimeDetector;
 import edu.wpi.first.util.RuntimeLoader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -30,8 +29,7 @@ public class PhotonTargetingJniLoader {
     public static boolean isWorking = false;
 
     public static boolean load() throws IOException, UnsatisfiedLinkError {
-        if (isWorking)
-            return true;
+        if (isWorking) return true;
         isWorking = load_();
         return isWorking;
     }

--- a/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
+++ b/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
@@ -29,8 +29,7 @@ public class PhotonTargetingJniLoader {
     public static boolean isWorking = false;
 
     public static boolean load() throws IOException, UnsatisfiedLinkError {
-        if (isWorking)
-            return true;
+        if (isWorking) return true;
         isWorking = load_();
         return isWorking;
     }

--- a/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
+++ b/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
@@ -17,72 +17,19 @@
 
 package org.photonvision.jni;
 
-import edu.wpi.first.util.RuntimeDetector;
 import edu.wpi.first.util.RuntimeLoader;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
-import org.photonvision.common.hardware.Platform;
 
 public class PhotonTargetingJniLoader {
     public static boolean isWorking = false;
 
     public static boolean load() throws IOException, UnsatisfiedLinkError {
         if (isWorking) return true;
-        isWorking = load_();
-        return isWorking;
-    }
-
-    public static boolean load_() throws IOException, UnsatisfiedLinkError {
-        // We always extract the shared object (we could hash each so, but that's a lot
-        // of work)
-        String arch_name = Platform.getNativeLibraryFolderName();
-        var clazz = PhotonTargetingJniLoader.class;
-
         for (var libraryName : List.of("photontargeting", "photontargetingJNI")) {
-            if (RuntimeDetector.isAthena()) {
-                System.out.println("Detected rio - loading directly");
-                RuntimeLoader.loadLibrary(libraryName);
-                continue;
-            }
-
-            var nativeLibName = System.mapLibraryName(libraryName);
-            var path = "/nativelibraries/" + arch_name + "/" + nativeLibName;
-            var in = clazz.getResourceAsStream(path);
-
-            if (in == null) {
-                System.err.println("Could not get resource at path " + path);
-                return false;
-            }
-
-            // It's important that we don't mangle the names of these files on Windows at
-            // least
-            var tempfolder = Files.createTempDirectory("nativeextract");
-            File temp = new File(tempfolder.toAbsolutePath().toString(), nativeLibName);
-            System.out.println(temp.getAbsolutePath().toString());
-            FileOutputStream fos = new FileOutputStream(temp);
-
-            int read = -1;
-            byte[] buffer = new byte[1024];
-            while ((read = in.read(buffer)) != -1) {
-                fos.write(buffer, 0, read);
-            }
-            fos.close();
-            in.close();
-
-            try {
-                System.load(temp.getAbsolutePath());
-            } catch (Throwable t) {
-                System.err.println("Unable to System.load " + temp.getName() + " : " + t.getMessage());
-                t.printStackTrace();
-                return false;
-            }
-
-            System.out.println("Successfully loaded shared object " + temp.getName());
+            RuntimeLoader.loadLibrary(libraryName);
         }
-
-        return true;
+        isWorking = true;
+        return isWorking;
     }
 }

--- a/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
+++ b/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
@@ -29,7 +29,8 @@ public class PhotonTargetingJniLoader {
     public static boolean isWorking = false;
 
     public static boolean load() throws IOException, UnsatisfiedLinkError {
-        if (isWorking) return true;
+        if (isWorking)
+            return true;
         isWorking = load_();
         return isWorking;
     }
@@ -43,7 +44,7 @@ public class PhotonTargetingJniLoader {
         for (var libraryName : List.of("photontargeting", "photontargetingJNI")) {
             try {
                 RuntimeLoader.loadLibrary(libraryName);
-                return true;
+                continue;
             } catch (Exception e) {
                 System.out.println("Direct library load failed; falling back to extraction");
             }

--- a/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
+++ b/photon-targeting/src/main/java/org/photonvision/jni/PhotonTargetingJniLoader.java
@@ -17,19 +17,73 @@
 
 package org.photonvision.jni;
 
+import edu.wpi.first.util.RuntimeDetector;
 import edu.wpi.first.util.RuntimeLoader;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
+import org.photonvision.common.hardware.Platform;
 
 public class PhotonTargetingJniLoader {
     public static boolean isWorking = false;
 
     public static boolean load() throws IOException, UnsatisfiedLinkError {
-        if (isWorking) return true;
-        for (var libraryName : List.of("photontargeting", "photontargetingJNI")) {
-            RuntimeLoader.loadLibrary(libraryName);
-        }
-        isWorking = true;
+        if (isWorking)
+            return true;
+        isWorking = load_();
         return isWorking;
+    }
+
+    public static boolean load_() throws IOException, UnsatisfiedLinkError {
+        // We always extract the shared object (we could hash each so, but that's a lot
+        // of work)
+        String arch_name = Platform.getNativeLibraryFolderName();
+        var clazz = PhotonTargetingJniLoader.class;
+
+        for (var libraryName : List.of("photontargeting", "photontargetingJNI")) {
+            try {
+                RuntimeLoader.loadLibrary(libraryName);
+            } catch (Exception e) {
+                System.out.println("Direct library load failed; falling back to extraction");
+            }
+
+            var nativeLibName = System.mapLibraryName(libraryName);
+            var path = "/nativelibraries/" + arch_name + "/" + nativeLibName;
+            var in = clazz.getResourceAsStream(path);
+
+            if (in == null) {
+                System.err.println("Could not get resource at path " + path);
+                return false;
+            }
+
+            // It's important that we don't mangle the names of these files on Windows at
+            // least
+            var tempfolder = Files.createTempDirectory("nativeextract");
+            File temp = new File(tempfolder.toAbsolutePath().toString(), nativeLibName);
+            System.out.println(temp.getAbsolutePath().toString());
+            FileOutputStream fos = new FileOutputStream(temp);
+
+            int read = -1;
+            byte[] buffer = new byte[1024];
+            while ((read = in.read(buffer)) != -1) {
+                fos.write(buffer, 0, read);
+            }
+            fos.close();
+            in.close();
+
+            try {
+                System.load(temp.getAbsolutePath());
+            } catch (Throwable t) {
+                System.err.println("Unable to System.load " + temp.getName() + " : " + t.getMessage());
+                t.printStackTrace();
+                return false;
+            }
+
+            System.out.println("Successfully loaded shared object " + temp.getName());
+        }
+
+        return true;
     }
 }

--- a/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
+++ b/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
@@ -35,10 +35,11 @@ import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.subsystems.drivetrain.SwerveDrive;
 import org.photonvision.PhotonCamera;
+import org.photonvision.timesync.TimeSyncSingleton;
 
 public class Robot extends TimedRobot {
     private SwerveDrive drivetrain;
-    private VisionSim visionSim;
+    // private VisionSim visionSim;
     private PhotonCamera camera;
 
     private final double VISION_TURN_kP = 0.01;
@@ -50,7 +51,10 @@ public class Robot extends TimedRobot {
         drivetrain = new SwerveDrive();
         camera = new PhotonCamera(kCameraName);
 
-        visionSim = new VisionSim(camera);
+        if (!TimeSyncSingleton.load()) {
+            System.exit(-111);
+        }
+        // visionSim = new VisionSim(camera);
 
         controller = new XboxController(0);
     }
@@ -122,11 +126,11 @@ public class Robot extends TimedRobot {
         drivetrain.simulationPeriodic();
 
         // Update camera simulation
-        visionSim.simulationPeriodic(drivetrain.getSimPose());
+        // visionSim.simulationPeriodic(drivetrain.getSimPose());
 
-        var debugField = visionSim.getSimDebugField();
-        debugField.getObject("EstimatedRobot").setPose(drivetrain.getPose());
-        debugField.getObject("EstimatedRobotModules").setPoses(drivetrain.getModulePoses());
+        // var debugField = visionSim.getSimDebugField();
+        // debugField.getObject("EstimatedRobot").setPose(drivetrain.getPose());
+        // debugField.getObject("EstimatedRobotModules").setPoses(drivetrain.getModulePoses());
 
         // Calculate battery voltage sag due to current draw
         RoboRioSim.setVInVoltage(
@@ -139,6 +143,6 @@ public class Robot extends TimedRobot {
         // The first pose in an autonomous path is often a good choice.
         var startPose = new Pose2d(1, 1, new Rotation2d());
         drivetrain.resetPose(startPose, true);
-        visionSim.resetSimPose(startPose);
+        // visionSim.resetSimPose(startPose);
     }
 }

--- a/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
+++ b/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
@@ -35,7 +35,6 @@ import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.subsystems.drivetrain.SwerveDrive;
 import org.photonvision.PhotonCamera;
-import org.photonvision.timesync.TimeSyncSingleton;
 
 public class Robot extends TimedRobot {
     private SwerveDrive drivetrain;
@@ -51,9 +50,6 @@ public class Robot extends TimedRobot {
         drivetrain = new SwerveDrive();
         camera = new PhotonCamera(kCameraName);
 
-        if (!TimeSyncSingleton.load()) {
-            System.exit(-111);
-        }
         visionSim = new VisionSim(camera);
 
         controller = new XboxController(0);

--- a/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
+++ b/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
@@ -39,7 +39,7 @@ import org.photonvision.timesync.TimeSyncSingleton;
 
 public class Robot extends TimedRobot {
     private SwerveDrive drivetrain;
-    // private VisionSim visionSim;
+    private VisionSim visionSim;
     private PhotonCamera camera;
 
     private final double VISION_TURN_kP = 0.01;
@@ -54,7 +54,7 @@ public class Robot extends TimedRobot {
         if (!TimeSyncSingleton.load()) {
             System.exit(-111);
         }
-        // visionSim = new VisionSim(camera);
+        visionSim = new VisionSim(camera);
 
         controller = new XboxController(0);
     }
@@ -126,11 +126,11 @@ public class Robot extends TimedRobot {
         drivetrain.simulationPeriodic();
 
         // Update camera simulation
-        // visionSim.simulationPeriodic(drivetrain.getSimPose());
+        visionSim.simulationPeriodic(drivetrain.getSimPose());
 
-        // var debugField = visionSim.getSimDebugField();
-        // debugField.getObject("EstimatedRobot").setPose(drivetrain.getPose());
-        // debugField.getObject("EstimatedRobotModules").setPoses(drivetrain.getModulePoses());
+        var debugField = visionSim.getSimDebugField();
+        debugField.getObject("EstimatedRobot").setPose(drivetrain.getPose());
+        debugField.getObject("EstimatedRobotModules").setPoses(drivetrain.getModulePoses());
 
         // Calculate battery voltage sag due to current draw
         RoboRioSim.setVInVoltage(
@@ -143,6 +143,6 @@ public class Robot extends TimedRobot {
         // The first pose in an autonomous path is often a good choice.
         var startPose = new Pose2d(1, 1, new Rotation2d());
         drivetrain.resetPose(startPose, true);
-        // visionSim.resetSimPose(startPose);
+        visionSim.resetSimPose(startPose);
     }
 }

--- a/photonlib-java-examples/aimattarget/src/test/java/frc/robot/JniLoadTest.java
+++ b/photonlib-java-examples/aimattarget/src/test/java/frc/robot/JniLoadTest.java
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) PhotonVision
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package frc.robot;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.photonvision.timesync.TimeSyncSingleton;
+
+public class JniLoadTest {
+    @Test
+    public void smoketest() {
+        if (!TimeSyncSingleton.load()) {
+            fail("Could not load TimeSync JNI????????");
+        }
+    }
+}

--- a/shared/javacpp/publish.gradle
+++ b/shared/javacpp/publish.gradle
@@ -75,7 +75,10 @@ addTaskToCopyAllOutputs(cppHeadersZip)
 
 model {
     publishing {
-        def cppTaskList = createComponentZipTasks($.components, [nativeName, "${nativeName}JNI"], zipBaseName, Zip, project, includeStandardZipFormat)
+        def cppTaskList = createComponentZipTasks($.components, [
+            nativeName,
+            "${nativeName}JNI"
+        ], zipBaseName, Zip, project, includeStandardZipFormat)
 
         // From https://github.com/wpilibsuite/allwpilib/blob/1c220ebc607daa8da7d983b8f17bc40323633cb2/shared/jni/publish.gradle#L80C9-L100C11
         def jniTaskList = createComponentZipTasks($.components, ["${nativeName}JNI"], jniBaseName, Jar, project, { task, value ->

--- a/shared/javacpp/publish.gradle
+++ b/shared/javacpp/publish.gradle
@@ -76,29 +76,7 @@ addTaskToCopyAllOutputs(cppHeadersZip)
 model {
     publishing {
         def cppTaskList = createComponentZipTasks($.components, [nativeName], zipBaseName, Zip, project, includeStandardZipFormat)
-
-        // From https://github.com/wpilibsuite/allwpilib/blob/1c220ebc607daa8da7d983b8f17bc40323633cb2/shared/jni/publish.gradle#L80C9-L100C11
-        def jniTaskList = createComponentZipTasks($.components, ["${nativeName}JNI"], jniBaseName, Jar, project, { task, value ->
-            value.each { binary ->
-                if (binary.buildable) {
-                    if (binary instanceof SharedLibraryBinarySpec) {
-                        task.dependsOn binary.tasks.link
-                        def hashFile = new File(binary.sharedLibraryFile.parentFile.absolutePath, "${binary.component.baseName}.hash")
-                        task.outputs.file(hashFile)
-                        task.inputs.file(binary.sharedLibraryFile)
-                        task.from(hashFile) {
-                            into nativeUtils.getPlatformPath(binary)
-                        }
-                        task.doFirst {
-                            hashFile.text = MessageDigest.getInstance("MD5").digest(binary.sharedLibraryFile.bytes).encodeHex().toString()
-                        }
-                        task.from(binary.sharedLibraryFile) {
-                            into nativeUtils.getPlatformPath(binary)
-                        }
-                    }
-                }
-            }
-        })
+        def jniTaskList = createComponentZipTasks($.components, ["${nativeName}JNI"], jniBaseName, Zip, project, includeStandardZipFormat)
 
         publications {
             cpp(MavenPublication) {

--- a/shared/javacpp/publish.gradle
+++ b/shared/javacpp/publish.gradle
@@ -75,8 +75,30 @@ addTaskToCopyAllOutputs(cppHeadersZip)
 
 model {
     publishing {
-        def cppTaskList = createComponentZipTasks($.components, [nativeName], zipBaseName, Zip, project, includeStandardZipFormat)
-        def jniTaskList = createComponentZipTasks($.components, ["${nativeName}JNI"], jniBaseName, Zip, project, includeStandardZipFormat)
+        def cppTaskList = createComponentZipTasks($.components, [nativeName, "${nativeName}JNI"], zipBaseName, Zip, project, includeStandardZipFormat)
+
+        // From https://github.com/wpilibsuite/allwpilib/blob/1c220ebc607daa8da7d983b8f17bc40323633cb2/shared/jni/publish.gradle#L80C9-L100C11
+        def jniTaskList = createComponentZipTasks($.components, ["${nativeName}JNI"], jniBaseName, Jar, project, { task, value ->
+            value.each { binary ->
+                if (binary.buildable) {
+                    if (binary instanceof SharedLibraryBinarySpec) {
+                        task.dependsOn binary.tasks.link
+                        def hashFile = new File(binary.sharedLibraryFile.parentFile.absolutePath, "${binary.component.baseName}.hash")
+                        task.outputs.file(hashFile)
+                        task.inputs.file(binary.sharedLibraryFile)
+                        task.from(hashFile) {
+                            into nativeUtils.getPlatformPath(binary)
+                        }
+                        task.doFirst {
+                            hashFile.text = MessageDigest.getInstance("MD5").digest(binary.sharedLibraryFile.bytes).encodeHex().toString()
+                        }
+                        task.from(binary.sharedLibraryFile) {
+                            into nativeUtils.getPlatformPath(binary)
+                        }
+                    }
+                }
+            }
+        })
 
         publications {
             cpp(MavenPublication) {


### PR DESCRIPTION
This is still a hack, but it should work better than the old one.

For simulation:
- Now successfully passes smoketest for me!
![image](https://github.com/user-attachments/assets/0ff9b402-0e88-43ba-ba98-cc1bc45331f9)

For RoboRIO:
- photontargeting-java ships the linux .so's, because ~reasons~
- Since photontargeting-jni is a JNI dependency in our vendor JSON, it will be extracted and deployed to the roborio as part of the deploy process to a directory on the java library search path (?)
  - Which we then have RuntimeLoader System.load for us as part of `PhotonTargetingJniLoader`