### PR TITLE
Calibration stream resolution, stream resolution warning, divisor 8x

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/frame/FrameDivisor.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/FrameDivisor.java
@@ -18,14 +18,11 @@
 package org.photonvision.vision.frame;
 
 public enum FrameDivisor {
-    NONE(1),
-    HALF(2),
-    QUARTER(4),
-    SIXTH(6);
+	NONE(1), HALF(2), QUARTER(4), SIXTH(6), EIGTH(8);
 
-    public final Integer value;
+	public final Integer value;
 
-    FrameDivisor(int value) {
-        this.value = value;
-    }
+	FrameDivisor(int value) {
+		this.value = value;
+	}
 }


### PR DESCRIPTION
We are not able to do this with chessboard at this time since we use the framedivisor for decimation. This also adds a warning for resolutions over 320x240. Finally, it adds an 8x divisor.
![image](https://github.com/user-attachments/assets/5509f0fb-3bec-4a17-8ad8-85b8ad67956e)
![image](https://github.com/user-attachments/assets/6d7b487e-ac73-4d12-9d18-8ee27cfe6756)
also fixes #1501