### PR TITLE
Remove selective builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,8 @@ on:
     branches: [ master ]
     tags:
       - 'v*'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   pull_request:
     branches: [ master ]
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   merge_group:
 
 jobs:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -6,16 +6,8 @@ on:
     branches: [ master ]
     tags:
       - 'v*'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   pull_request:
     branches: [ master ]
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   merge_group:
 
 concurrency:

--- a/.github/workflows/photon-code-docs.yml
+++ b/.github/workflows/photon-code-docs.yml
@@ -6,16 +6,8 @@ on:
     branches: [ master ]
     tags:
       - 'v*'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   pull_request:
     branches: [ master ]
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   merge_group:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/photonvision-docs.yml
+++ b/.github/workflows/photonvision-docs.yml
@@ -3,14 +3,8 @@ name: PhotonVision Sphinx Documentation Checks
 on:
   push:
     branches: [ master ]
-    paths:
-      - 'docs/**'
-      - '.github/**'
   pull_request:
     branches: [ master ]
-    paths:
-      - 'docs/**'
-      - '.github/**'
   merge_group:
 
 env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,16 +8,8 @@ on:
     branches: [ master ]
     tags:
       - 'v*'
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   pull_request:
     branches: [ master ]
-    paths:
-      - '**'
-      - '!docs/**'
-      - '.github/**'
   merge_group:
 
 jobs:

--- a/photonlib-java-examples/aimattarget/src/test/java/frc/robot/JniLoadTest.java
+++ b/photonlib-java-examples/aimattarget/src/test/java/frc/robot/JniLoadTest.java
@@ -26,17 +26,14 @@ package frc.robot;
 
 import static org.junit.Assert.fail;
 
-import java.util.List;
-
-import org.junit.Test;
-import org.photonvision.timesync.TimeSyncSingleton;
-
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
-
+import java.util.List;
+import org.junit.Test;
+import org.photonvision.PhotonCamera;
 import org.photonvision.simulation.PhotonCameraSim;
 import org.photonvision.simulation.SimCameraProperties;
-import org.photonvision.PhotonCamera;
+import org.photonvision.timesync.TimeSyncSingleton;
 
 public class JniLoadTest {
     @Test


### PR DESCRIPTION
Selective builds breaks my ability to require that checks pass before merging. It's not worth the bite for very few docs-only PRs, given github limitations on needing to skip INDIVIDUAL JOB STEPS on required CI jobs. 

Maybe we should move to gitlab 💀 