### PR TITLE
Dont sanitize unique name in calibration JSON HTTP URL

### DIFF
--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -478,7 +478,7 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
       const url = new URL(`http://${host}/api/utils/getCalibrationJSON`);
       url.searchParams.set("width", Math.round(resolution.width).toFixed(0));
       url.searchParams.set("height", Math.round(resolution.height).toFixed(0));
-      url.searchParams.set("cameraUniqueName", cameraUniqueName.replace(" ", "").trim().toLowerCase());
+      url.searchParams.set("cameraUniqueName", cameraUniqueName);
 
       return url.href;
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/PhotonVision/photonvision/issues/1845 , which was caused by us sanitizing stuff we shouldn't've been. We now hit the URL we ought to, and respect capitalization and weird symbols. Because this is a UI/Backend interaction, we can't easily test for it automatically.

![image](https://github.com/user-attachments/assets/18f8492d-baff-4386-a9e3-eb091094b986)

@Juniormunk any context on -why- we had added this in https://github.com/Juniormunk/photonvision/commit/1f801cda5a30ed3c25e99199cbea5b08ae640d78#r154266807 ?


## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR addresses a bug, a regression test for it is added
