### PR TITLE
[photon-lib] Fix incorrect tag visualization transforms

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
@@ -84,15 +84,17 @@ public class VideoSimUtil {
      * Gets the points representing the corners of this image. Because image pixels are accessed
      * through a Mat, the point (0,0) actually represents the center of the top-left pixel and not the
      * actual top-left corner.
+     * 
+     * Order of corners returned is: [BL, BR, TR, TL]
      *
      * @param size Size of image
      */
     public static Point[] getImageCorners(Size size) {
         return new Point[] {
-            new Point(-0.5, -0.5),
-            new Point(size.width - 0.5, -0.5),
+            new Point(-0.5, size.height - 0.5),
             new Point(size.width - 0.5, size.height - 0.5),
-            new Point(-0.5, size.height - 0.5)
+            new Point(size.width - 0.5, -0.5),
+            new Point(-0.5, -0.5)
         };
     }
 

--- a/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
@@ -84,8 +84,8 @@ public class VideoSimUtil {
      * Gets the points representing the corners of this image. Because image pixels are accessed
      * through a Mat, the point (0,0) actually represents the center of the top-left pixel and not the
      * actual top-left corner.
-     * 
-     * Order of corners returned is: [BL, BR, TR, TL]
+     *
+     * <p>Order of corners returned is: [BL, BR, TR, TL]
      *
      * @param size Size of image
      */

--- a/photon-lib/src/main/native/include/photon/simulation/VideoSimUtil.h
+++ b/photon-lib/src/main/native/include/photon/simulation/VideoSimUtil.h
@@ -76,10 +76,10 @@ static std::unordered_map<int, cv::Mat> LoadAprilTagImages() {
 
 static std::vector<cv::Point2f> GetImageCorners(const cv::Size& size) {
   std::vector<cv::Point2f> retVal{};
-  retVal.emplace_back(cv::Point2f{-0.5f, -0.5f});
-  retVal.emplace_back(cv::Point2f{size.width - 0.5f, -0.5f});
-  retVal.emplace_back(cv::Point2f{size.width - 0.5f, size.height - 0.5f});
   retVal.emplace_back(cv::Point2f{-0.5f, size.height - 0.5f});
+  retVal.emplace_back(cv::Point2f{size.width - 0.5f, size.height - 0.5f});
+  retVal.emplace_back(cv::Point2f{size.width - 0.5f, -0.5f});
+  retVal.emplace_back(cv::Point2f{-0.5f, -0.5f});
   return retVal;
 }
 


### PR DESCRIPTION
## Description

Fixes #1239

Tag image corners used in `VideoSimUtil` did not match the expected corner order returned by the detection pipeline of [BL, BR, TR, TL], causing the tag image to appear flipped.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR addresses a bug, a regression test for it is added
