### PR TITLE
[docs] Update "About Pipelines" list

### DIFF
--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -26,13 +26,13 @@ This pipeline type is based on detecting objects using a neural network. The obj
 This pipeline type is only available on the Orange Pi 5/5+ coprocessors due to its Neural Processing Unit used by PhotonVision to support running ML-based object detection.
 :::
 
-### Reflective
-
-This pipeline type is based on detecting targets with 3M retro-reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
-
 ### Colored Shape
 
 This pipeline type is based on detecting different shapes like circles, triangles, quadrilaterals, or a polygon. An example usage would be detecting yellow PowerCells from the 2020 FRC game. You can read more about the specific settings available in the contours page.
+
+### Reflective
+
+This pipeline type is based on detecting targets with 3M retro-reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
 
 ## Note About Multiple Cameras and Pipelines
 

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -10,21 +10,21 @@ A vision pipeline represents a series of steps that are used to acquire an image
 
 ## Types of Pipelines
 
-### Reflective
-
-This is the most common pipeline type and it is based on detecting targets with retroreflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
-
-### Colored Shape
-
-This pipeline type is based on detecting different shapes like circles, triangles, quadrilaterals, or a polygon. An example usage would be detecting yellow PowerCells from the 2020 FRC game. You can read more about the specific settings available in the contours page.
-
 ### AprilTag / AruCo
 
-This pipeline type is based on detecting AprilTag fiducial markers. More information about AprilTags can be found in the WPILib documentation. While being more performance intensive than the reflective and colored shape pipeline, it has the benefit of providing easy to use 3D pose information which allows localization.
+This pipeline type is based on detecting AprilTag fiducial markers. More information about AprilTags can be found in the [WPILib documentation](https://docs.wpilib.org/en/stable/docs/software/vision-processing/apriltag/apriltag-intro.html). While being more performance intensive than the reflective and colored shape pipeline, it has the benefit of providing easy to use 3D pose information which allows localization.
 
 :::{note}
 In order to get 3D Pose data about AprilTags, you are required to {ref}`calibrate your camera<docs/calibration/calibration:Calibrating Your Camera>`.
 :::
+
+### Reflective
+
+This pipeline type is based on detecting targets with 3m retro-reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
+
+### Colored Shape
+
+This pipeline type is based on detecting different shapes like circles, triangles, quadrilaterals, or a polygon. An example usage would be detecting yellow PowerCells from the 2020 FRC game. You can read more about the specific settings available in the contours page.
 
 ## Note About Multiple Cameras and Pipelines
 

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -42,25 +42,25 @@ This pipeline type is not used anymore due to FRC's removal of retro-reflective 
 
 When using more than one camera, it is important to keep in mind that all cameras run one pipeline each, all publish to NT, and all send both streams. This will have a noticeable affect on performance and we recommend users limit themselves to 1-2 cameras per coprocessor.
 
-## Pipeline Steps
+## Pipeline Configuration
 
-All pipelines follow a similar structure with an Input and Output step.
+Each pipeline has a set of tabs that are used to configure the pipeline. All pipelines follow a similar structure with an Input and Output tab, as well as a set of tabs that are specific to the pipeline type.
 
 - Input: This tab allows the raw camera image to be modified before it gets processed. Here, you can set exposure, brightness, gain, orientation, and resolution.
 
 - Output: This allows you to manipulate the detected target via the target offset point (for calculating pitch/yaw) and robot (crosshair) offset. In addition, it allows users to send additional (up to 5) outputs through PhotonLib.
 
-Pipielines also have additional steps that are specific to the pipeline type. Listed below are the steps for each pipeline type.
-
-### Reflective and Colored Shape Pipelines
-
-- Threshold: This tabs allows you to filter our specific colors/pixels in your camera stream through HSV tuning. The end goal here is having a black and white image that will only have your target lit up.
-- Contours: After thresholding, contiguous white pixels are grouped together, and described by a curve that outlines the group. This curve is called a "contour" which represent various targets on your screen. Regardless of type, you can filter how the targets are grouped, their intersection, and how the targets are sorted. Other available filters will change based on different pipeline types.
+Pipielines also have additional tabs that are specific to the pipeline type. Listed below are the tabs for each pipeline type.
 
 ### AprilTag / AruCo Pipelines
 
-- AprilTag: This step includes AprilTag specific tuning parameters, such as decimate, blur, threads, pose iterations, and more.
+- AprilTag: This tab includes AprilTag specific tuning parameters, such as decimate, blur, threads, pose iterations, and more.
 
 ### Object Detection Pipelines
 
-- Object Detection: This step allows you to filter results from the neural network, such as confidence, area, and width/height ratio. The end goal of this step is to filter out any false positives.
+- Object Detection: This tab allows you to filter results from the neural network, such as confidence, area, and width/height ratio. The end goal of this tab is to filter out any false positives.
+
+### Reflective and Colored Shape Pipelines
+
+- Threshold: This tab allows you to filter out specific colors/pixels in your camera stream through HSV tuning. The end goal here is having a black and white image that will only have your target lit up.
+- Contours: After thresholding, contiguous white pixels are grouped together, and described by a curve that outlines the group. This curve is called a "contour" which represent various targets on your screen. Regardless of type, you can filter how the targets are grouped, their intersection, and how the targets are sorted. Other available filters will change based on different pipeline types.

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -18,9 +18,17 @@ This pipeline type is based on detecting AprilTag fiducial markers. More informa
 In order to get 3D Pose data about AprilTags, you are required to {ref}`calibrate your camera<docs/calibration/calibration:Calibrating Your Camera>`.
 :::
 
+### Object Detection
+
+This pipeline type is based on detecting objects using a neural network. The object detection pipeline uses a pre-trained model to detect objects in the camera stream.
+
+:::{note}
+This pipeline type is only available on the Orange Pi 5/5+ coprocessors due to its Neural Processing Unit used by PhotonVision to support running ML-based object detection.
+:::
+
 ### Reflective
 
-This pipeline type is based on detecting targets with 3m retro-reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
+This pipeline type is based on detecting targets with 3M retro-reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
 
 ### Colored Shape
 

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -20,7 +20,7 @@ In order to get 3D Pose data about AprilTags, you are required to {ref}`calibrat
 
 ### Object Detection
 
-This pipeline type is based on detecting objects using a neural network. The object detection pipeline uses a pre-trained model to detect objects in the camera stream.
+This pipeline type is based on detecting objects using a neural network. The object detection pipeline uses a pre-trained model to detect objects in the camera stream. In the object detection tab of this pipeline type, you can configure the confidence threshold and apply filters based on area and width/height ratio.
 
 :::{note}
 This pipeline type is only available on the Orange Pi 5/5+ coprocessors due to its Neural Processing Unit used by PhotonVision to support running ML-based object detection.

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -57,7 +57,7 @@ AprilTag / AruCo Pipelines have 3 steps:
 2. AprilTag: This step include AprilTag specific tuning parameters, such as decimate, blur, threads, pose iterations, and more.
 3. Output: This is the same as the above.
 
-Object Detection Pipelines have 2 steps:
+Object Detection Pipelines have 3 steps:
 
 1. Input: This is the same as the above.
 2. Object Detection: This step allows you to filter results from the neural network, such as confidence, area, and width/height ratio. The end goal of this step is to filter out any false positives.

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -44,21 +44,23 @@ When using more than one camera, it is important to keep in mind that all camera
 
 ## Pipeline Steps
 
-Reflective and Colored Shape Pipelines have 4 steps (represented as 4 tabs):
+All pipelines follow a similar structure with an Input and Output step.
 
-1. Input: This tab allows the raw camera image to be modified before it gets processed. Here, you can set exposure, brightness, gain, orientation, and resolution.
-2. Threshold (Only Reflective and Colored Shape): This tabs allows you to filter our specific colors/pixels in your camera stream through HSV tuning. The end goal here is having a black and white image that will only have your target lit up.
-3. Contours: After thresholding, contiguous white pixels are grouped together, and described by a curve that outlines the group. This curve is called a "contour" which represent various targets on your screen. Regardless of type, you can filter how the targets are grouped, their intersection, and how the targets are sorted. Other available filters will change based on different pipeline types.
-4. Output: Now that you have filtered all of your contours, this allows you to manipulate the detected target via orientation, the offset point, and offset.
+- Input: This tab allows the raw camera image to be modified before it gets processed. Here, you can set exposure, brightness, gain, orientation, and resolution.
 
-AprilTag / AruCo Pipelines have 3 steps:
+- Output: This allows you to manipulate the detected target via the target offset point (for calculating pitch/yaw) and robot (crosshair) offset. In addition, it allows users to send additional (up to 5) outputs through PhotonLib.
 
-1. Input: This is the same as the above.
-2. AprilTag: This step include AprilTag specific tuning parameters, such as decimate, blur, threads, pose iterations, and more.
-3. Output: This is the same as the above.
+Pipielines also have additional steps that are specific to the pipeline type. Listed below are the steps for each pipeline type.
 
-Object Detection Pipelines have 3 steps:
+### Reflective and Colored Shape Pipelines
 
-1. Input: This is the same as the above.
-2. Object Detection: This step allows you to filter results from the neural network, such as confidence, area, and width/height ratio. The end goal of this step is to filter out any false positives.
-3. Output: This is the same as the above.
+- Threshold: This tabs allows you to filter our specific colors/pixels in your camera stream through HSV tuning. The end goal here is having a black and white image that will only have your target lit up.
+- Contours: After thresholding, contiguous white pixels are grouped together, and described by a curve that outlines the group. This curve is called a "contour" which represent various targets on your screen. Regardless of type, you can filter how the targets are grouped, their intersection, and how the targets are sorted. Other available filters will change based on different pipeline types.
+
+### AprilTag / AruCo Pipelines
+
+- AprilTag: This step includes AprilTag specific tuning parameters, such as decimate, blur, threads, pose iterations, and more.
+
+### Object Detection Pipelines
+
+- Object Detection: This step allows you to filter results from the neural network, such as confidence, area, and width/height ratio. The end goal of this step is to filter out any false positives.

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -20,10 +20,10 @@ In order to get 3D Pose data about AprilTags, you are required to {ref}`calibrat
 
 ### Object Detection
 
-This pipeline type is based on detecting objects using a neural network. The object detection pipeline uses a pre-trained model to detect objects in the camera stream. In the object detection tab of this pipeline type, you can configure the confidence threshold and apply filters based on area and width/height ratio.
+This pipeline type is based on detecting objects using a neural network. The object detection pipeline uses a pre-trained model to detect objects in the camera stream.
 
 :::{note}
-This pipeline type is only available on the Orange Pi 5/5+ coprocessors due to its Neural Processing Unit used by PhotonVision to support running ML-based object detection.
+This pipeline type is only supported on the Orange Pi 5/5+ coprocessors due to its Neural Processing Unit used by PhotonVision to support running ML-based object detection.
 :::
 
 ### Colored Shape
@@ -32,7 +32,7 @@ This pipeline type is based on detecting different shapes like circles, triangle
 
 ### Reflective
 
-This pipeline type is based on detecting targets with 3M retro-reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
+This pipeline type is based on detecting targets with reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
 
 :::{note}
 This pipeline type is not used anymore due to FRC's removal of retro-reflective tape from the game. It is still available as a pipeline for legacy purposes.

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -34,6 +34,10 @@ This pipeline type is based on detecting different shapes like circles, triangle
 
 This pipeline type is based on detecting targets with 3M retro-reflective tape. In the contours tab of this pipeline type, you can filter the area, width/height ratio, fullness, degree of speckle rejection.
 
+:::{note}
+This pipeline type is not used anymore due to FRC's removal of retro-reflective tape from the game. It is still available as a pipeline for legacy purposes.
+:::
+
 ## Note About Multiple Cameras and Pipelines
 
 When using more than one camera, it is important to keep in mind that all cameras run one pipeline each, all publish to NT, and all send both streams. This will have a noticeable affect on performance and we recommend users limit themselves to 1-2 cameras per coprocessor.

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -56,3 +56,9 @@ AprilTag / AruCo Pipelines have 3 steps:
 1. Input: This is the same as the above.
 2. AprilTag: This step include AprilTag specific tuning parameters, such as decimate, blur, threads, pose iterations, and more.
 3. Output: This is the same as the above.
+
+Object Detection Pipelines have 2 steps:
+
+1. Input: This is the same as the above.
+2. Object Detection: This step allows you to filter results from the neural network, such as confidence, area, and width/height ratio. The end goal of this step is to filter out any false positives.
+3. Output: This is the same as the above.

--- a/docs/source/docs/pipelines/about-pipelines.md
+++ b/docs/source/docs/pipelines/about-pipelines.md
@@ -12,7 +12,7 @@ A vision pipeline represents a series of steps that are used to acquire an image
 
 ### AprilTag / AruCo
 
-This pipeline type is based on detecting AprilTag fiducial markers. More information about AprilTags can be found in the [WPILib documentation](https://docs.wpilib.org/en/stable/docs/software/vision-processing/apriltag/apriltag-intro.html). While being more performance intensive than the reflective and colored shape pipeline, it has the benefit of providing easy to use 3D pose information which allows localization.
+This pipeline type is based on detecting AprilTag fiducial markers. More information about AprilTags can be found in the [WPILib documentation](https://docs.wpilib.org/en/stable/docs/software/vision-processing/apriltag/apriltag-intro.html). This pipeline provides easy to use 3D pose information which allows localization.
 
 :::{note}
 In order to get 3D Pose data about AprilTags, you are required to {ref}`calibrate your camera<docs/calibration/calibration:Calibrating Your Camera>`.


### PR DESCRIPTION
## Description

In the [About Pipelines](https://docs.photonvision.org/en/latest/docs/pipelines/about-pipelines.html#types-of-pipelines) page, move the reflective pipeline down the list because students don't encounter this after FIRST removed it from their games. Also, mention object detection as a pipeline type.

Closes #1849 

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [x] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [x] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [x] If this PR addresses a bug, a regression test for it is added
