### PR TITLE
photonlibpy: License under MIT

### DIFF
--- a/photon-lib/py/photonlibpy/__init__.py
+++ b/photon-lib/py/photonlibpy/__init__.py
@@ -1,19 +1,26 @@
-###############################################################################
-## Copyright (C) Photon Vision.
-###############################################################################
-## This program is free software: you can redistribute it and/or modify
-## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation, either version 3 of the License, or
-## (at your option) any later version.
-##
-## This program is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-## GNU General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with this program.  If not, see <https://www.gnu.org/licenses/>.
-###############################################################################
+#
+# MIT License
+#
+# Copyright (c) PhotonVision
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 
 from .estimatedRobotPose import EstimatedRobotPose  # noqa
 from .packet import Packet  # noqa

--- a/photon-lib/py/setup.py
+++ b/photon-lib/py/setup.py
@@ -71,4 +71,7 @@ setup(
     author="Photonvision Development Team",
     long_description="A Pure-python implementation of PhotonLib",
     long_description_content_type="text/markdown",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+    ],
 )


### PR DESCRIPTION
Everything under the `photon-lib` directory is intended to all be licensed under MIT:

https://github.com/PhotonVision/photonvision/blob/e40c8fbca08e8397e00e35f72809ac69d752ad57/photon-lib/.styleguide-license#L2

Presumably we don't want to force teams to release their robot code under GPL.