### PR TITLE
Explain how to install older version of PhotonVision on Romi

### DIFF
--- a/docs/source/docs/advanced-installation/sw_install/romi.md
+++ b/docs/source/docs/advanced-installation/sw_install/romi.md
@@ -11,7 +11,7 @@ SSH into the Raspberry Pi (using Windows command line, or a tool like [Putty](ht
 :::.. The following paragraph can be restored when WPILibPi becomes compatible with the current version of PhotonVision. 
 :::.. Follow the process for installing PhotonVision on {ref}`"Other Debian-Based Co-Processor Installation" <docs/advanced-installation/sw_install/other-coprocessors:Other Debian-Based Co-Processor Installation>`. As it mentions, this will require an internet connection so connecting the Raspberry Pi to an internet-connected router via an Ethernet cable will be the easiest solution. The pi must remain writable while you are following these steps! 
 
-:::..Temporary instructions explaiining how to install the older version of PhotonVision on a Romi. Remove when no longer needed.
+:::..Temporary instructions explaining how to install the older version of PhotonVision on a Romi. Remove when no longer needed.
 :::{attention}
 The version of WPILibPi for the Romi is 2023.2.1, which is not compatible with the current version of PhotonVision. **If you are using WPILibPi 2023.2.1 on your Romi, you must install PhotonVision v2023.4.2 or earlier!**
 

--- a/docs/source/docs/advanced-installation/sw_install/romi.md
+++ b/docs/source/docs/advanced-installation/sw_install/romi.md
@@ -8,7 +8,7 @@ The WPILibPi image includes FRCVision, which reserves USB cameras; to use Photon
 
 SSH into the Raspberry Pi (using Windows command line, or a tool like [Putty](https://www.chiark.greenend.org.uk/~sgtatham/putty/) ) at the Romi's default address `10.0.0.2`. The default user is `pi`, and the password is `raspberry`.
 
-:::.. The following paragraph can be restored when (if) WPILibPi is becomes compatible with the current version of PhotonVision. 
+:::.. The following paragraph can be restored when WPILibPi is becomes compatible with the current version of PhotonVision. 
 :::.. Follow the process for installing PhotonVision on {ref}`"Other Debian-Based Co-Processor Installation" <docs/advanced-installation/sw_install/other-coprocessors:Other Debian-Based Co-Processor Installation>`. As it mentions, this will require an internet connection so connecting the Raspberry Pi to an internet-connected router via an Ethernet cable will be the easiest solution. The pi must remain writable while you are following these steps! 
 
 :::..Temporary instructions explaiining how to install the older version of PhotonVision on a Romi. Remove when no longer needed.
@@ -34,6 +34,9 @@ Next, from the SSH terminal, run `sudo nano /home/pi/runCamera` then arrow down 
 
 After the Romi reboots, you should be able to open the PhotonVision UI at: [`http://10.0.0.2:5800/`](http://10.0.0.2:5800/). From here, you can adjust {ref}`Settings <docs/settings:Settings>` and configure {ref}`Pipelines <docs/pipelines/index:Pipelines>`.
 
+:::{attention}
+When using an older version of PhotonVision, the user interface and features may be different than what appears in the online documentation. The [Documentation](http://10.0.0.2:5800/#/docs) link in the User Interface will open a bundled version of the documentation that matches the PhotonVision version running on your coprocessor.
+:::
 
 :::{warning}
 In order for settings, logs, etc. to be saved / take effect, ensure that PhotonVision is in writable mode.

--- a/docs/source/docs/advanced-installation/sw_install/romi.md
+++ b/docs/source/docs/advanced-installation/sw_install/romi.md
@@ -8,7 +8,7 @@ The WPILibPi image includes FRCVision, which reserves USB cameras; to use Photon
 
 SSH into the Raspberry Pi (using Windows command line, or a tool like [Putty](https://www.chiark.greenend.org.uk/~sgtatham/putty/) ) at the Romi's default address `10.0.0.2`. The default user is `pi`, and the password is `raspberry`.
 
-:::.. The following paragraph can be restored when WPILibPi is becomes compatible with the current version of PhotonVision. 
+:::.. The following paragraph can be restored when WPILibPi becomes compatible with the current version of PhotonVision. 
 :::.. Follow the process for installing PhotonVision on {ref}`"Other Debian-Based Co-Processor Installation" <docs/advanced-installation/sw_install/other-coprocessors:Other Debian-Based Co-Processor Installation>`. As it mentions, this will require an internet connection so connecting the Raspberry Pi to an internet-connected router via an Ethernet cable will be the easiest solution. The pi must remain writable while you are following these steps! 
 
 :::..Temporary instructions explaiining how to install the older version of PhotonVision on a Romi. Remove when no longer needed.

--- a/docs/source/docs/advanced-installation/sw_install/romi.md
+++ b/docs/source/docs/advanced-installation/sw_install/romi.md
@@ -8,15 +8,32 @@ The WPILibPi image includes FRCVision, which reserves USB cameras; to use Photon
 
 SSH into the Raspberry Pi (using Windows command line, or a tool like [Putty](https://www.chiark.greenend.org.uk/~sgtatham/putty/) ) at the Romi's default address `10.0.0.2`. The default user is `pi`, and the password is `raspberry`.
 
-Follow the process for installing PhotonVision on {ref}`"Other Debian-Based Co-Processor Installation" <docs/advanced-installation/sw_install/other-coprocessors:Other Debian-Based Co-Processor Installation>`. As it mentions this will require an internet connection so plugging into the ethernet jack on the Raspberry Pi will be the easiest solution. The pi must remain writable!
+:::.. The following paragraph can be restored when (if) WPILibPi is becomes compatible with the current version of PhotonVision. 
+:::.. Follow the process for installing PhotonVision on {ref}`"Other Debian-Based Co-Processor Installation" <docs/advanced-installation/sw_install/other-coprocessors:Other Debian-Based Co-Processor Installation>`. As it mentions, this will require an internet connection so connecting the Raspberry Pi to an internet-connected router via an Ethernet cable will be the easiest solution. The pi must remain writable while you are following these steps! 
 
-Next, from the SSH terminal, run `sudo nano /home/pi/runCamera` then arrow down to the start of the exec line and press "Enter" to add a new line. Then add `#` before the exec command to comment it out. Then, arrow up to the new line and type `sleep 10000`. Hit "Ctrl + O" and then "Enter" to save the file. Finally press "Ctrl + X" to exit nano. Now, reboot the Romi by typing `sudo reboot`.
+:::..Temporary instructions explaiining how to install the older version of PhotonVision on a Romi. Remove when no longer needed.
+:::{attention}
+The version of WPILibPi for the Romi is 2023.2.1, which is not compatible with the current version of PhotonVision. **If you are using WPILibPi 2023.2.1 on your Romi, you must install PhotonVision v2023.4.2 or earlier!**
+
+To install a compatible version of PhotonVision, enter these commands in the SSH terminal connected to the Raspberry Pi. This will download and run the install script, which will intall PhotonVision on your Raspberry Pi and configure it to run at startup.
+
+```bash
+$ wget https://git.io/JJrEP -O install.sh
+$ sudo chmod +x install.sh
+$ sudo ./install.sh -v 2023.4.2
+```
+The install script requires an internet connection, so connecting the Raspberry Pi to an internet-connected router via an Ethernet cable will be the easiest solution. The pi must remain writable while you are following these steps!
+:::
+:::..End of temporary instructions.
+
+Next, from the SSH terminal, run `sudo nano /home/pi/runCamera` then arrow down to the start of the exec line and press "Enter" to add a new line. Then add `#` before the exec command to comment it out. Then, arrow up to the new line and type `sleep 10000`. Hit "Ctrl + O" and then "Enter" to save the file. Finally press "Ctrl + X" to exit nano. Now, reboot the Romi by typing `sudo reboot now`.
 
 ```{image} images/nano.png
 
 ```
 
-After it reboots, you should be able to [locate the PhotonVision UI](https://photonvision.github.io/gloworm-docs/docs/quickstart/#finding-gloworm) at: `http://10.0.0.2:5800/`.
+After the Romi reboots, you should be able to open the PhotonVision UI at: [`http://10.0.0.2:5800/`](http://10.0.0.2:5800/). From here, you can adjust {ref}`Settings <docs/settings:Settings>` and configure {ref}`Pipelines <docs/pipelines/index:Pipelines>`.
+
 
 :::{warning}
 In order for settings, logs, etc. to be saved / take effect, ensure that PhotonVision is in writable mode.

--- a/docs/source/docs/advanced-installation/sw_install/romi.md
+++ b/docs/source/docs/advanced-installation/sw_install/romi.md
@@ -8,8 +8,8 @@ The WPILibPi image includes FRCVision, which reserves USB cameras; to use Photon
 
 SSH into the Raspberry Pi (using Windows command line, or a tool like [Putty](https://www.chiark.greenend.org.uk/~sgtatham/putty/) ) at the Romi's default address `10.0.0.2`. The default user is `pi`, and the password is `raspberry`.
 
-:::.. The following paragraph can be restored when WPILibPi becomes compatible with the current version of PhotonVision. 
-:::.. Follow the process for installing PhotonVision on {ref}`"Other Debian-Based Co-Processor Installation" <docs/advanced-installation/sw_install/other-coprocessors:Other Debian-Based Co-Processor Installation>`. As it mentions, this will require an internet connection so connecting the Raspberry Pi to an internet-connected router via an Ethernet cable will be the easiest solution. The pi must remain writable while you are following these steps! 
+:::.. The following paragraph can be restored when WPILibPi becomes compatible with the current version of PhotonVision.
+:::.. Follow the process for installing PhotonVision on {ref}`"Other Debian-Based Co-Processor Installation" <docs/advanced-installation/sw_install/other-coprocessors:Other Debian-Based Co-Processor Installation>`. As it mentions, this will require an internet connection so connecting the Raspberry Pi to an internet-connected router via an Ethernet cable will be the easiest solution. The pi must remain writable while you are following these steps!
 
 :::..Temporary instructions explaining how to install the older version of PhotonVision on a Romi. Remove when no longer needed.
 :::{attention}
@@ -34,10 +34,10 @@ Next, from the SSH terminal, run `sudo nano /home/pi/runCamera` then arrow down 
 
 After the Romi reboots, you should be able to open the PhotonVision UI at: [`http://10.0.0.2:5800/`](http://10.0.0.2:5800/). From here, you can adjust {ref}`Settings <docs/settings:Settings>` and configure {ref}`Pipelines <docs/pipelines/index:Pipelines>`.
 
-:::{attention}
-When using an older version of PhotonVision, the user interface and features may be different than what appears in the online documentation. The [Documentation](http://10.0.0.2:5800/#/docs) link in the User Interface will open a bundled version of the documentation that matches the PhotonVision version running on your coprocessor.
-:::
-
 :::{warning}
 In order for settings, logs, etc. to be saved / take effect, ensure that PhotonVision is in writable mode.
+:::
+
+:::{attention}
+When using an older version of PhotonVision, the user interface and features may be different than what appears in the online documentation. The [Documentation](http://10.0.0.2:5800/#/docs) link in the User Interface will open a bundled version of the documentation that matches the PhotonVision version running on your coprocessor.
 :::


### PR DESCRIPTION
Provide instructions for installing the PhotonVision version that is compatible with WPILibPi 2023.4.2, which is the newest version available for the Romi. 

The older text is hidden in a comment so that it can be restored when there is a newer version of WPILibPi that is compatible with newer versions of PhotonVision.
