### PR TITLE
stop getting full stack trace on test failure

### DIFF
--- a/photon-lib/py/buildAndTest.sh
+++ b/photon-lib/py/buildAndTest.sh
@@ -11,4 +11,4 @@ for f in dist/*.whl; do
 done
 
 # Run the test suite
-pytest -rP --full-trace
+pytest -rP


### PR DESCRIPTION
Signal/noise ratio is too low with this enabled. When dealing with #1567 I got ~46000 lines of errors going around in a circle rather than just an import failure at the scope of each failed test