### PR TITLE
Updated PhotonPoseEstimator examples

### DIFF
--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -102,17 +102,15 @@ Calling `update()` on your `PhotonPoseEstimator` will return an `EstimatedRobotP
 
    .. code-block:: C++
 
-    std::pair<frc::Pose2d, units::millisecond_t> getEstimatedGlobalPose(
+    std::Optional<EstimatedRobotPose> getEstimatedGlobalPose(
       frc::Pose3d prevEstimatedRobotPose) {
         robotPoseEstimator.SetReferencePose(prevEstimatedRobotPose);
-        units::millisecond_t currentTime = frc::Timer::GetFPGATimestamp();
-        auto result = robotPoseEstimator.Update();
-        if (result.second) {
-          return std::make_pair<>(result.first.ToPose2d(),
-                                  currentTime - result.second);
-        } else {
-          return std::make_pair(frc::Pose2d(), 0_ms);
+        std::Optional<EstimatedRobotPose> latest = std::nullopt;
+
+        for(auto result : camera.GetAllUnreadResults()) {
+            latest = robotPoseEstimator.Update(result);
         }
+        return latest;
     }
 
    .. code-block:: Python

--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -26,7 +26,8 @@ The API documentation can be found in here: [Java](https://github.wpilib.org/all
 
    .. code-block:: Python
 
-        # Coming Soon!
+      # The field from AprilTagField will be different depending on the game
+      kAprilTagFieldLayout = AprilTagFieldLayout.loadField(AprilTagField.kDefaultField)
 
 ```
 
@@ -77,7 +78,7 @@ The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (s
         )
 
         self.camPoseEst = PhotonPoseEstimator(
-            loadAprilTagLayoutField(AprilTagField.kDefaultField),
+            kAprilTagFieldLayout,
             PoseStrategy.CLOSEST_TO_REFERENCE_POSE,
             kRobotToCam
         )
@@ -102,11 +103,8 @@ Calling `update()` on your `PhotonPoseEstimator` will return an `EstimatedRobotP
 
    .. code-block:: C++
 
-    std::Optional<EstimatedRobotPose> getEstimatedGlobalPose(
-      frc::Pose3d prevEstimatedRobotPose) {
-        robotPoseEstimator.SetReferencePose(prevEstimatedRobotPose);
+    std::Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
         std::Optional<EstimatedRobotPose> latest = std::nullopt;
-
         for(auto result : camera.GetAllUnreadResults()) {
             latest = robotPoseEstimator.Update(result);
         }
@@ -115,7 +113,7 @@ Calling `update()` on your `PhotonPoseEstimator` will return an `EstimatedRobotP
 
    .. code-block:: Python
 
-      # Coming Soon!
+    # Coming Soon!
 
 ```
 

--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -21,7 +21,7 @@ The API documentation can be found in here: [Java](https://github.wpilib.org/all
 
    .. code-block:: C++
 
-      // The parameter for LoadAPrilTagLayoutField will be different depending on the game.
+      // The parameter for LoadAprilTagLayoutField will be different depending on the game.
       frc::AprilTagFieldLayout aprilTagFieldLayout = frc::LoadAprilTagLayoutField(frc::AprilTagField::kDefaultField);
 
    .. code-block:: Python
@@ -32,7 +32,7 @@ The API documentation can be found in here: [Java](https://github.wpilib.org/all
 
 ## Creating a `PhotonPoseEstimator`
 
-The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (see above), `PoseStrategy`, `PhotonCamera`, and `Transform3d`. `PoseStrategy` has six possible values:
+The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (see above), `PoseStrategy`, and `Transform3d`. `PoseStrategy` has six possible values:
 
 - MULTI_TAG_PNP_ON_COPROCESSOR
     - Calculates a new robot position estimate by combining all visible tag corners. Recommended for all teams as it will be the most accurate.
@@ -52,34 +52,22 @@ The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (s
 .. tab-set-code::
    .. code-block:: Java
 
-      //Forward Camera
-      cam = new PhotonCamera("testCamera");
+      //Forward Camera Location
       Transform3d robotToCam = new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0,0,0)); //Cam mounted facing forward, half a meter forward of center, half a meter up from center.
 
       // Construct PhotonPoseEstimator
-      PhotonPoseEstimator photonPoseEstimator = new PhotonPoseEstimator(aprilTagFieldLayout, PoseStrategy.CLOSEST_TO_REFERENCE_POSE, cam, robotToCam);
+      PhotonPoseEstimator photonPoseEstimator = new PhotonPoseEstimator(aprilTagFieldLayout, PoseStrategy.CLOSEST_TO_REFERENCE_POSE, robotToCam);
 
    .. code-block:: C++
 
-      // Forward Camera
-      std::shared_ptr<photonlib::PhotonCamera> cameraOne =
-          std::make_shared<photonlib::PhotonCamera>("testCamera");
       // Camera is mounted facing forward, half a meter forward of center, half a
       // meter up from center.
       frc::Transform3d robotToCam =
           frc::Transform3d(frc::Translation3d(0.5_m, 0_m, 0.5_m),
                           frc::Rotation3d(0_rad, 0_rad, 0_rad));
 
-      // ... Add other cameras here
-
-      // Assemble the list of cameras & mount locations
-      std::vector<
-          std::pair<std::shared_ptr<photonlib::PhotonCamera>, frc::Transform3d>>
-          cameras;
-      cameras.push_back(std::make_pair(cameraOne, robotToCam));
-
       photonlib::RobotPoseEstimator estimator(
-          aprilTags, photonlib::CLOSEST_TO_REFERENCE_POSE, cameras);
+          aprilTags, photonlib::CLOSEST_TO_REFERENCE_POSE, robotToCam);
 
    .. code-block:: Python
 
@@ -88,12 +76,9 @@ The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (s
             wpimath.geometry.Rotation3d.fromDegrees(0.0, -30.0, 0.0),
         )
 
-        self.cam = PhotonCamera("YOUR CAMERA NAME")
-
         self.camPoseEst = PhotonPoseEstimator(
             loadAprilTagLayoutField(AprilTagField.kDefaultField),
             PoseStrategy.CLOSEST_TO_REFERENCE_POSE,
-            self.cam,
             kRobotToCam
         )
 ```

--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -89,14 +89,21 @@ Calling `update()` on your `PhotonPoseEstimator` will return an `EstimatedRobotP
 
 ```{eval-rst}
 .. tab-set-code::
-   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/357d8a518a93f7a1f8084a79449249e613b605a7/photonlib-java-examples/apriltagExample/src/main/java/frc/robot/PhotonCameraWrapper.java
-      :language: java
-      :lines: 85-88
+   .. code-block:: Java
+      
+    public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
+        Optional<EstimatedRobotPose> visionEst = Optional.empty();
+        for (var change : camera.getAllUnreadResults()) {
+            visionEst = photonEstimator.update(change);
+            updateEstimationStdDevs(visionEst, change.getTargets());
+        }
+        return visionEst;
+    }
 
    .. code-block:: C++
 
-      std::pair<frc::Pose2d, units::millisecond_t> getEstimatedGlobalPose(
-          frc::Pose3d prevEstimatedRobotPose) {
+    std::pair<frc::Pose2d, units::millisecond_t> getEstimatedGlobalPose(
+      frc::Pose3d prevEstimatedRobotPose) {
         robotPoseEstimator.SetReferencePose(prevEstimatedRobotPose);
         units::millisecond_t currentTime = frc::Timer::GetFPGATimestamp();
         auto result = robotPoseEstimator.Update();
@@ -106,13 +113,11 @@ Calling `update()` on your `PhotonPoseEstimator` will return an `EstimatedRobotP
         } else {
           return std::make_pair(frc::Pose2d(), 0_ms);
         }
-      }
+    }
 
    .. code-block:: Python
 
       # Coming Soon!
-
-
 
 ```
 


### PR DESCRIPTION
Attempts to resolve #1759 and #1757 

Updated the AprilTags and PhotonPoseEstimator docs page to reflect the new PhotonPoseEstimator which no longer takes a camera in the constructor, and now uses getAllUnreadResults rather than getLatestResult. 

First time writing C++ so please review my syntax :) 
Not sure about the third python section either, as I couldn't find an updated version of the python documentation.