### PR TITLE
Fix snapshot methods not working

### DIFF
--- a/photon-client/src/components/app/photon-camera-stream.vue
+++ b/photon-client/src/components/app/photon-camera-stream.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, ref, onBeforeUnmount } from "vue";
 import { useStateStore } from "@/stores/StateStore";
+import { useCameraSettingsStore } from "@/stores/settings/CameraSettingsStore";
 import loadingImage from "@/assets/images/loading-transparent.svg";
 import type { StyleValue } from "vue/types/jsx";
 import PvIcon from "@/components/common/pv-icon.vue";
@@ -58,9 +59,9 @@ const overlayStyle = computed<StyleValue>(() => {
 
 const handleCaptureClick = () => {
   if (props.streamType === "Raw") {
-    props.cameraSettings.pipelineSettings[props.cameraSettings.currentPipelineIndex].saveInputSnapshot();
+    useCameraSettingsStore().saveInputSnapshot();
   } else {
-    props.cameraSettings.pipelineSettings[props.cameraSettings.currentPipelineIndex].saveOutputSnapshot();
+    useCameraSettingsStore().saveOutputSnapshot();
   }
 };
 const handlePopoutClick = () => {

--- a/photon-core/src/main/java/org/photonvision/vision/frame/consumer/FileSaveFrameConsumer.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/consumer/FileSaveFrameConsumer.java
@@ -39,7 +39,7 @@ public class FileSaveFrameConsumer implements Consumer<CVMat> {
     private final Logger logger = new Logger(FileSaveFrameConsumer.class, LogGroup.General);
 
     // match type's values from the FMS.
-    private static final String[] matchTypes = {"N/A", "P", "Q", "E", "EV"};
+    private static final String[] matchTypes = {"None", "P", "Q", "E", "EV"};
 
     // Formatters to generate unique, timestamped file names
     private static final String FILE_PATH = ConfigManager.getInstance().getImageSavePath().toString();
@@ -74,7 +74,7 @@ public class FileSaveFrameConsumer implements Consumer<CVMat> {
 
         NetworkTable fmsTable = NetworkTablesManager.getInstance().getNTInst().getTable("FMSInfo");
         this.ntEventName = fmsTable.getStringTopic("EventName").subscribe("UNKNOWN");
-        this.ntMatchNum = fmsTable.getIntegerTopic("MatchNumber").subscribe(-1);
+        this.ntMatchNum = fmsTable.getIntegerTopic("MatchNumber").subscribe(0);
         this.ntMatchType = fmsTable.getIntegerTopic("MatchType").subscribe(0);
 
         updateCameraNickname(camNickname);
@@ -146,18 +146,18 @@ public class FileSaveFrameConsumer implements Consumer<CVMat> {
 
     /**
      * Returns the match Data collected from the NT. eg : Q58 for qualification match 58. If not in
-     * event, returns N/A-0-EVENTNAME
+     * event, returns None-0-Unknown
      */
     private String getMatchData() {
         var matchType = ntMatchType.getAtomic();
         if (matchType.timestamp == 0) {
             // no NT info yet
-            logger.warn("Did not receive match type, defaulting to 0");
+            logger.warn("Did not receive match type, defaulting to None");
         }
 
         var matchNum = ntMatchNum.getAtomic();
         if (matchNum.timestamp == 0) {
-            logger.warn("Did not receive match num, defaulting to -1");
+            logger.warn("Did not receive match num, defaulting to 0");
         }
 
         var eventName = ntEventName.getAtomic();


### PR DESCRIPTION
## Description
It seems like the slash in `N/A` caused the image to not get saved. Amusingly enough, I bet if you tried to take a snapshot while connected to FMS, it would work, but it would never work anywhere else. PR that introduced this bug seems to be #1460, which matches with my own manual testing of old JARs.

In addition, it seems like #1556 also broke the snapshot button in the UI. Not quite sure what happened here, but it seems like an object from UiCameraConfiguration was being used when the CameraSettingsStore should've been used instead.

Here's the new format:
![image](https://github.com/user-attachments/assets/413c8df6-e7c4-4847-8c3c-016cb4645c4c)

Closes #1793.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR addresses a bug, a regression test for it is added
