### PR TITLE
Tidy up of python autogenerated messages

### DIFF
--- a/photon-lib/py/photonlibpy/generated/MultiTargetPNPResultSerde.py
+++ b/photon-lib/py/photonlibpy/generated/MultiTargetPNPResultSerde.py
@@ -40,10 +40,10 @@ class MultiTargetPNPResultSerde:
         ret = Packet()
 
         # estimatedPose is of non-intrinsic type PnpResult
-        ret.encodeBytes(PnpResult.photonStruct.pack(value.estimatedPose).getData())
+        ret.encodeBytes(PnpResult.photonStruct.pack(value.estimatedPose).getData())  # fmt: skip
 
         # fiducialIDsUsed is a custom VLA!
-        ret.encodeShortList(value.fiducialIDsUsed)
+        ret.encodeShortList(value.fiducialIDsUsed)  # fmt: skip
         return ret
 
     @staticmethod
@@ -51,10 +51,10 @@ class MultiTargetPNPResultSerde:
         ret = MultiTargetPNPResult()
 
         # estimatedPose is of non-intrinsic type PnpResult
-        ret.estimatedPose = PnpResult.photonStruct.unpack(packet)
+        ret.estimatedPose = PnpResult.photonStruct.unpack(packet)  # fmt: skip
 
         # fiducialIDsUsed is a custom VLA!
-        ret.fiducialIDsUsed = packet.decodeShortList()
+        ret.fiducialIDsUsed = packet.decodeShortList()  # fmt: skip
 
         return ret
 

--- a/photon-lib/py/photonlibpy/generated/PhotonPipelineMetadataSerde.py
+++ b/photon-lib/py/photonlibpy/generated/PhotonPipelineMetadataSerde.py
@@ -39,16 +39,16 @@ class PhotonPipelineMetadataSerde:
         ret = Packet()
 
         # sequenceID is of intrinsic type int64
-        ret.encodeLong(value.sequenceID)
+        ret.encodeLong(value.sequenceID)  # fmt: skip
 
         # captureTimestampMicros is of intrinsic type int64
-        ret.encodeLong(value.captureTimestampMicros)
+        ret.encodeLong(value.captureTimestampMicros)  # fmt: skip
 
         # publishTimestampMicros is of intrinsic type int64
-        ret.encodeLong(value.publishTimestampMicros)
+        ret.encodeLong(value.publishTimestampMicros)  # fmt: skip
 
         # timeSinceLastPong is of intrinsic type int64
-        ret.encodeLong(value.timeSinceLastPong)
+        ret.encodeLong(value.timeSinceLastPong)  # fmt: skip
         return ret
 
     @staticmethod
@@ -56,16 +56,16 @@ class PhotonPipelineMetadataSerde:
         ret = PhotonPipelineMetadata()
 
         # sequenceID is of intrinsic type int64
-        ret.sequenceID = packet.decodeLong()
+        ret.sequenceID = packet.decodeLong()  # fmt: skip
 
         # captureTimestampMicros is of intrinsic type int64
-        ret.captureTimestampMicros = packet.decodeLong()
+        ret.captureTimestampMicros = packet.decodeLong()  # fmt: skip
 
         # publishTimestampMicros is of intrinsic type int64
-        ret.publishTimestampMicros = packet.decodeLong()
+        ret.publishTimestampMicros = packet.decodeLong()  # fmt: skip
 
         # timeSinceLastPong is of intrinsic type int64
-        ret.timeSinceLastPong = packet.decodeLong()
+        ret.timeSinceLastPong = packet.decodeLong()  # fmt: skip
 
         return ret
 

--- a/photon-lib/py/photonlibpy/generated/PhotonPipelineResultSerde.py
+++ b/photon-lib/py/photonlibpy/generated/PhotonPipelineResultSerde.py
@@ -42,15 +42,13 @@ class PhotonPipelineResultSerde:
         ret = Packet()
 
         # metadata is of non-intrinsic type PhotonPipelineMetadata
-        ret.encodeBytes(
-            PhotonPipelineMetadata.photonStruct.pack(value.metadata).getData()
-        )
+        ret.encodeBytes(PhotonPipelineMetadata.photonStruct.pack(value.metadata).getData())  # fmt: skip
 
         # targets is a custom VLA!
-        ret.encodeList(value.targets, PhotonTrackedTarget.photonStruct)
+        ret.encodeList(value.targets, PhotonTrackedTarget.photonStruct)  # fmt: skip
 
         # multitagResult is optional! it better not be a VLA too
-        ret.encodeOptional(value.multitagResult, MultiTargetPNPResult.photonStruct)
+        ret.encodeOptional(value.multitagResult, MultiTargetPNPResult.photonStruct)  # fmt: skip
         return ret
 
     @staticmethod
@@ -58,13 +56,13 @@ class PhotonPipelineResultSerde:
         ret = PhotonPipelineResult()
 
         # metadata is of non-intrinsic type PhotonPipelineMetadata
-        ret.metadata = PhotonPipelineMetadata.photonStruct.unpack(packet)
+        ret.metadata = PhotonPipelineMetadata.photonStruct.unpack(packet)  # fmt: skip
 
         # targets is a custom VLA!
-        ret.targets = packet.decodeList(PhotonTrackedTarget.photonStruct)
+        ret.targets = packet.decodeList(PhotonTrackedTarget.photonStruct)  # fmt: skip
 
         # multitagResult is optional! it better not be a VLA too
-        ret.multitagResult = packet.decodeOptional(MultiTargetPNPResult.photonStruct)
+        ret.multitagResult = packet.decodeOptional(MultiTargetPNPResult.photonStruct)  # fmt: skip
 
         return ret
 

--- a/photon-lib/py/photonlibpy/generated/PhotonTrackedTargetSerde.py
+++ b/photon-lib/py/photonlibpy/generated/PhotonTrackedTargetSerde.py
@@ -40,38 +40,38 @@ class PhotonTrackedTargetSerde:
         ret = Packet()
 
         # yaw is of intrinsic type float64
-        ret.encodeDouble(value.yaw)
+        ret.encodeDouble(value.yaw)  # fmt: skip
 
         # pitch is of intrinsic type float64
-        ret.encodeDouble(value.pitch)
+        ret.encodeDouble(value.pitch)  # fmt: skip
 
         # area is of intrinsic type float64
-        ret.encodeDouble(value.area)
+        ret.encodeDouble(value.area)  # fmt: skip
 
         # skew is of intrinsic type float64
-        ret.encodeDouble(value.skew)
+        ret.encodeDouble(value.skew)  # fmt: skip
 
         # fiducialId is of intrinsic type int32
-        ret.encodeInt(value.fiducialId)
+        ret.encodeInt(value.fiducialId)  # fmt: skip
 
         # objDetectId is of intrinsic type int32
-        ret.encodeInt(value.objDetectId)
+        ret.encodeInt(value.objDetectId)  # fmt: skip
 
         # objDetectConf is of intrinsic type float32
-        ret.encodeFloat(value.objDetectConf)
+        ret.encodeFloat(value.objDetectConf)  # fmt: skip
 
-        ret.encodeTransform(value.bestCameraToTarget)
+        ret.encodeTransform(value.bestCameraToTarget)  # fmt: skip
 
-        ret.encodeTransform(value.altCameraToTarget)
+        ret.encodeTransform(value.altCameraToTarget)  # fmt: skip
 
         # poseAmbiguity is of intrinsic type float64
-        ret.encodeDouble(value.poseAmbiguity)
+        ret.encodeDouble(value.poseAmbiguity)  # fmt: skip
 
         # minAreaRectCorners is a custom VLA!
-        ret.encodeList(value.minAreaRectCorners, TargetCorner.photonStruct)
+        ret.encodeList(value.minAreaRectCorners, TargetCorner.photonStruct)  # fmt: skip
 
         # detectedCorners is a custom VLA!
-        ret.encodeList(value.detectedCorners, TargetCorner.photonStruct)
+        ret.encodeList(value.detectedCorners, TargetCorner.photonStruct)  # fmt: skip
         return ret
 
     @staticmethod
@@ -79,38 +79,38 @@ class PhotonTrackedTargetSerde:
         ret = PhotonTrackedTarget()
 
         # yaw is of intrinsic type float64
-        ret.yaw = packet.decodeDouble()
+        ret.yaw = packet.decodeDouble()  # fmt: skip
 
         # pitch is of intrinsic type float64
-        ret.pitch = packet.decodeDouble()
+        ret.pitch = packet.decodeDouble()  # fmt: skip
 
         # area is of intrinsic type float64
-        ret.area = packet.decodeDouble()
+        ret.area = packet.decodeDouble()  # fmt: skip
 
         # skew is of intrinsic type float64
-        ret.skew = packet.decodeDouble()
+        ret.skew = packet.decodeDouble()  # fmt: skip
 
         # fiducialId is of intrinsic type int32
-        ret.fiducialId = packet.decodeInt()
+        ret.fiducialId = packet.decodeInt()  # fmt: skip
 
         # objDetectId is of intrinsic type int32
-        ret.objDetectId = packet.decodeInt()
+        ret.objDetectId = packet.decodeInt()  # fmt: skip
 
         # objDetectConf is of intrinsic type float32
-        ret.objDetectConf = packet.decodeFloat()
+        ret.objDetectConf = packet.decodeFloat()  # fmt: skip
 
-        ret.bestCameraToTarget = packet.decodeTransform()
+        ret.bestCameraToTarget = packet.decodeTransform()  # fmt: skip
 
-        ret.altCameraToTarget = packet.decodeTransform()
+        ret.altCameraToTarget = packet.decodeTransform()  # fmt: skip
 
         # poseAmbiguity is of intrinsic type float64
-        ret.poseAmbiguity = packet.decodeDouble()
+        ret.poseAmbiguity = packet.decodeDouble()  # fmt: skip
 
         # minAreaRectCorners is a custom VLA!
-        ret.minAreaRectCorners = packet.decodeList(TargetCorner.photonStruct)
+        ret.minAreaRectCorners = packet.decodeList(TargetCorner.photonStruct)  # fmt: skip
 
         # detectedCorners is a custom VLA!
-        ret.detectedCorners = packet.decodeList(TargetCorner.photonStruct)
+        ret.detectedCorners = packet.decodeList(TargetCorner.photonStruct)  # fmt: skip
 
         return ret
 

--- a/photon-lib/py/photonlibpy/generated/PnpResultSerde.py
+++ b/photon-lib/py/photonlibpy/generated/PnpResultSerde.py
@@ -38,36 +38,36 @@ class PnpResultSerde:
     def pack(value: "PnpResult") -> "Packet":
         ret = Packet()
 
-        ret.encodeTransform(value.best)
+        ret.encodeTransform(value.best)  # fmt: skip
 
-        ret.encodeTransform(value.alt)
+        ret.encodeTransform(value.alt)  # fmt: skip
 
         # bestReprojErr is of intrinsic type float64
-        ret.encodeDouble(value.bestReprojErr)
+        ret.encodeDouble(value.bestReprojErr)  # fmt: skip
 
         # altReprojErr is of intrinsic type float64
-        ret.encodeDouble(value.altReprojErr)
+        ret.encodeDouble(value.altReprojErr)  # fmt: skip
 
         # ambiguity is of intrinsic type float64
-        ret.encodeDouble(value.ambiguity)
+        ret.encodeDouble(value.ambiguity)  # fmt: skip
         return ret
 
     @staticmethod
     def unpack(packet: "Packet") -> "PnpResult":
         ret = PnpResult()
 
-        ret.best = packet.decodeTransform()
+        ret.best = packet.decodeTransform()  # fmt: skip
 
-        ret.alt = packet.decodeTransform()
+        ret.alt = packet.decodeTransform()  # fmt: skip
 
         # bestReprojErr is of intrinsic type float64
-        ret.bestReprojErr = packet.decodeDouble()
+        ret.bestReprojErr = packet.decodeDouble()  # fmt: skip
 
         # altReprojErr is of intrinsic type float64
-        ret.altReprojErr = packet.decodeDouble()
+        ret.altReprojErr = packet.decodeDouble()  # fmt: skip
 
         # ambiguity is of intrinsic type float64
-        ret.ambiguity = packet.decodeDouble()
+        ret.ambiguity = packet.decodeDouble()  # fmt: skip
 
         return ret
 

--- a/photon-lib/py/photonlibpy/generated/TargetCornerSerde.py
+++ b/photon-lib/py/photonlibpy/generated/TargetCornerSerde.py
@@ -39,10 +39,10 @@ class TargetCornerSerde:
         ret = Packet()
 
         # x is of intrinsic type float64
-        ret.encodeDouble(value.x)
+        ret.encodeDouble(value.x)  # fmt: skip
 
         # y is of intrinsic type float64
-        ret.encodeDouble(value.y)
+        ret.encodeDouble(value.y)  # fmt: skip
         return ret
 
     @staticmethod
@@ -50,10 +50,10 @@ class TargetCornerSerde:
         ret = TargetCorner()
 
         # x is of intrinsic type float64
-        ret.x = packet.decodeDouble()
+        ret.x = packet.decodeDouble()  # fmt: skip
 
         # y is of intrinsic type float64
-        ret.y = packet.decodeDouble()
+        ret.y = packet.decodeDouble()  # fmt: skip
 
         return ret
 

--- a/photon-serde/message_data_types.yaml
+++ b/photon-serde/message_data_types.yaml
@@ -6,6 +6,8 @@ bool:
   cpp_type: bool
   java_decode_method: decodeBoolean
   java_encode_shim: encodeBoolean
+  python_decode_shim: decodeBoolean
+  python_encode_shim: encodeBoolean
 int16:
   len: 2
   java_type: short
@@ -13,27 +15,37 @@ int16:
   java_decode_method: decodeShort
   java_list_decode_method: decodeShortList
   java_encode_shim: encodeShort
+  python_decode_shim: decodeShort
+  python_encode_shim: encodeShort
 int32:
   len: 4
   java_type: int
   cpp_type: int32_t
   java_decode_method: decodeInt
   java_encode_shim: encodeInt
+  python_decode_shim: decodeInt
+  python_encode_shim: encodeInt
 int64:
   len: 8
   java_type: long
   cpp_type: int64_t
   java_decode_method: decodeLong
   java_encode_shim: encodeLong
+  python_decode_shim: decodeLong
+  python_encode_shim: encodeLong
 float32:
   len: 4
   java_type: float
   cpp_type: float
   java_decode_method: decodeFloat
   java_encode_shim: encodeFloat
+  python_decode_shim: decodeFloat
+  python_encode_shim: encodeFloat
 float64:
   len: 8
   java_type: double
   cpp_type: double
   java_decode_method: decodeDouble
   java_encode_shim: encodeDouble
+  python_decode_shim: decodeDouble
+  python_encode_shim: encodeDouble

--- a/photon-serde/messages.yaml
+++ b/photon-serde/messages.yaml
@@ -16,7 +16,7 @@
   java_encode_shim: PacketUtils.packTransform3d
   cpp_type: frc::Transform3d
   cpp_include: "<frc/geometry/Transform3d.h>"
-  python_decode_shim: packet.decodeTransform
+  python_decode_shim: decodeTransform
   python_encode_shim: encodeTransform
   java_import: edu.wpi.first.math.geometry.Transform3d
   # shim since we expect fields to at least exist

--- a/photon-serde/templates/ThingSerde.py.jinja
+++ b/photon-serde/templates/ThingSerde.py.jinja
@@ -44,7 +44,7 @@ class {{ name }}Serde:
     MESSAGE_FORMAT = "{{ message_fmt }}"
 
     @staticmethod
-    def pack(value: '{{ name }}' ) -> 'Packet':
+    def pack(value: "{{ name }}" ) -> "Packet":
         ret = Packet()
 {% for field in fields -%}
 {%- if field.type | is_shimmed %}
@@ -72,7 +72,7 @@ class {{ name }}Serde:
 
 
     @staticmethod
-    def unpack(packet: 'Packet') -> '{{ name }}':
+    def unpack(packet: "Packet") -> "{{ name }}":
         ret = {{ name }}()
 {% for field in fields -%}
 {%- if field.type | is_shimmed %}

--- a/photon-serde/templates/ThingSerde.py.jinja
+++ b/photon-serde/templates/ThingSerde.py.jinja
@@ -48,22 +48,22 @@ class {{ name }}Serde:
         ret = Packet()
 {% for field in fields -%}
 {%- if field.type | is_shimmed %}
-        ret.{{ get_message_by_name(field.type).python_encode_shim}}(value.{{ field.name }})
+        ret.{{ get_message_by_name(field.type).python_encode_shim}}(value.{{ field.name }})  # fmt: skip
 {%- elif field.optional == True %}
         # {{ field.name }} is optional! it better not be a VLA too
-        ret.encodeOptional(value.{{ field.name }}, {{ field.type }}.photonStruct)
+        ret.encodeOptional(value.{{ field.name }}, {{ field.type }}.photonStruct)  # fmt: skip
 {%- elif field.vla == True and not field.type | is_intrinsic %}
         # {{ field.name }} is a custom VLA!
-        ret.encodeList(value.{{ field.name }}, {{ field.type }}.photonStruct)
+        ret.encodeList(value.{{ field.name }}, {{ field.type }}.photonStruct)  # fmt: skip
 {%- elif field.vla == True and field.type | is_intrinsic %}
         # {{ field.name }} is a custom VLA!
-        ret.encode{{ type_map[field.type].java_type.title() }}List(value.{{ field.name }})
+        ret.encode{{ type_map[field.type].java_type.title() }}List(value.{{ field.name }})  # fmt: skip
 {%- elif field.type | is_intrinsic %}
         # {{ field.name }} is of intrinsic type {{ field.type }}
-        ret.{{ type_map[field.type].python_encode_shim }}(value.{{field.name}})
+        ret.{{ type_map[field.type].python_encode_shim }}(value.{{field.name}})  # fmt: skip
 {%- else %}
         # {{ field.name }} is of non-intrinsic type {{ field.type }}
-        ret.encodeBytes({{ field.type }}.photonStruct.pack(value.{{field.name}}).getData())
+        ret.encodeBytes({{ field.type }}.photonStruct.pack(value.{{field.name}}).getData())  # fmt: skip
 {%- endif %}
 {%- if not loop.last %}
 {% endif -%}
@@ -75,22 +75,22 @@ class {{ name }}Serde:
         ret = {{ name }}()
 {% for field in fields -%}
 {%- if field.type | is_shimmed %}
-        ret.{{ field.name }} = packet.{{ get_message_by_name(field.type).python_decode_shim }}()
+        ret.{{ field.name }} = packet.{{ get_message_by_name(field.type).python_decode_shim }}()  # fmt: skip
 {%- elif field.optional == True %}
         # {{ field.name }} is optional! it better not be a VLA too
-        ret.{{ field.name }} = packet.decodeOptional({{ field.type }}.photonStruct)
+        ret.{{ field.name }} = packet.decodeOptional({{ field.type }}.photonStruct)  # fmt: skip
 {%- elif field.vla == True and not field.type | is_intrinsic %}
         # {{ field.name }} is a custom VLA!
-        ret.{{ field.name }} = packet.decodeList({{ field.type }}.photonStruct)
+        ret.{{ field.name }} = packet.decodeList({{ field.type }}.photonStruct)  # fmt: skip
 {%- elif field.vla == True and field.type | is_intrinsic %}
         # {{ field.name }} is a custom VLA!
-        ret.{{ field.name }} = packet.decode{{ type_map[field.type].java_type.title() }}List()
+        ret.{{ field.name }} = packet.decode{{ type_map[field.type].java_type.title() }}List()  # fmt: skip
 {%- elif field.type | is_intrinsic %}
         # {{ field.name }} is of intrinsic type {{ field.type }}
-        ret.{{field.name}} = packet.{{ type_map[field.type].python_decode_shim }}()
+        ret.{{field.name}} = packet.{{ type_map[field.type].python_decode_shim }}()  # fmt: skip
 {%- else %}
         # {{ field.name }} is of non-intrinsic type {{ field.type }}
-        ret.{{field.name}} = {{ field.type }}.photonStruct.unpack(packet)
+        ret.{{field.name}} = {{ field.type }}.photonStruct.unpack(packet)  # fmt: skip
 {%- endif %}
 {%- if not loop.last %}
 {% endif -%}

--- a/photon-serde/templates/ThingSerde.py.jinja
+++ b/photon-serde/templates/ThingSerde.py.jinja
@@ -60,7 +60,7 @@ class {{ name }}Serde:
         ret.encode{{ type_map[field.type].java_type.title() }}List(value.{{ field.name }})
 {%- elif field.type | is_intrinsic %}
         # {{ field.name }} is of intrinsic type {{ field.type }}
-        ret.{{ type_map[field.type].java_encode_shim }}(value.{{field.name}})
+        ret.{{ type_map[field.type].python_encode_shim }}(value.{{field.name}})
 {%- else %}
         # {{ field.name }} is of non-intrinsic type {{ field.type }}
         ret.encodeBytes({{ field.type }}.photonStruct.pack(value.{{field.name}}).getData())
@@ -87,7 +87,7 @@ class {{ name }}Serde:
         ret.{{ field.name }} = packet.decode{{ type_map[field.type].java_type.title() }}List()
 {%- elif field.type | is_intrinsic %}
         # {{ field.name }} is of intrinsic type {{ field.type }}
-        ret.{{field.name}} = packet.{{ type_map[field.type].java_decode_method }}()
+        ret.{{field.name}} = packet.{{ type_map[field.type].python_decode_shim }}()
 {%- else %}
         # {{ field.name }} is of non-intrinsic type {{ field.type }}
         ret.{{field.name}} = {{ field.type }}.photonStruct.unpack(packet)

--- a/photon-serde/templates/ThingSerde.py.jinja
+++ b/photon-serde/templates/ThingSerde.py.jinja
@@ -101,4 +101,4 @@ class {{ name }}Serde:
 
 
 # Hack ourselves into the base class
-{{ name }}.photonStruct = {{ name }}Serde()
+{{ name }}.photonStruct = {{ name }}Serde(){{'\n'}}

--- a/photon-serde/templates/ThingSerde.py.jinja
+++ b/photon-serde/templates/ThingSerde.py.jinja
@@ -70,7 +70,6 @@ class {{ name }}Serde:
 {% endfor%}
         return ret
 
-
     @staticmethod
     def unpack(packet: "Packet") -> "{{ name }}":
         ret = {{ name }}()

--- a/photon-serde/templates/ThingSerde.py.jinja
+++ b/photon-serde/templates/ThingSerde.py.jinja
@@ -75,7 +75,7 @@ class {{ name }}Serde:
         ret = {{ name }}()
 {% for field in fields -%}
 {%- if field.type | is_shimmed %}
-        ret.{{ field.name }} = {{ get_message_by_name(field.type).python_decode_shim }}()
+        ret.{{ field.name }} = packet.{{ get_message_by_name(field.type).python_decode_shim }}()
 {%- elif field.optional == True %}
         # {{ field.name }} is optional! it better not be a VLA too
         ret.{{ field.name }} = packet.decodeOptional({{ field.type }}.photonStruct)

--- a/photon-serde/templates/ThingSerde.py.jinja
+++ b/photon-serde/templates/ThingSerde.py.jinja
@@ -44,7 +44,7 @@ class {{ name }}Serde:
     MESSAGE_FORMAT = "{{ message_fmt }}"
 
     @staticmethod
-    def pack(value: "{{ name }}" ) -> "Packet":
+    def pack(value: "{{ name }}") -> "Packet":
         ret = Packet()
 {% for field in fields -%}
 {%- if field.type | is_shimmed %}


### PR DESCRIPTION
This fixes mostly formatting issues so there is no longer any diff with things after rerunning the generation script. Yes, most of this can be fixed by running wpiformat but that doesn't exist as a pre-commit hook atm, so I think this is nicer.

It also removes any reference to the java encode/decode within the python message gen