### PR TITLE
Fix CSI camera exposure setting

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/csi/LibcameraGpuSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/csi/LibcameraGpuSettables.java
@@ -126,14 +126,14 @@ public class LibcameraGpuSettables extends VisionSourceSettables {
     public void setAutoExposure(boolean cameraAutoExposure) {
         lastAutoExposureActive = cameraAutoExposure;
         LibCameraJNI.setAutoExposure(r_ptr, cameraAutoExposure);
+        if (!cameraAutoExposure) {
+            setExposureRaw(lastManualExposure);
+        }
     }
 
     @Override
     public void setExposureRaw(double exposureRaw) {
-        if (exposureRaw < 0.0 || lastAutoExposureActive) {
-            // Auto-exposure is active right now, don't set anything.
-            return;
-        }
+        LibCameraJNI.setAutoExposure(r_ptr, false);
 
         // Store the exposure for use when we need to recreate the camera.
         lastManualExposure = exposureRaw;

--- a/photon-core/src/main/java/org/photonvision/vision/camera/csi/LibcameraGpuSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/csi/LibcameraGpuSettables.java
@@ -124,6 +124,7 @@ public class LibcameraGpuSettables extends VisionSourceSettables {
 
     @Override
     public void setAutoExposure(boolean cameraAutoExposure) {
+        logger.debug("Setting auto exposure to " + cameraAutoExposure);
         lastAutoExposureActive = cameraAutoExposure;
         LibCameraJNI.setAutoExposure(r_ptr, cameraAutoExposure);
         if (!cameraAutoExposure) {
@@ -133,6 +134,8 @@ public class LibcameraGpuSettables extends VisionSourceSettables {
 
     @Override
     public void setExposureRaw(double exposureRaw) {
+        logger.debug("Setting exposure to " + exposureRaw);
+
         LibCameraJNI.setAutoExposure(r_ptr, false);
 
         // Store the exposure for use when we need to recreate the camera.


### PR DESCRIPTION
Adjusts the exposure setting of csi cameras to match that of USB cameras. If you set a manual exposure it will drop out of auto exposure.