### PR TITLE
Fix roborio duplicate .so's on deploy

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/TimeSyncManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/TimeSyncManager.java
@@ -128,9 +128,10 @@ public class TimeSyncManager {
         if (m_client != null) {
             var conns = ntInstance.getConnections();
 
-            if (conns.length > 0) {
-                logger.debug("Changing TimeSyncClient server to " + conns[0].remote_ip);
-                m_client.setServer(conns[0].remote_ip);
+            var newServer = conns[0].remote_ip;
+            if (conns.length > 0 && !m_client.getServer().equals(newServer)) {
+                logger.debug("Changing TimeSyncClient server to " + newServer);
+                m_client.setServer(newServer);
             }
 
             if (m_client != null) {

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/TimeSyncManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/TimeSyncManager.java
@@ -128,10 +128,12 @@ public class TimeSyncManager {
         if (m_client != null) {
             var conns = ntInstance.getConnections();
 
-            var newServer = conns[0].remote_ip;
-            if (conns.length > 0 && !m_client.getServer().equals(newServer)) {
-                logger.debug("Changing TimeSyncClient server to " + newServer);
-                m_client.setServer(newServer);
+            if (conns.length > 0) {
+                var newServer = conns[0].remote_ip;
+                if (!m_client.getServer().equals(newServer)) {
+                    logger.debug("Changing TimeSyncClient server to " + newServer);
+                    m_client.setServer(newServer);
+                }
             }
 
             if (m_client != null) {

--- a/photon-targeting/build.gradle
+++ b/photon-targeting/build.gradle
@@ -106,8 +106,6 @@ model {
                 }
 
                 if (binary.targetPlatform.name == platName) {
-
-
                     // only include release binaries (hard coded for now)
                     def isDebug = binary.buildType.name.contains('debug')
                     if (!isDebug) {
@@ -190,6 +188,27 @@ model {
 }
 
 apply from: "${rootDir}/shared/javacpp/publish.gradle"
+
+// quickly hack our raw jar into publishing
+def rawjavaJar = tasks.register("rawjavaJar", Jar) {
+    dependsOn classes
+    includeEmptyDirs = false
+    from sourceSets.main.output
+    archiveClassifier = 'raw'
+}
+
+publishing {
+    publications {
+        rawjava(MavenPublication) {
+            artifact (rawjavaJar) {
+                classifier = null
+            }
+            artifactId = "${nativeName}-rawjava"
+            groupId artifactGroupId
+            version pubVersion
+        }
+    }
+}
 
 // Add photon serde headers to our published sources
 cppHeadersZip {

--- a/photon-targeting/src/main/java/org/photonvision/jni/TimeSyncClient.java
+++ b/photon-targeting/src/main/java/org/photonvision/jni/TimeSyncClient.java
@@ -104,7 +104,7 @@ public class TimeSyncClient {
 
     public void stop() {
         synchronized (mutex) {
-            if (handle > 0) {
+            if (handle != 0) {
                 TimeSyncClient.stop(handle);
                 handle = 0;
             }
@@ -119,7 +119,7 @@ public class TimeSyncClient {
      */
     public long getOffset() {
         synchronized (mutex) {
-            if (handle > 0) {
+            if (handle != 0) {
                 return TimeSyncClient.getOffset(handle);
             }
 
@@ -139,7 +139,7 @@ public class TimeSyncClient {
 
     public PingMetadata getPingMetadata() {
         synchronized (mutex) {
-            if (handle > 0) {
+            if (handle != 0) {
                 return TimeSyncClient.getLatestMetadata(handle);
             }
 

--- a/photon-targeting/src/main/java/org/photonvision/jni/TimeSyncServer.java
+++ b/photon-targeting/src/main/java/org/photonvision/jni/TimeSyncServer.java
@@ -27,7 +27,7 @@ public class TimeSyncServer {
 
     public void start() {
         synchronized (mutex) {
-            if (handle > 0) {
+            if (handle != 0) {
                 TimeSyncServer.start(handle);
             } else {
                 System.err.println("TimeSyncServer: use after free?");
@@ -36,7 +36,7 @@ public class TimeSyncServer {
     }
 
     public void stop() {
-        if (handle > 0) {
+        if (handle != 0) {
             TimeSyncServer.stop(handle);
             handle = 0;
         }

--- a/photon-targeting/src/main/native/cpp/net/TimeSyncClient.cpp
+++ b/photon-targeting/src/main/native/cpp/net/TimeSyncClient.cpp
@@ -17,7 +17,6 @@
 
 #include "net/TimeSyncClient.h"
 
-#include <fmt/core.h>
 #include <wpinet/UDPClient.h>
 #include <wpinet/uv/util.h>
 
@@ -32,6 +31,7 @@
 
 #include <Eigen/Core>
 #include <wpi/Logger.h>
+#include <wpi/print.h>
 #include <wpi/struct/Struct.h>
 
 #include "ntcore_cpp.h"
@@ -58,7 +58,7 @@ static void ClientLoggerFunc(unsigned int level, const char* file,
 }
 
 void wpi::tsp::TimeSyncClient::Tick() {
-  // fmt::println("wpi::tsp::TimeSyncClient::Tick");
+  // wpi::println("wpi::tsp::TimeSyncClient::Tick");
   // Regardless of if we've gotten a pong back yet, we'll ping again. this is
   // pretty naive but should be "fine" for now?
 
@@ -101,15 +101,15 @@ void wpi::tsp::TimeSyncClient::UdpCallback(uv::Buffer& buf, size_t nbytes,
       wpi::UnpackStruct<TspPong>(buf.bytes()),
   };
 
-  // fmt::println("->[client] Got pong: {} {} {} {}", pong.version,
+  // wpi::println("->[client] Got pong: {} {} {} {}", pong.version,
   //              pong.message_id, pong.client_time, pong.server_time);
 
   if (pong.version != 1) {
-    fmt::println("Bad version from server?");
+    wpi::println("Bad version from server?");
     return;
   }
   if (pong.message_id != 2) {
-    fmt::println("Bad message id from server?");
+    wpi::println("Bad message id from server?");
     return;
   }
 
@@ -131,7 +131,7 @@ void wpi::tsp::TimeSyncClient::UdpCallback(uv::Buffer& buf, size_t nbytes,
 
   auto filtered = m_lastOffsets.Calculate(serverTimeOffsetUs);
 
-  // fmt::println("Ping-ponged! RTT2 {} uS, offset {}/filtered offset {} uS",
+  // wpi::println("Ping-ponged! RTT2 {} uS, offset {}/filtered offset {} uS",
   // rtt2,
   //              serverTimeOffsetUs, filtered);
 
@@ -144,9 +144,9 @@ void wpi::tsp::TimeSyncClient::UdpCallback(uv::Buffer& buf, size_t nbytes,
   }
 
   using std::cout;
-  // fmt::println("Ping-ponged! RTT2 {} uS, offset {} uS", rtt2,
+  // wpi::println("Ping-ponged! RTT2 {} uS, offset {} uS", rtt2,
   //              serverTimeOffsetUs);
-  // fmt::println("Estimated server time {} s",
+  // wpi::println("Estimated server time {} s",
   //              (m_timeProvider() + serverTimeOffsetUs) / 1000000.0);
 }
 
@@ -161,12 +161,12 @@ wpi::tsp::TimeSyncClient::TimeSyncClient(std::string_view server,
       m_serverIP{server},
       m_serverPort{remote_port},
       m_loopDelay(ping_delay) {
-  // fmt::println("Starting client (with server address {}:{})", server,
+  // wpi::println("Starting client (with server address {}:{})", server,
   //              remote_port);
 }
 
 void wpi::tsp::TimeSyncClient::Start() {
-  // fmt::println("Connecting received");
+  // wpi::println("Connecting received");
 
   m_loopRunner.ExecSync([this](uv::Loop&) {
     struct sockaddr_in serverAddr;
@@ -180,7 +180,7 @@ void wpi::tsp::TimeSyncClient::Start() {
     m_udp->StartRecv();
   });
 
-  // fmt::println("Starting pinger");
+  // wpi::println("Starting pinger");
   using namespace std::chrono_literals;
   m_pingTimer->timeout.connect(&wpi::tsp::TimeSyncClient::Tick, this);
 

--- a/photon-targeting/src/main/native/cpp/net/TimeSyncServer.cpp
+++ b/photon-targeting/src/main/native/cpp/net/TimeSyncServer.cpp
@@ -17,7 +17,6 @@
 
 #include "net/TimeSyncServer.h"
 
-#include <fmt/core.h>
 #include <wpinet/UDPClient.h>
 #include <wpinet/uv/util.h>
 
@@ -31,6 +30,7 @@
 #include <thread>
 
 #include <wpi/Logger.h>
+#include <wpi/print.h>
 #include <wpi/struct/Struct.h>
 
 #include "ntcore_cpp.h"
@@ -59,7 +59,7 @@ static void ServerLoggerFunc(unsigned int level, const char* file,
 void wpi::tsp::TimeSyncServer::UdpCallback(uv::Buffer& data, size_t n,
                                            const sockaddr& sender,
                                            unsigned flags) {
-  // fmt::println("TimeSyncServer got ping!");
+  // wpi::println("TimeSyncServer got ping!");
 
   TspPing ping{wpi::UnpackStruct<TspPing>(data.bytes())};
 
@@ -85,7 +85,7 @@ void wpi::tsp::TimeSyncServer::UdpCallback(uv::Buffer& data, size_t n,
   wpi::uv::Buffer pongBuf{pongData};
   int sent =
       m_udp->TrySend(sender, wpi::SmallVector<wpi::uv::Buffer, 1>{pongBuf});
-  // fmt::println("Pong ret: {}", sent);
+  // wpi::println("Pong ret: {}", sent);
   if (static_cast<size_t>(sent) != wpi::Struct<TspPong>::GetSize()) {
     WPI_ERROR(m_logger, "Didn't send the whole pong back?");
     return;

--- a/photon-targeting/src/main/native/include/net/TimeSyncClient.h
+++ b/photon-targeting/src/main/native/include/net/TimeSyncClient.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <wpinet/EventLoopRunner.h>
 #include <wpinet/UDPClient.h>
 #include <wpinet/uv/Buffer.h>
@@ -38,6 +37,7 @@
 
 #include <frc/filter/MedianFilter.h>
 #include <wpi/Logger.h>
+#include <wpi/print.h>
 #include <wpi/static_circular_buffer.h>
 #include <wpi/struct/Struct.h>
 

--- a/photon-targeting/src/main/native/include/net/TimeSyncServer.h
+++ b/photon-targeting/src/main/native/include/net/TimeSyncServer.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <wpinet/EventLoopRunner.h>
 #include <wpinet/UDPClient.h>
 #include <wpinet/uv/Buffer.h>
@@ -37,6 +36,7 @@
 #include <thread>
 
 #include <wpi/Logger.h>
+#include <wpi/print.h>
 #include <wpi/struct/Struct.h>
 
 #include "TimeSyncStructs.h"

--- a/photon-targeting/src/main/native/jni/FileLoggerExtrasJNI.cpp
+++ b/photon-targeting/src/main/native/jni/FileLoggerExtrasJNI.cpp
@@ -35,12 +35,12 @@ struct QueuedFileLogger {
   explicit QueuedFileLogger(std::string_view file)
       : logger{file, std::bind(&QueuedFileLogger::callback, this,
                                std::placeholders::_1)} {
-    // fmt::println("Watching {}", file);
+    // wpi::println("Watching {}", file);
   }
 
   void callback(std::string_view newline) {
     std::lock_guard lock{m_mutex};
-    // fmt::println("FileLogger got: {}", newline);
+    // wpi::println("FileLogger got: {}", newline);
     m_data.insert(m_data.end(), newline.begin(), newline.end());
   }
 

--- a/photon-targeting/src/main/native/jni/jni_utils.h
+++ b/photon-targeting/src/main/native/jni/jni_utils.h
@@ -17,13 +17,15 @@
 
 #pragma once
 
+#include <wpi/print.h>
+
 #define CHECK_PTR(ptr)                                               \
   if (!ptr) {                                                        \
-    fmt::println("Got invalid pointer?? {}:{}", __FILE__, __LINE__); \
+    wpi::println("Got invalid pointer?? {}:{}", __FILE__, __LINE__); \
     return;                                                          \
   }
 #define CHECK_PTR_RETURN(ptr, default)                               \
   if (!ptr) {                                                        \
-    fmt::println("Got invalid pointer?? {}:{}", __FILE__, __LINE__); \
+    wpi::println("Got invalid pointer?? {}:{}", __FILE__, __LINE__); \
     return default;                                                  \
   }

--- a/photon-targeting/src/test/native/cpp/PacketTest.cpp
+++ b/photon-targeting/src/test/native/cpp/PacketTest.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <units/angle.h>
+#include <wpi/print.h>
 
 #include "gtest/gtest.h"
 #include "photon/dataflow/structures/Packet.h"
@@ -141,7 +142,7 @@ TEST(PacketTest, PhotonPipelineResult) {
   auto t3 = std::chrono::steady_clock::now();
   EXPECT_EQ(result2, b2);
 
-  fmt::println(
+  wpi::println(
       "Pack {} unpack {} packet length {}",
       std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count(),
       std::chrono::duration_cast<std::chrono::nanoseconds>(t3 - t2).count(),

--- a/photon-targeting/src/test/native/cpp/net/TimeSyncTest.cpp
+++ b/photon-targeting/src/test/native/cpp/net/TimeSyncTest.cpp
@@ -33,7 +33,7 @@ TEST(TimeSyncProtocolTest, Smoketest) {
   for (int i = 0; i < 10; i++) {
     std::this_thread::sleep_for(100ms);
     TimeSyncClient::Metadata m = client.GetMetadata();
-    fmt::println("Offset={} rtt={}", m.offset, m.rtt2);
+    wpi::println("Offset={} rtt={}", m.offset, m.rtt2);
   }
 
   server.Stop();

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -12,7 +12,7 @@ nativeUtils.wpi.configureDependencies {
     opencvVersion = openCVversion
     googleTestYear = "frc2024"
     googleTestVersion = "1.14.0-1"
-    niLibVersion = "2024.2.1"
+    niLibVersion = "2025.0.0"
 }
 
 // Configure warnings and errors


### PR DESCRIPTION
TLDR on the current problem:
photontargeting-java includes .so's
But we deploy them to the robot via jniDependencies: photontargeting-cpp
So we need to strip them from the JAR we ship to the robot

Also fixes niLibVersion.

Tested on Chris's rio! Java:
![image](https://github.com/user-attachments/assets/c7eb0f24-472d-4730-bd07-eeeb75e1d6f4)
C++: 
![image](https://github.com/user-attachments/assets/a669a2c7-644b-4c01-bfb3-832e6a1f709c)

