### PR TITLE
Cancel previous GH commit jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
     branches: [ main ]
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-client:
     name: "PhotonClient Build"

--- a/.github/workflows/photon-code-docs.yml
+++ b/.github/workflows/photon-code-docs.yml
@@ -10,15 +10,15 @@ on:
     branches: [ main ]
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build-client:

--- a/.github/workflows/photonvision-docs.yml
+++ b/.github/workflows/photonvision-docs.yml
@@ -7,6 +7,10 @@ on:
     branches: [ master ]
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,6 +12,10 @@ on:
     branches: [ master ]
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   buildAndDeploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Cancel gradle workflows when you push a new commit. This should free up actions runners