### PR TITLE
Fix deprecation warnings in PhotonLib examples

### DIFF
--- a/photon-lib/py/disableUsingDevBuilds.sh
+++ b/photon-lib/py/disableUsingDevBuilds.sh
@@ -1,0 +1,1 @@
+python3 -m pip config set global.find-links dist

--- a/photon-lib/py/disableUsingDevBuilds.sh
+++ b/photon-lib/py/disableUsingDevBuilds.sh
@@ -1,1 +1,1 @@
-python3 -m pip config set global.find-links dist
+python3 -m pip config unset global.find-links

--- a/photon-lib/py/enableUsingDevBuilds.sh
+++ b/photon-lib/py/enableUsingDevBuilds.sh
@@ -1,0 +1,1 @@
+python3 -m pip config set global.find-links dist

--- a/photonlib-java-examples/aimandrange/src/main/java/frc/robot/Constants.java
+++ b/photonlib-java-examples/aimandrange/src/main/java/frc/robot/Constants.java
@@ -47,7 +47,8 @@ public class Constants {
                 new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, -camPitch, 0));
 
         // The layout of the AprilTags on the field
-        public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
+        public static final AprilTagFieldLayout kTagLayout =
+                AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
 
         // The standard deviations of our vision estimated poses, which affect correction rate
         // (Fake values. Experiment and determine estimation noise on an actual robot.)

--- a/photonlib-java-examples/aimandrange/src/main/java/frc/robot/Constants.java
+++ b/photonlib-java-examples/aimandrange/src/main/java/frc/robot/Constants.java
@@ -47,8 +47,7 @@ public class Constants {
                 new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, -camPitch, 0));
 
         // The layout of the AprilTags on the field
-        public static final AprilTagFieldLayout kTagLayout =
-                AprilTagFields.kDefaultField.loadAprilTagLayoutField();
+        public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
 
         // The standard deviations of our vision estimated poses, which affect correction rate
         // (Fake values. Experiment and determine estimation noise on an actual robot.)

--- a/photonlib-java-examples/aimandrange/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
+++ b/photonlib-java-examples/aimandrange/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
@@ -108,7 +108,7 @@ public class SwerveModule {
             SwerveModuleState desiredState, boolean openLoop, boolean steerInPlace) {
         Rotation2d currentRotation = getAbsoluteHeading();
         // Avoid turning more than 90 degrees by inverting speed on large angle changes
-        desiredState = SwerveModuleState.optimize(desiredState, currentRotation);
+        desiredState.optimize(currentRotation);
 
         this.desiredState = desiredState;
     }

--- a/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Constants.java
+++ b/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Constants.java
@@ -47,7 +47,8 @@ public class Constants {
                 new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, -camPitch, 0));
 
         // The layout of the AprilTags on the field
-        public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
+        public static final AprilTagFieldLayout kTagLayout =
+                AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
 
         // The standard deviations of our vision estimated poses, which affect correction rate
         // (Fake values. Experiment and determine estimation noise on an actual robot.)

--- a/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Constants.java
+++ b/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Constants.java
@@ -47,8 +47,7 @@ public class Constants {
                 new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, -camPitch, 0));
 
         // The layout of the AprilTags on the field
-        public static final AprilTagFieldLayout kTagLayout =
-                AprilTagFields.kDefaultField.loadAprilTagLayoutField();
+        public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
 
         // The standard deviations of our vision estimated poses, which affect correction rate
         // (Fake values. Experiment and determine estimation noise on an actual robot.)

--- a/photonlib-java-examples/aimattarget/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
+++ b/photonlib-java-examples/aimattarget/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
@@ -108,7 +108,7 @@ public class SwerveModule {
             SwerveModuleState desiredState, boolean openLoop, boolean steerInPlace) {
         Rotation2d currentRotation = getAbsoluteHeading();
         // Avoid turning more than 90 degrees by inverting speed on large angle changes
-        desiredState = SwerveModuleState.optimize(desiredState, currentRotation);
+        desiredState.optimize(currentRotation);
 
         this.desiredState = desiredState;
     }

--- a/photonlib-java-examples/poseest/src/main/java/frc/robot/Constants.java
+++ b/photonlib-java-examples/poseest/src/main/java/frc/robot/Constants.java
@@ -45,8 +45,7 @@ public class Constants {
                 new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, 0, 0));
 
         // The layout of the AprilTags on the field
-        public static final AprilTagFieldLayout kTagLayout =
-                AprilTagFields.kDefaultField.loadAprilTagLayoutField();
+        public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
 
         // The standard deviations of our vision estimated poses, which affect correction rate
         // (Fake values. Experiment and determine estimation noise on an actual robot.)

--- a/photonlib-java-examples/poseest/src/main/java/frc/robot/Constants.java
+++ b/photonlib-java-examples/poseest/src/main/java/frc/robot/Constants.java
@@ -45,7 +45,8 @@ public class Constants {
                 new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, 0, 0));
 
         // The layout of the AprilTags on the field
-        public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
+        public static final AprilTagFieldLayout kTagLayout =
+                AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
 
         // The standard deviations of our vision estimated poses, which affect correction rate
         // (Fake values. Experiment and determine estimation noise on an actual robot.)

--- a/photonlib-java-examples/poseest/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
+++ b/photonlib-java-examples/poseest/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
@@ -108,7 +108,7 @@ public class SwerveModule {
             SwerveModuleState desiredState, boolean openLoop, boolean steerInPlace) {
         Rotation2d currentRotation = getAbsoluteHeading();
         // Avoid turning more than 90 degrees by inverting speed on large angle changes
-        desiredState = SwerveModuleState.optimize(desiredState, currentRotation);
+        desiredState.optimize(currentRotation);
 
         this.desiredState = desiredState;
     }

--- a/photonlib-python-examples/aimandrange/swervemodule.py
+++ b/photonlib-python-examples/aimandrange/swervemodule.py
@@ -142,25 +142,23 @@ class SwerveModule:
         encoderRotation = wpimath.geometry.Rotation2d(self.turningEncoder.getDistance())
 
         # Optimize the reference state to avoid spinning further than 90 degrees
-        state = wpimath.kinematics.SwerveModuleState.optimize(
-            self.desiredState, encoderRotation
-        )
+        desiredState.optimize(encoderRotation)
 
         # Scale speed by cosine of angle error. This scales down movement perpendicular to the desired
         # direction of travel that can occur when modules change directions. This results in smoother
         # driving.
-        state.speed *= (state.angle - encoderRotation).cos()
+        desiredState.speed *= (desiredState.angle - encoderRotation).cos()
 
         # Calculate the drive output from the drive PID controller.
         driveOutput = self.drivePIDController.calculate(
-            self.driveEncoder.getRate(), state.speed
+            self.driveEncoder.getRate(), desiredState.speed
         )
 
-        driveFeedforward = self.driveFeedforward.calculate(state.speed)
+        driveFeedforward = self.driveFeedforward.calculate(desiredState.speed)
 
         # Calculate the turning motor output from the turning PID controller.
         turnOutput = self.turningPIDController.calculate(
-            self.turningEncoder.getDistance(), state.angle.radians()
+            self.turningEncoder.getDistance(), desiredState.angle.radians()
         )
 
         turnFeedforward = self.turnFeedforward.calculate(

--- a/photonlib-python-examples/aimattarget/swervemodule.py
+++ b/photonlib-python-examples/aimattarget/swervemodule.py
@@ -142,25 +142,23 @@ class SwerveModule:
         encoderRotation = wpimath.geometry.Rotation2d(self.turningEncoder.getDistance())
 
         # Optimize the reference state to avoid spinning further than 90 degrees
-        state = wpimath.kinematics.SwerveModuleState.optimize(
-            self.desiredState, encoderRotation
-        )
+        desiredState.optimize(encoderRotation)
 
         # Scale speed by cosine of angle error. This scales down movement perpendicular to the desired
         # direction of travel that can occur when modules change directions. This results in smoother
         # driving.
-        state.speed *= (state.angle - encoderRotation).cos()
+        desiredState.speed *= (desiredState.angle - encoderRotation).cos()
 
         # Calculate the drive output from the drive PID controller.
         driveOutput = self.drivePIDController.calculate(
-            self.driveEncoder.getRate(), state.speed
+            self.driveEncoder.getRate(), desiredState.speed
         )
 
-        driveFeedforward = self.driveFeedforward.calculate(state.speed)
+        driveFeedforward = self.driveFeedforward.calculate(desiredState.speed)
 
         # Calculate the turning motor output from the turning PID controller.
         turnOutput = self.turningPIDController.calculate(
-            self.turningEncoder.getDistance(), state.angle.radians()
+            self.turningEncoder.getDistance(), desiredState.angle.radians()
         )
 
         turnFeedforward = self.turnFeedforward.calculate(

--- a/photonlib-python-examples/poseest/swervemodule.py
+++ b/photonlib-python-examples/poseest/swervemodule.py
@@ -141,25 +141,23 @@ class SwerveModule:
         encoderRotation = wpimath.geometry.Rotation2d(self.turningEncoder.getDistance())
 
         # Optimize the reference state to avoid spinning further than 90 degrees
-        state = wpimath.kinematics.SwerveModuleState.optimize(
-            self.desiredState, encoderRotation
-        )
+        self.desiredState.optimize(encoderRotation)
 
         # Scale speed by cosine of angle error. This scales down movement perpendicular to the desired
         # direction of travel that can occur when modules change directions. This results in smoother
         # driving.
-        state.speed *= (state.angle - encoderRotation).cos()
+        self.desiredState.speed *= (self.desiredState.angle - encoderRotation).cos()
 
         # Calculate the drive output from the drive PID controller.
         driveOutput = self.drivePIDController.calculate(
-            self.driveEncoder.getRate(), state.speed
+            self.driveEncoder.getRate(), self.desiredState.speed
         )
 
-        driveFeedforward = self.driveFeedforward.calculate(state.speed)
+        driveFeedforward = self.driveFeedforward.calculate(self.desiredState.speed)
 
         # Calculate the turning motor output from the turning PID controller.
         turnOutput = self.turningPIDController.calculate(
-            self.turningEncoder.getDistance(), state.angle.radians()
+            self.turningEncoder.getDistance(), self.desiredState.angle.radians()
         )
 
         self.driveMotor.setVoltage(driveOutput + driveFeedforward)

--- a/photonlib-python-examples/run.sh
+++ b/photonlib-python-examples/run.sh
@@ -1,6 +1,6 @@
 # Check if the first argument is provided
 if [ $# -eq 0 ]
-  then 
+  then
     echo "Error: No example-to-run provided."
     exit 1
 fi

--- a/photonlib-python-examples/run.sh
+++ b/photonlib-python-examples/run.sh
@@ -1,0 +1,25 @@
+# Check if the first argument is provided
+if [ $# -eq 0 ]
+  then 
+    echo "Error: No example-to-run provided."
+    exit 1
+fi
+
+# To run any example, we want to use photonlib out of this repo
+# Build the wheel first
+pushd ../photon-lib/py
+if [ -d build ]
+  then rm -rdf build
+fi
+python3 setup.py bdist_wheel
+popd
+
+# Add the output directory to PYTHONPATH to make sure it gets picked up
+export PHOTONLIBPY_ROOT=../photon-lib/py
+export PYTHONPATH=$PHOTONLIBPY_ROOT
+
+# Move to the right example folder
+cd $1
+
+# Run the example
+robotpy sim


### PR DESCRIPTION
The following deprecation warnings have been fixed:
- `SwerveModuleState.optimize(desiredState, currentRotation);`, which is now an instance method
- `AprilTagFields.kDefaultField.loadAprilTagLayoutField();`, which is now `AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);`

WIP:
- [x] C++
- [x] Python