### PR TITLE
feat: link methods in javadocs to source code

### DIFF
--- a/photon-docs/build.gradle
+++ b/photon-docs/build.gradle
@@ -129,6 +129,7 @@ task generateJavaDocs(type: Javadoc) {
     options.addStringOption("tag", "pre:a:Pre-Condition")
     options.addBooleanOption("Xdoclint:html,missing,reference,syntax", true)
     options.addBooleanOption('html5', true)
+    options.linkSource(true)
     failOnError = true
 
     title = "PhotonVision $pubVersion"


### PR DESCRIPTION
## Description

When in javadocs, clicking on a method will open the source code for that method.  This is currently implemented for the WPILib javadocs, and I'm just stealing it from there.

closes #1865 

## Meta

Merge checklist:
- [X] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [X] The description documents the _what_ and _why_
- [X] If this PR changes behavior or adds a feature, user documentation is updated
- [X] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [X] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [X] If this PR addresses a bug, a regression test for it is added
