### PR TITLE
Allow for non-quantized RKNN models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     joglVersion = "2.4.0"
     javalinVersion = "5.6.2"
     libcameraDriverVersion = "v2025.0.3"
-    rknnVersion = "v2025.0.0"
+    rknnVersion = "0cb57245c82b2252f7c23b7a6b5019a465a028e7"
     frcYear = "2025"
     mrcalVersion = "v2025.0.0";
 


### PR DESCRIPTION
Following this [PR](https://github.com/PhotonVision/rknn_jni/pull/16) in the rknn jni repo, I'm testing whether this works here, and will change the rknn version to the latest once it gets merged and fixed. 