### PR TITLE
Fix release action glob exclusion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -557,16 +557,14 @@ jobs:
       - uses: softprops/action-gh-release@v2.0.9
         with:
           files: |
-            **/*orangepi5*.xz
-            **/*rock5*.xz
+            **/@(*orangepi5*|*rock5*).xz
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: softprops/action-gh-release@v2.0.9
         with:
           files: |
-            **/!(*orangepi5*).xz
-            **/!(*rock5*).xz
+            **/!(*orangepi5*|*rock5*).xz
             **/*.jar
             **/photonlib*.json
             **/photonlib*.zip


### PR DESCRIPTION
In softprops/action-gh-release, when using an glob pattern to exclude files, all of the files to exclude must be specified on one line. Splitting them to multiple lines causes all files to match one of the two lines. 

To combine on one line, use `|` between the patterns.