### PR TITLE
Increase precision on displayed target distance

### DIFF
--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -108,8 +108,8 @@ const resetCurrentBuffer = () => {
                 <td class="text-center">{{ target.area.toFixed(2) }}&deg;</td>
               </template>
               <template v-else>
-                <td class="text-center">{{ target.pose?.x.toFixed(2) }}&nbsp;m</td>
-                <td class="text-center">{{ target.pose?.y.toFixed(2) }}&nbsp;m</td>
+                <td class="text-center">{{ target.pose?.x.toFixed(3) }}&nbsp;m</td>
+                <td class="text-center">{{ target.pose?.y.toFixed(3) }}&nbsp;m</td>
                 <td class="text-center">{{ toDeg(target.pose?.angle_z || 0).toFixed(2) }}&deg;</td>
               </template>
               <template
@@ -157,13 +157,13 @@ const resetCurrentBuffer = () => {
             <tbody v-show="useStateStore().currentPipelineResults?.multitagResult">
               <tr>
                 <td class="text-center white--text">
-                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.x.toFixed(2) }}&nbsp;m
+                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.x.toFixed(3) }}&nbsp;m
                 </td>
                 <td class="text-center white--text">
-                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(2) }}&nbsp;m
+                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(3) }}&nbsp;m
                 </td>
                 <td class="text-center white--text">
-                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.z.toFixed(2) }}&nbsp;m
+                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.z.toFixed(3) }}&nbsp;m
                 </td>
                 <td class="text-center white--text">
                   {{


### PR DESCRIPTION
## Description

The precision on the 3D distance was a little low, so the precision has been increased by one decimal point.

Closes #1831

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR addresses a bug, a regression test for it is added
