### PR TITLE
Change default core mask to all cores

### DIFF
--- a/photon-core/src/main/java/org/photonvision/jni/RknnObjectDetector.java
+++ b/photon-core/src/main/java/org/photonvision/jni/RknnObjectDetector.java
@@ -68,7 +68,7 @@ public class RknnObjectDetector implements ObjectDetector {
 
         // Create the detector
         objPointer =
-                RknnJNI.create(model.modelFile.getPath(), model.labels.size(), model.version.ordinal(), -1);
+                RknnJNI.create(model.modelFile.getPath(), model.labels.size(), model.version.ordinal(), 210);
         if (objPointer <= 0) {
             throw new RuntimeException(
                     "Failed to create detector from path " + model.modelFile.getPath());


### PR DESCRIPTION
After some testing, we've found that using all cores all the time is the fastest option, even when running more than one object detection pipeline simultaneously. This is using `RKNN_NPU_CORE_0_1_2` instead `RKNN_NPU_CORE_AUTO`