### PR TITLE
Fix "Manage Device Networking" toggle being disabled incorrectly

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -110,12 +110,6 @@ public class NetworkConfig {
         return "\"" + networkManagerIface + "\"";
     }
 
-    @JsonIgnore
-    public boolean shouldManage() {
-        return this.shouldManage;
-    }
-
-    @JsonIgnore
     public void setShouldManage(boolean shouldManage) {
         this.shouldManage = shouldManage && this.deviceCanManageNetwork();
     }

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -104,17 +104,6 @@ public class NetworkConfig {
                 config.matchCamerasOnlyByPath);
     }
 
-    public Map<String, Object> toHashMap() {
-        try {
-            var ret = new ObjectMapper().convertValue(this, JacksonUtils.UIMap.class);
-            ret.put("canManage", this.deviceCanManageNetwork());
-            return ret;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return new HashMap<>();
-        }
-    }
-
     @JsonIgnore
     public String getPhysicalInterfaceName() {
         return this.networkManagerIface;

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -21,12 +21,8 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.HashMap;
-import java.util.Map;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.networking.NetworkMode;
-import org.photonvision.common.util.file.JacksonUtils;
 
 public class NetworkConfig {
     // Can be an integer team number, or an IP address

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NetworkConfig.java
@@ -136,7 +136,7 @@ public class NetworkConfig {
     }
 
     @JsonIgnore
-    private boolean deviceCanManageNetwork() {
+    protected boolean deviceCanManageNetwork() {
         return Platform.isLinux();
     }
 

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UINetConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UINetConfig.java
@@ -27,7 +27,7 @@ public class UINetConfig extends NetworkConfig {
         super(config);
         this.networkInterfaceNames = networkInterfaceNames;
         this.networkingDisabled = networkingDisabled;
-        this.canManage =  this.deviceCanManageNetwork();
+        this.canManage = this.deviceCanManageNetwork();
     }
 
     public List<NMDeviceInfo> networkInterfaceNames;

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UINetConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UINetConfig.java
@@ -27,8 +27,10 @@ public class UINetConfig extends NetworkConfig {
         super(config);
         this.networkInterfaceNames = networkInterfaceNames;
         this.networkingDisabled = networkingDisabled;
+        this.canManage =  this.deviceCanManageNetwork();
     }
 
     public List<NMDeviceInfo> networkInterfaceNames;
     public boolean networkingDisabled;
+    public boolean canManage;
 }

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -113,7 +113,7 @@ public class NetworkManager {
     }
 
     public void reinitialize() {
-        initialize(ConfigManager.getInstance().getConfig().getNetworkConfig().shouldManage());
+        initialize(ConfigManager.getInstance().getConfig().getNetworkConfig().shouldManage);
 
         DataChangeService.getInstance()
                 .publishEvent(


### PR DESCRIPTION
This fixes a bug introduced in #1592 that caused the Manage Device Networking toggle to be disabled for systems where PhotonVision is managing the network.

There is still a problem with the toggle defaulting to "off" and not staying in the "on" position after settings are saved. I need help from someone who understands the frontend to figure out why it keeps getting set back to "off".