### PR TITLE
Handle remote UUID mismatch properly

### DIFF
--- a/photon-lib/src/main/native/cpp/photon/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonCamera.cpp
@@ -305,6 +305,7 @@ void PhotonCamera::VerifyVersion() {
       FRC_ReportError(frc::warn::Warning,
                       "Cannot find property message_uuid for PhotonCamera {}",
                       path);
+      return;
     }
     std::string remote_uuid{remote_uuid_json};
 


### PR DESCRIPTION
Check for no response
Only throw if incorrect version, and not when missing

Resolves #1569 