### PR TITLE
chore[docs]: Recommend ethernet tether over port forwarding for VH-109

### DIFF
--- a/docs/source/docs/quick-start/networking.md
+++ b/docs/source/docs/quick-start/networking.md
@@ -66,6 +66,10 @@ you can set the team number to "localhost", and PhotonVision will send data to t
 
 ## Port Forwarding
 
+:::{note}
+If you are using a VH-109 radio (2025 and later, excluding China and Taiwan), you should not use port forwarding. Instead, tether to the dedicated DS ethernet port on the VH-109. The VH-109 does not exhibit the issues found in the OM5P radio with multiple ports, and with a dedicated DS port, it provides more realistic match conditions and removes the need to tether over USB.
+:::
+
 If you would like to access your Ethernet-connected vision device from a computer when tethered to the USB port on the roboRIO, you can use [WPILib's](https://docs.wpilib.org/en/stable/docs/networking/networking-utilities/portforwarding.html) `PortForwarder`.
 
 ```{eval-rst}


### PR DESCRIPTION
closes #1825

The new radio has four ethernet ports, and one dedicated port for the DS.  There's no reason for teams to tether to the roborio via USB-B, and tethering via radio will provide more realistic match conditions. Therefore, recommend tethering via radio.

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [x] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [x] If this PR addresses a bug, a regression test for it is added
