### PR TITLE
[Python] remove opencv  dependency for robot installations

### DIFF
--- a/photon-lib/py/setup.py
+++ b/photon-lib/py/setup.py
@@ -63,7 +63,6 @@ setup(
         "robotpy-apriltag<2026,>=2025.0.0b1",
         "robotpy-cscore<2026,>=2025.0.0b1",
         "pyntcore<2026,>=2025.0.0b1",
-        "robotpy-opencv;platform_machine=='roborio'",
         "opencv-python;platform_machine!='roborio'",
     ],
     description=descriptionStr,


### PR DESCRIPTION
We have more dependency problems attached to opencv....

Rio-related installations are broken because some things don't exist. This is not an issue worth solving by fighting the dependency manager. Python is a client library and will only ever have this dependency for simulation things. IE let's never try to install opencv things because we wont actually need them.

@mcm001, we would be super grateful if you could make another release with this being merged. This brings us to a baseline where teams will be able to install the 2025 Python library. I have now tested this myself and am confident that this is the end of installation nightmares for now....