### PR TITLE
Check for exposure setting validity before accessing.

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
@@ -95,9 +95,11 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
         // first.
         var autoExpProp = findProperty("exposure_auto", "auto_exposure");
 
-        exposureAbsProp = expProp.get();
-        this.minExposure = exposureAbsProp.getMin();
-        this.maxExposure = exposureAbsProp.getMax();
+        if (expProp.isPresent()) {
+            exposureAbsProp = expProp.get();
+            this.minExposure = exposureAbsProp.getMin();
+            this.maxExposure = exposureAbsProp.getMax();
+        }
 
         if (autoExpProp.isPresent()) {
             autoExposureProp = autoExpProp.get();
@@ -184,7 +186,7 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
             softSet("auto_exposure_bias", 12);
             softSet("iso_sensitivity_auto", 1);
             softSet("iso_sensitivity", 1); // Manual ISO adjustment by default
-            autoExposureProp.set(PROP_AUTO_EXPOSURE_ENABLED);
+            if (autoExposureProp != null) autoExposureProp.set(PROP_AUTO_EXPOSURE_ENABLED);
         }
     }
 


### PR DESCRIPTION
If the exposure property for the generic USB camera settable was not valid for one camera in the list, then the thread would crash/hang and no cameras would show up in the list