### PR TITLE
Fix exception thrown when isUp() is called on an unavailable network interface

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -274,9 +274,8 @@ public class NetworkManager {
                                 logger.warn("Interface " + devName + " is disconnected, check Ethernet!");
                             }
                         }
-                        NetworkInterface iFace;
-                        iFace = NetworkInterface.getByName(devName);
-                        if (iFace.isUp()) {
+                        var iFace = NetworkInterface.getByName(devName);
+                        if (iFace != null && iFace.isUp()) {
                             String tmpAddresses = "";
                             tmpAddresses = iFace.getInterfaceAddresses().toString();
                             if (!last.addresses.equals(tmpAddresses)) {

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -188,16 +188,16 @@ public class NetworkUtils {
         List<String> addresses = new ArrayList<String>();
         try {
             var iFace = NetworkInterface.getByName(iFaceName);
-            for (var addr : iFace.getInterfaceAddresses()) {
-                var addrStr = addr.getAddress().toString();
-                if (addrStr.startsWith("/")) {
-                    addrStr = addrStr.substring(1);
+            if (iFace != null && iFace.isUp()) {
+                for (var addr : iFace.getInterfaceAddresses()) {
+                    var addrStr = addr.getAddress().toString();
+                    if (addrStr.startsWith("/")) {
+                        addrStr = addrStr.substring(1);
+                    }
+                    addrStr = addrStr + "/" + addr.getNetworkPrefixLength();
+                    addresses.add(addrStr);
                 }
-                addrStr = addrStr + "/" + addr.getNetworkPrefixLength();
-                addresses.add(addrStr);
             }
-            // addresses = iFace.inetAddresses().map(a ->
-            // a.getAddress().toString()).collect(Collectors.joining(","));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Make sure to check if the interface returned from NetworkInterface.getByName() is null before calling isUp() on it.