### PR TITLE
Improve slider text input fields

### DIFF
--- a/photon-client/src/components/common/pv-slider.vue
+++ b/photon-client/src/components/common/pv-slider.vue
@@ -64,7 +64,7 @@ const localValue = computed({
         >
           <template #append>
             <v-text-field
-              v-model="localValue"
+              v-model.lazy="localValue"
               dark
               color="accent"
               :max="max"

--- a/photon-client/src/components/common/pv-slider.vue
+++ b/photon-client/src/components/common/pv-slider.vue
@@ -42,13 +42,12 @@ const localValue = computed({
   get: () => props.value,
   set: (v) => debouncedEmit(parseFloat(v as unknown as string))
 });
-
 </script>
 
 <template>
   <div>
     <v-row dense align="center">
-      <v-col :cols="12 - sliderCols -1">
+      <v-col :cols="12 - sliderCols - 1">
         <tooltipped-label :tooltip="tooltip" :label="label" />
       </v-col>
       <v-col :cols="sliderCols">

--- a/photon-client/src/components/common/pv-slider.vue
+++ b/photon-client/src/components/common/pv-slider.vue
@@ -70,8 +70,6 @@ const localValue = computed({
       <v-col :cols="1">
         <v-text-field
           :value="localValue"
-          @keyup.enter="localValue = $event.target.value"
-          @blur="localValue = $event.target.value"
           dark
           color="accent"
           :max="max"
@@ -84,6 +82,8 @@ const localValue = computed({
           style="width: 45px"
           :step="step"
           hide-spin-buttons="true"
+          @keyup.enter="localValue = $event.target.value"
+          @blur="localValue = $event.target.value"
         />
       </v-col>
     </v-row>

--- a/photon-client/src/components/common/pv-slider.vue
+++ b/photon-client/src/components/common/pv-slider.vue
@@ -42,12 +42,13 @@ const localValue = computed({
   get: () => props.value,
   set: (v) => debouncedEmit(parseFloat(v as unknown as string))
 });
+
 </script>
 
 <template>
   <div>
     <v-row dense align="center">
-      <v-col :cols="12 - sliderCols">
+      <v-col :cols="12 - sliderCols -1">
         <tooltipped-label :tooltip="tooltip" :label="label" />
       </v-col>
       <v-col :cols="sliderCols">
@@ -61,24 +62,30 @@ const localValue = computed({
           color="accent"
           :disabled="disabled"
           :step="step"
-        >
-          <template #append>
-            <v-text-field
-              v-model.lazy="localValue"
-              dark
-              color="accent"
-              :max="max"
-              :min="min"
-              :disabled="disabled"
-              class="mt-0 pt-0"
-              hide-details
-              single-line
-              type="number"
-              style="width: 50px"
-              :step="step"
-            />
-          </template>
-        </v-slider>
+          append-icon="mdi-menu-right"
+          prepend-icon="mdi-menu-left"
+          @click:append="localValue += step"
+          @click:prepend="localValue -= step"
+        />
+      </v-col>
+      <v-col :cols="1">
+        <v-text-field
+          :value="localValue"
+          @keyup.enter="localValue = $event.target.value"
+          @blur="localValue = $event.target.value"
+          dark
+          color="accent"
+          :max="max"
+          :min="min"
+          :disabled="disabled"
+          class="mt-0 pt-0"
+          hide-details
+          single-line
+          type="number"
+          style="width: 45px"
+          :step="step"
+          hide-spin-buttons="true"
+        />
       </v-col>
     </v-row>
   </div>


### PR DESCRIPTION
This PR changes the text input fields to allow a user to type in a value and press enter (or click away) before the UI registers the updated value. It makes text input behave in a more expected manner.  The spin buttons are no longer shown for the text box. Instead, there are up and down buttons on either side of the slider.

The only thing that I can't figure out is a way to make the up and down buttons continuously increment (decrement) the value if you click and hold. I'm not sure that this is required, but if someone wants to propose a solution, please add it to this PR.