### PR TITLE
Update libcamera version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
     openCVversion = "4.8.0-4"
     joglVersion = "2.4.0"
     javalinVersion = "5.6.2"
-    libcameraDriverVersion = "dev-v2023.1.0-14-g787ab59"
+    libcameraDriverVersion = "dev-v2023.1.0-15-gc8988b3"
     rknnVersion = "dev-v2024.0.1-4-g0db16ac"
     frcYear = "2025"
     mrcalVersion = "dev-v2024.0.0-24-gc1efcf0";


### PR DESCRIPTION
This uses the version of libcamera-gl-driver that was built using our image. This verifies that the version of libcamera used in libcamera-gl-driver is the same as the image we provide. This assumes the correct update path of the pi image version to libcamera to photonvision.