### PR TITLE
remove core and server from javadocs

### DIFF
--- a/photon-docs/build.gradle
+++ b/photon-docs/build.gradle
@@ -115,8 +115,6 @@ ext {
 
 task generateJavaDocs(type: Javadoc) {
     def exportedProjects = [
-        ':photon-core',
-        ':photon-server',
         ':photon-targeting',
         ':photon-lib'
     ]

--- a/photon-docs/build.gradle
+++ b/photon-docs/build.gradle
@@ -121,7 +121,6 @@ task generateJavaDocs(type: Javadoc) {
 
     source exportedProjects.collect { project(it).sourceSets.main.allJava }
     classpath = files(exportedProjects.collect { project(it).sourceSets.main.compileClasspath })
-    dependsOn project(':photon-core').writeCurrentVersion
 
     options.links "https://docs.oracle.com/en/java/javase/17/docs/api/", "https://github.wpilib.org/allwpilib/docs/release/java/"
     options.addStringOption("tag", "pre:a:Pre-Condition")


### PR DESCRIPTION
## Description

The javadocs should reflect only what is shipped in the vendordep.  Currently, photon-core and photon-server are not shipped with the vendordep, therefore they are being removed from the javadoc.

## Meta

Merge checklist:
- [X] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [X] The description documents the _what_ and _why_
- [X] If this PR changes behavior or adds a feature, user documentation is updated
- [X] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [X] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [X] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [X] If this PR addresses a bug, a regression test for it is added
