### PR TITLE
[python] Fix PhotonPipelineMetadata constructor arg order

### DIFF
--- a/photon-lib/py/photonlibpy/simulation/photonCameraSim.py
+++ b/photon-lib/py/photonlibpy/simulation/photonCameraSim.py
@@ -423,9 +423,9 @@ class PhotonCameraSim:
         now_micros = wpilib.Timer.getFPGATimestamp() * 1e6
         return PhotonPipelineResult(
             metadata=PhotonPipelineMetadata(
-                self.heartbeatCounter,
                 int(now_micros - latency * 1e6),
                 int(now_micros),
+                self.heartbeatCounter,
                 # Pretend like we heard a pong recently
                 int(np.random.uniform(950, 1050)),
             ),


### PR DESCRIPTION
Relates to https://github.com/PhotonVision/photonvision/pull/1578