### PR TITLE
Cleanup Docs for PhotonPoseEstimator

### DIFF
--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -156,6 +156,6 @@ Updates the stored reference pose when using the CLOSEST_TO_REFERENCE_POSE strat
 
 Update the stored last pose. Useful for setting the initial estimate when using the CLOSEST_TO_LAST_POSE strategy.
 
-### `public void addHeadingData(double timestampSeconds, Rotation3d heading)`
+### `addHeadingData(double timestampSeconds, Rotation3d heading)`
 
 Adds robot heading data to be stored in buffer. Must be called periodically with a proper timestamp for the PNP_DISTANCE_TRIG_SOLVE and CONSTRAINED_SOLVEPNP strategies

--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -156,6 +156,6 @@ Updates the stored reference pose when using the CLOSEST_TO_REFERENCE_POSE strat
 
 Update the stored last pose. Useful for setting the initial estimate when using the CLOSEST_TO_LAST_POSE strategy.
 
-### `addHeadingData(double timestampSeconds, Rotation3d heading)`
+### `addHeadingData(double timestampSeconds, Rotation2d heading)`
 
 Adds robot heading data to be stored in buffer. Must be called periodically with a proper timestamp for the PNP_DISTANCE_TRIG_SOLVE and CONSTRAINED_SOLVEPNP strategies

--- a/docs/source/docs/programming/photonlib/robot-pose-estimator.md
+++ b/docs/source/docs/programming/photonlib/robot-pose-estimator.md
@@ -32,7 +32,7 @@ The API documentation can be found in here: [Java](https://github.wpilib.org/all
 
 ## Creating a `PhotonPoseEstimator`
 
-The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (see above), `PoseStrategy`, `PhotonCamera`, and `Transform3d`. `PoseStrategy` has six possible values:
+The PhotonPoseEstimator has a constructor that takes an `AprilTagFieldLayout` (see above), `PoseStrategy`, `PhotonCamera`, and `Transform3d`. `PoseStrategy` has nine possible values:
 
 - MULTI_TAG_PNP_ON_COPROCESSOR
     - Calculates a new robot position estimate by combining all visible tag corners. Recommended for all teams as it will be the most accurate.
@@ -155,3 +155,7 @@ Updates the stored reference pose when using the CLOSEST_TO_REFERENCE_POSE strat
 ### `setLastPose(Pose3d lastPose)`
 
 Update the stored last pose. Useful for setting the initial estimate when using the CLOSEST_TO_LAST_POSE strategy.
+
+### `public void addHeadingData(double timestampSeconds, Rotation3d heading)`
+
+Adds robot heading data to be stored in buffer. Must be called periodically with a proper timestamp for the PNP_DISTANCE_TRIG_SOLVE and CONSTRAINED_SOLVEPNP strategies


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

Small cleanups in docs for the new photonPoseEstimator strategies. 

There's a stalled pr for the 2025 version of the update() function so I didn't change that portion. 
https://github.com/PhotonVision/photonvision/pull/1765 

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR addresses a bug, a regression test for it is added
