### PR TITLE
Fix rate limiting in sphinx link checker

### DIFF
--- a/.github/workflows/photonvision-docs.yml
+++ b/.github/workflows/photonvision-docs.yml
@@ -11,9 +11,10 @@ on:
     paths:
       - 'docs/**'
       - '.github/**'
+
 env:
-  GITHUB_TOKEN: ${{ github.token }}
-  
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/photonvision-docs.yml
+++ b/.github/workflows/photonvision-docs.yml
@@ -11,7 +11,9 @@ on:
     paths:
       - 'docs/**'
       - '.github/**'
-
+env:
+  GITHUB_TOKEN: ${{ github.token }}
+  
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,7 +144,8 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 # These should be periodically checked by hand to ensure that they are still functional
 linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..+"]
 
-print("Github Token: ", os.environ.get("GITHUB_TOKEN", None))
+
+import os
 
 token = os.environ.get("GITHUB_TOKEN", None)
 
@@ -161,7 +162,7 @@ myst_enable_extensions = ["colon_fence"]
 # Add Github Token to all Github API Requests made by any extension anywhere
 
 import http.client
-import os
+
 
 original_send = http.client.HTTPConnection.send
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,9 +145,9 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 # These should be periodically checked by hand to ensure that they are still functional
 linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..+"]
 
-token = os.environ.get("GITHUB_TOKEN", None)
-if token:
-    linkcheck_auth = [(R"https://github.com/.+", token)]
+# token = os.environ.get("GITHUB_TOKEN", None)
+# if token:
+#     linkcheck_auth = [(R"https://github.com/.+", token)]
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -161,39 +161,39 @@ myst_enable_extensions = ["colon_fence"]
 
 # Add Github Token to all Github API Requests made by any extension anywhere
 
-import http.client
+# import http.client
 
 
-original_send = http.client.HTTPConnection.send
+# original_send = http.client.HTTPConnection.send
 
 
-def new_send(self, data):
-    try:
-        headers = dict(
-            (a.lower(), b)
-            for a, b in (
-                header.split(b":", 1) for header in data.strip().split(b"\r\n")[1:]
-            )
-        )
+# def new_send(self, data):
+#     try:
+#         headers = dict(
+#             (a.lower(), b)
+#             for a, b in (
+#                 header.split(b":", 1) for header in data.strip().split(b"\r\n")[1:]
+#             )
+#         )
 
-        new_data = data
-        if b"api.github.com" in headers[b"host"]:
-            if b"authorization" not in headers:
-                if github_token := os.environ.get("GITHUB_TOKEN", None):
-                    new_data = (
-                        new_data[:-2]  # Remove the last CRLF
-                        + b"Authorization: Bearer "
-                        + github_token.encode("ascii")
-                        + b"\r\n\r\n"
-                    )
+#         new_data = data
+#         if b"api.github.com" in headers[b"host"]:
+#             if b"authorization" not in headers:
+#                 if github_token := os.environ.get("GITHUB_TOKEN", None):
+#                     new_data = (
+#                         new_data[:-2]  # Remove the last CRLF
+#                         + b"Authorization: Bearer "
+#                         + github_token.encode("ascii")
+#                         + b"\r\n\r\n"
+#                     )
 
-        original_send(self, new_data)
-    except Exception as e:
-        original_send(self, data)
-        print(
-            f"Intercepting a http(s) request failed. Running original request for header: {data}"
-        )
-        print(f"The exception is: {e}")
+#         original_send(self, new_data)
+#     except Exception as e:
+#         original_send(self, data)
+#         print(
+#             f"Intercepting a http(s) request failed. Running original request for header: {data}"
+#         )
+#         print(f"The exception is: {e}")
 
 
-http.client.HTTPConnection.send = new_send
+# http.client.HTTPConnection.send = new_send

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,9 +145,9 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 # These should be periodically checked by hand to ensure that they are still functional
 linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..+"]
 
-# token = os.environ.get("GITHUB_TOKEN", None)
-# if token:
-#     linkcheck_auth = [(R"https://github.com/.+", token)]
+token = os.environ.get("GITHUB_TOKEN", None)
+if token:
+    linkcheck_auth = [(R"https://github.com/.+", token)]
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -138,9 +138,11 @@ suppress_warnings = ["epub.unknown_project_files"]
 
 sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 
+# -- Options for linkcheck -------------------------------------------------
+
 # Excluded links for linkcheck
 # These should be periodically checked by hand to ensure that they are still functional
-linkcheck_ignore = ["https://www.raspberrypi.com/software/"]
+linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..*"]
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
+
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -144,56 +145,9 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 # These should be periodically checked by hand to ensure that they are still functional
 linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..+"]
 
-
-import os
-
 token = os.environ.get("GITHUB_TOKEN", None)
-
 if token:
-    linkcheck_auth = [
-        (R"https://github.com/.+", token)
-        ]
-else:
-    print("Token not found ******************************************************************************")
+    linkcheck_auth = [(R"https://github.com/.+", token)]
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence"]
-
-# Add Github Token to all Github API Requests made by any extension anywhere
-
-# import http.client
-
-
-# original_send = http.client.HTTPConnection.send
-
-
-# def new_send(self, data):
-#     try:
-#         headers = dict(
-#             (a.lower(), b)
-#             for a, b in (
-#                 header.split(b":", 1) for header in data.strip().split(b"\r\n")[1:]
-#             )
-#         )
-
-#         new_data = data
-#         if b"api.github.com" in headers[b"host"]:
-#             if b"authorization" not in headers:
-#                 if github_token := os.environ.get("GITHUB_TOKEN", None):
-#                     new_data = (
-#                         new_data[:-2]  # Remove the last CRLF
-#                         + b"Authorization: Bearer "
-#                         + github_token.encode("ascii")
-#                         + b"\r\n\r\n"
-#                     )
-
-#         original_send(self, new_data)
-#     except Exception as e:
-#         original_send(self, data)
-#         print(
-#             f"Intercepting a http(s) request failed. Running original request for header: {data}"
-#         )
-#         print(f"The exception is: {e}")
-
-
-# http.client.HTTPConnection.send = new_send

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -142,7 +142,18 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 
 # Excluded links for linkcheck
 # These should be periodically checked by hand to ensure that they are still functional
-linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..*"]
+linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..+"]
+
+print("Github Token: ", os.environ.get("GITHUB_TOKEN", None))
+
+token = os.environ.get("GITHUB_TOKEN", None)
+
+if token:
+    linkcheck_auth = [
+        (R"https://github.com/.+", token)
+        ]
+else:
+    print("Token not found ******************************************************************************")
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,3 +144,42 @@ linkcheck_ignore = ["https://www.raspberrypi.com/software/"]
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence"]
+
+# Add Github Token to all Github API Requests made by any extension anywhere
+
+import http.client
+import os
+
+original_send = http.client.HTTPConnection.send
+
+
+def new_send(self, data):
+    try:
+        headers = dict(
+            (a.lower(), b)
+            for a, b in (
+                header.split(b":", 1) for header in data.strip().split(b"\r\n")[1:]
+            )
+        )
+
+        new_data = data
+        if b"api.github.com" in headers[b"host"]:
+            if b"authorization" not in headers:
+                if github_token := os.environ.get("GITHUB_TOKEN", None):
+                    new_data = (
+                        new_data[:-2]  # Remove the last CRLF
+                        + b"Authorization: Bearer "
+                        + github_token.encode("ascii")
+                        + b"\r\n\r\n"
+                    )
+
+        original_send(self, new_data)
+    except Exception as e:
+        original_send(self, data)
+        print(
+            f"Intercepting a http(s) request failed. Running original request for header: {data}"
+        )
+        print(f"The exception is: {e}")
+
+
+http.client.HTTPConnection.send = new_send


### PR DESCRIPTION
Fixes rate-limit errors in the sphinx linkchecker on GitHub links caused by a missing token.

```
-rate limited-   https://github.com/PhotonVision/photonvision/commits/master/ | sleeping...
-rate limited-   https://github.com/PhotonVision/photonvision/commits/master/ | sleeping...
(docs/advanced-installation/prerelease-software: line    9) broken    https://github.com/PhotonVision/photonvision/commits/master/ - 429 Client Error: Too Many Requests for url: https://github.com/PhotonVision/photonvision/commits/master/
```