### PR TITLE
Remove time source override

### DIFF
--- a/photon-targeting/src/main/native/cpp/net/TimeSyncClient.cpp
+++ b/photon-targeting/src/main/native/cpp/net/TimeSyncClient.cpp
@@ -152,10 +152,9 @@ void wpi::tsp::TimeSyncClient::UdpCallback(uv::Buffer& buf, size_t nbytes,
 
 wpi::tsp::TimeSyncClient::TimeSyncClient(std::string_view server,
                                          int remote_port,
-                                         std::chrono::milliseconds ping_delay,
-                                         std::function<uint64_t()> timeProvider)
+                                         std::chrono::milliseconds ping_delay)
     : m_logger(::ClientLoggerFunc),
-      m_timeProvider(timeProvider),
+      m_timeProvider(nt::Now),
       m_udp{},
       m_pingTimer{},
       m_serverIP{server},

--- a/photon-targeting/src/main/native/cpp/net/TimeSyncServer.cpp
+++ b/photon-targeting/src/main/native/cpp/net/TimeSyncServer.cpp
@@ -97,10 +97,9 @@ void wpi::tsp::TimeSyncServer::UdpCallback(uv::Buffer& data, size_t n,
   //          pong.client_time, pong.server_time);
 }
 
-wpi::tsp::TimeSyncServer::TimeSyncServer(int port,
-                                         std::function<uint64_t()> timeProvider)
+wpi::tsp::TimeSyncServer::TimeSyncServer(int port)
     : m_logger{::ServerLoggerFunc},
-      m_timeProvider{timeProvider},
+      m_timeProvider{nt::Now},
       m_udp{},
       m_port(port) {}
 

--- a/photon-targeting/src/main/native/include/net/TimeSyncClient.h
+++ b/photon-targeting/src/main/native/include/net/TimeSyncClient.h
@@ -74,11 +74,11 @@ class TimeSyncClient {
 
   std::chrono::milliseconds m_loopDelay;
 
-  std::mutex m_offsetMutex;
-  Metadata m_metadata;
+  std::mutex m_offsetMutex{};
+  Metadata m_metadata{};
 
   // We only allow the most recent ping to stay alive, so only keep track of it
-  TspPing m_lastPing;
+  TspPing m_lastPing{};
 
   // 30s is a reasonable guess
   frc::MedianFilter<int64_t> m_lastOffsets{30};
@@ -90,8 +90,7 @@ class TimeSyncClient {
 
  public:
   TimeSyncClient(std::string_view server, int remote_port,
-                 std::chrono::milliseconds ping_delay,
-                 std::function<uint64_t()> timeProvider = nt::Now);
+                 std::chrono::milliseconds ping_delay);
 
   void Start();
   void Stop();

--- a/photon-targeting/src/main/native/include/net/TimeSyncClient.h
+++ b/photon-targeting/src/main/native/include/net/TimeSyncClient.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <wpinet/EventLoopRunner.h>
 #include <wpinet/UDPClient.h>
 #include <wpinet/uv/Buffer.h>

--- a/photon-targeting/src/main/native/include/net/TimeSyncServer.h
+++ b/photon-targeting/src/main/native/include/net/TimeSyncServer.h
@@ -36,7 +36,6 @@
 #include <thread>
 
 #include <wpi/Logger.h>
-#include <wpi/print.h>
 #include <wpi/struct/Struct.h>
 
 #include "TimeSyncStructs.h"

--- a/photon-targeting/src/main/native/include/net/TimeSyncServer.h
+++ b/photon-targeting/src/main/native/include/net/TimeSyncServer.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <wpinet/EventLoopRunner.h>
 #include <wpinet/UDPClient.h>
 #include <wpinet/uv/Buffer.h>
@@ -37,6 +36,7 @@
 #include <thread>
 
 #include <wpi/Logger.h>
+#include <wpi/print.h>
 #include <wpi/struct/Struct.h>
 
 #include "TimeSyncStructs.h"
@@ -62,8 +62,7 @@ class TimeSyncServer {
                    unsigned flags);
 
  public:
-  explicit TimeSyncServer(int port = 5810,
-                          std::function<uint64_t()> timeProvider = nt::Now);
+  explicit TimeSyncServer(int port = 5810);
 
   /**
    * Start listening for pings


### PR DESCRIPTION
This was part of the API, but nobody needs this handle exposed for now. This also makes wrapping via pybind harder anyways. Remove this useless layer of abstraction.