### PR TITLE
Add an error when the connection for the end calibration request fails

### DIFF
--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -182,8 +182,10 @@ const startCalibration = () => {
 const showCalibEndDialog = ref(false);
 const calibCanceled = ref(false);
 const calibSuccess = ref<boolean | undefined>(undefined);
+const calibEndpointFail = ref(false);
 const endCalibration = () => {
   calibSuccess.value = undefined;
+  calibEndpointFail.value = false;
 
   if (!useStateStore().calibrationData.hasEnoughImages) {
     calibCanceled.value = true;
@@ -196,7 +198,13 @@ const endCalibration = () => {
     .then(() => {
       calibSuccess.value = true;
     })
-    .catch(() => {
+    .catch((e) => {
+      if (e.response) {
+        // Server returned a status code
+      } else if (e.request) {
+        // Something went wrong. Unsure if calibration actually worked
+        calibEndpointFail.value = true;
+      }
       calibSuccess.value = false;
     })
     .finally(() => {
@@ -524,6 +532,13 @@ const setSelectedVideoFormat = (format: VideoFormat) => {
                 )?.name
               }}!
             </v-card-text>
+          </template>
+          <template v-else-if="calibEndpointFail">
+            <v-icon color="gray" size="70"> mdi-help-circle-outline </v-icon>
+            <v-card-text
+              >Unable to determine if calibration was successful. Refresh this page and manually check if calibration
+              was successful.</v-card-text
+            >
           </template>
           <template v-else>
             <v-icon color="red" size="70"> mdi-close </v-icon>

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -210,7 +210,7 @@ public class Calibrate3dPipeline
         broadcastState();
     }
 
-    private void broadcastState() {
+    public void broadcastState() {
         var state =
                 SerializationUtils.objectToHashMap(
                         new UICalibrationData(

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -395,6 +395,7 @@ public class VisionModule {
         settings.cameraAutoExposure = true;
 
         setPipeline(PipelineManager.CAL_3D_INDEX);
+        pipelineManager.calibration3dPipeline.broadcastState();
     }
 
     public void saveInputSnapshot() {


### PR DESCRIPTION
## Description

When the HTTP request to end calibration fails with a network error, the UI will show that the calibration failed, despite the fact the calibration may have actually succeeded on the server. This is most evident when you take hundreds of calibration images, and you need to wait a few minutes for the request to process. If the connection drops out for any reason (unstable connection due to use of the 2.4 GHz radio mode, or otherwise) users will now see a third error screen telling them they need to refresh the page to check the calibration manually.

This also changes the backend to broadcast out the calibration state when starting a calibration, which allows the state to be resynced if this error shows up.

![Screenshot 2025-03-22 112254](https://github.com/user-attachments/assets/7b9936f9-897e-4f23-ba56-4373848c9b10)

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR addresses a bug, a regression test for it is added
