### PR TITLE
Document UI hot reload option in dev docs

### DIFF
--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -69,6 +69,16 @@ In the root directory:
       ``gradlew buildAndCopyUI``
 ```
 
+### Using hot reload on the UI
+
+In the photon-client directory:
+
+```bash
+npm run dev
+```
+
+This allows you to make UI changes quickly without having to spend time rebuilding the jar. Hot reload is enabled, so changes that you make and save are reflected in the UI immediately. Running this command will give you the URL for accessing the UI, which is on a different port than normal. You must use the printed URL to use hot reload.
+
 ### Build and Run PhotonVision
 
 To compile and run the project, issue the following command in the root directory:


### PR DESCRIPTION
## Description

`npm run dev` is a much faster way of doing UI work without having to rebuild the JAR. It wasn't documented, and this adds documentation for that.
Closes #1829.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR addresses a bug, a regression test for it is added
