### PR TITLE
Bump Athena image to 2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: wpilib/roborio-cross-ubuntu:2024-22.04
+          - container: wpilib/roborio-cross-ubuntu:2025-24.04
             artifact-name: Athena
             build-options: "-Ponlylinuxathena"
           - container: wpilib/raspbian-cross-ubuntu:bullseye-22.04


### PR DESCRIPTION
This fixes Athena aritfacts not being uploaded to Maven. This doesn't yet fix the same for aarch64 and raspbian 32 bit artifacts.