### PR TITLE
Add camera mismatch banner to dashboard

### DIFF
--- a/photon-client/src/lib/MatchingUtils.ts
+++ b/photon-client/src/lib/MatchingUtils.ts
@@ -1,6 +1,11 @@
-import { useStateStore } from "@/stores/StateStore";
 import { PVCameraInfo, type PVCSICameraInfo, type PVFileCameraInfo, type PVUsbCameraInfo } from "@/types/SettingTypes";
 
+/**
+ * Check if two cameras match by comparing properties.
+ * For USB cameras, it checks the name, vendorId, productId, and uniquePath.
+ * For CSI cameras, it checks the uniquePath and baseName.
+ * For file cameras, it checks the uniquePath and name.
+ */
 export const camerasMatch = (camera1: PVCameraInfo, camera2: PVCameraInfo) => {
   if (camera1.PVUsbCameraInfo && camera2.PVUsbCameraInfo)
     return (
@@ -22,6 +27,9 @@ export const camerasMatch = (camera1: PVCameraInfo, camera2: PVCameraInfo) => {
   else return false;
 };
 
+/**
+ * Get the connection-type-specific camera info from the given PVCameraInfo object.
+ */
 export const cameraInfoFor = (
   camera: PVCameraInfo | null
 ): PVUsbCameraInfo | PVCSICameraInfo | PVFileCameraInfo | any => {
@@ -39,7 +47,7 @@ export const cameraInfoFor = (
 };
 
 /**
- * Find the PVCameraInfo currently occupying the same uniquepath as the the given module
+ * Find the PVCameraInfo currently occupying the same uniquePath as the the given module
  */
 export const getMatchedDevice = (allDevices: PVCameraInfo[], info: PVCameraInfo | undefined): PVCameraInfo => {
   if (!info) {

--- a/photon-client/src/lib/MatchingUtils.ts
+++ b/photon-client/src/lib/MatchingUtils.ts
@@ -41,7 +41,7 @@ export const cameraInfoFor = (
 /**
  * Find the PVCameraInfo currently occupying the same uniquepath as the the given module
  */
-export const getMatchedDevice = (info: PVCameraInfo | undefined): PVCameraInfo => {
+export const getMatchedDevice = (allDevices: PVCameraInfo[], info: PVCameraInfo | undefined): PVCameraInfo => {
   if (!info) {
     return {
       PVFileCameraInfo: undefined,
@@ -50,9 +50,7 @@ export const getMatchedDevice = (info: PVCameraInfo | undefined): PVCameraInfo =
     };
   }
   return (
-    useStateStore().vsmState.allConnectedCameras.find(
-      (it) => cameraInfoFor(it).uniquePath === cameraInfoFor(info).uniquePath
-    ) || {
+    allDevices.find((it) => cameraInfoFor(it).uniquePath === cameraInfoFor(info).uniquePath) || {
       PVFileCameraInfo: undefined,
       PVCSICameraInfo: undefined,
       PVUsbCameraInfo: undefined

--- a/photon-client/src/lib/MatchingUtils.ts
+++ b/photon-client/src/lib/MatchingUtils.ts
@@ -1,0 +1,61 @@
+import { useStateStore } from "@/stores/StateStore";
+import { PVCameraInfo, type PVCSICameraInfo, type PVFileCameraInfo, type PVUsbCameraInfo } from "@/types/SettingTypes";
+
+export const camerasMatch = (camera1: PVCameraInfo, camera2: PVCameraInfo) => {
+  if (camera1.PVUsbCameraInfo && camera2.PVUsbCameraInfo)
+    return (
+      camera1.PVUsbCameraInfo.name === camera2.PVUsbCameraInfo.name &&
+      camera1.PVUsbCameraInfo.vendorId === camera2.PVUsbCameraInfo.vendorId &&
+      camera1.PVUsbCameraInfo.productId === camera2.PVUsbCameraInfo.productId &&
+      camera1.PVUsbCameraInfo.uniquePath === camera2.PVUsbCameraInfo.uniquePath
+    );
+  else if (camera1.PVCSICameraInfo && camera2.PVCSICameraInfo)
+    return (
+      camera1.PVCSICameraInfo.uniquePath === camera2.PVCSICameraInfo.uniquePath &&
+      camera1.PVCSICameraInfo.baseName === camera2.PVCSICameraInfo.baseName
+    );
+  else if (camera1.PVFileCameraInfo && camera2.PVFileCameraInfo)
+    return (
+      camera1.PVFileCameraInfo.uniquePath === camera2.PVFileCameraInfo.uniquePath &&
+      camera1.PVFileCameraInfo.name === camera2.PVFileCameraInfo.name
+    );
+  else return false;
+};
+
+export const cameraInfoFor = (
+  camera: PVCameraInfo | null
+): PVUsbCameraInfo | PVCSICameraInfo | PVFileCameraInfo | any => {
+  if (!camera) return null;
+  if (camera.PVUsbCameraInfo) {
+    return camera.PVUsbCameraInfo;
+  }
+  if (camera.PVCSICameraInfo) {
+    return camera.PVCSICameraInfo;
+  }
+  if (camera.PVFileCameraInfo) {
+    return camera.PVFileCameraInfo;
+  }
+  return {};
+};
+
+/**
+ * Find the PVCameraInfo currently occupying the same uniquepath as the the given module
+ */
+export const getMatchedDevice = (info: PVCameraInfo | undefined): PVCameraInfo => {
+  if (!info) {
+    return {
+      PVFileCameraInfo: undefined,
+      PVCSICameraInfo: undefined,
+      PVUsbCameraInfo: undefined
+    };
+  }
+  return (
+    useStateStore().vsmState.allConnectedCameras.find(
+      (it) => cameraInfoFor(it).uniquePath === cameraInfoFor(info).uniquePath
+    ) || {
+      PVFileCameraInfo: undefined,
+      PVCSICameraInfo: undefined,
+      PVUsbCameraInfo: undefined
+    }
+  );
+};

--- a/photon-client/src/views/CameraMatchingView.vue
+++ b/photon-client/src/views/CameraMatchingView.vue
@@ -167,7 +167,7 @@ const openExportSettingsPrompt = () => {
           <v-card-subtitle
             v-else-if="
               cameraCononected(cameraInfoFor(module.matchedCameraInfo).uniquePath) &&
-              camerasMatch(getMatchedDevice(module.matchedCameraInfo), module.matchedCameraInfo)
+              camerasMatch(getMatchedDevice(useStateStore().vsmState.allConnectedCameras, module.matchedCameraInfo), module.matchedCameraInfo)
             "
             class="pb-2"
             >Status: <span class="active-status">Active</span></v-card-subtitle

--- a/photon-client/src/views/CameraMatchingView.vue
+++ b/photon-client/src/views/CameraMatchingView.vue
@@ -5,9 +5,6 @@ import { useStateStore } from "@/stores/StateStore";
 import {
   PlaceholderCameraSettings,
   PVCameraInfo,
-  type PVCSICameraInfo,
-  type PVFileCameraInfo,
-  type PVUsbCameraInfo,
   type UiCameraConfiguration
 } from "@/types/SettingTypes";
 import { getResolutionString } from "@/lib/PhotonUtils";
@@ -15,6 +12,7 @@ import PvCameraInfoCard from "@/components/common/pv-camera-info-card.vue";
 import axios from "axios";
 import PvCameraMatchCard from "@/components/common/pv-camera-match-card.vue";
 import type { WebsocketCameraSettingsUpdate } from "@/types/WebsocketDataTypes";
+import { camerasMatch, cameraInfoFor, getMatchedDevice } from "@/lib/MatchingUtils";
 
 const formatUrl = (port) => `http://${inject("backendHostname")}:${port}/stream.mjpg`;
 const host = inject<string>("backendHost");
@@ -93,63 +91,6 @@ const deleteThisCamera = (cameraName: string) => {
       setCameraDeleting(null);
       deletingCamera.value = false;
     });
-};
-
-const camerasMatch = (camera1: PVCameraInfo, camera2: PVCameraInfo) => {
-  if (camera1.PVUsbCameraInfo && camera2.PVUsbCameraInfo)
-    return (
-      camera1.PVUsbCameraInfo.name === camera2.PVUsbCameraInfo.name &&
-      camera1.PVUsbCameraInfo.vendorId === camera2.PVUsbCameraInfo.vendorId &&
-      camera1.PVUsbCameraInfo.productId === camera2.PVUsbCameraInfo.productId &&
-      camera1.PVUsbCameraInfo.uniquePath === camera2.PVUsbCameraInfo.uniquePath
-    );
-  else if (camera1.PVCSICameraInfo && camera2.PVCSICameraInfo)
-    return (
-      camera1.PVCSICameraInfo.uniquePath === camera2.PVCSICameraInfo.uniquePath &&
-      camera1.PVCSICameraInfo.baseName === camera2.PVCSICameraInfo.baseName
-    );
-  else if (camera1.PVFileCameraInfo && camera2.PVFileCameraInfo)
-    return (
-      camera1.PVFileCameraInfo.uniquePath === camera2.PVFileCameraInfo.uniquePath &&
-      camera1.PVFileCameraInfo.name === camera2.PVFileCameraInfo.name
-    );
-  else return false;
-};
-
-const cameraInfoFor = (camera: PVCameraInfo | null): PVUsbCameraInfo | PVCSICameraInfo | PVFileCameraInfo | any => {
-  if (!camera) return null;
-  if (camera.PVUsbCameraInfo) {
-    return camera.PVUsbCameraInfo;
-  }
-  if (camera.PVCSICameraInfo) {
-    return camera.PVCSICameraInfo;
-  }
-  if (camera.PVFileCameraInfo) {
-    return camera.PVFileCameraInfo;
-  }
-  return {};
-};
-
-/**
- * Find the PVCameraInfo currently occupying the same uniquepath as the the given module
- */
-const getMatchedDevice = (info: PVCameraInfo | undefined): PVCameraInfo => {
-  if (!info) {
-    return {
-      PVFileCameraInfo: undefined,
-      PVCSICameraInfo: undefined,
-      PVUsbCameraInfo: undefined
-    };
-  }
-  return (
-    useStateStore().vsmState.allConnectedCameras.find(
-      (it) => cameraInfoFor(it).uniquePath === cameraInfoFor(info).uniquePath
-    ) || {
-      PVFileCameraInfo: undefined,
-      PVCSICameraInfo: undefined,
-      PVUsbCameraInfo: undefined
-    }
-  );
 };
 
 const cameraCononected = (uniquePath: string): boolean => {

--- a/photon-client/src/views/DashboardView.vue
+++ b/photon-client/src/views/DashboardView.vue
@@ -7,6 +7,7 @@ import PipelineConfigCard from "@/components/dashboard/ConfigOptions.vue";
 import { useCameraSettingsStore } from "@/stores/settings/CameraSettingsStore";
 import { useStateStore } from "@/stores/StateStore";
 import { PlaceholderCameraSettings } from "@/types/SettingTypes";
+import { camerasMatch, getMatchedDevice } from "@/lib/MatchingUtils";
 
 const cameraViewType = computed<number[]>({
   get: (): number[] => {
@@ -58,6 +59,14 @@ const arducamWarningShown = computed<boolean>(() => {
       )
   );
 });
+
+const cameraMismatchWarningShown = computed<boolean>(() => {
+  return Object.values(useCameraSettingsStore().cameras).some((camera) => 
+  !camerasMatch(
+    getMatchedDevice(camera.matchedCameraInfo),
+    camera.matchedCameraInfo
+  ));
+});
 </script>
 
 <template>
@@ -73,6 +82,19 @@ const arducamWarningShown = computed<boolean>(() => {
     >
       <span
         >Arducam Camera Detected! Please configure the camera model in the <a href="#/cameras">Cameras tab</a>!
+      </span>
+    </v-banner>
+    <v-banner
+      v-if="cameraMismatchWarningShown"
+      v-model="cameraMismatchWarningShown"
+      rounded
+      color="error"
+      dark
+      class="mb-3"
+      icon="mdi-alert-circle-outline"
+    >
+      <span
+        >Camera Mismatch Detected! Please ensure cameras are plugged in correctly. Visit the <a href="#/cameraConfigs">Camera Matching</a> page for more information.
       </span>
     </v-banner>
     <v-row no-gutters align="center" justify="center">

--- a/photon-client/src/views/DashboardView.vue
+++ b/photon-client/src/views/DashboardView.vue
@@ -63,7 +63,7 @@ const arducamWarningShown = computed<boolean>(() => {
 const cameraMismatchWarningShown = computed<boolean>(() => {
   return Object.values(useCameraSettingsStore().cameras).some((camera) => 
   !camerasMatch(
-    getMatchedDevice(camera.matchedCameraInfo),
+    getMatchedDevice(useStateStore().vsmState.allConnectedCameras, camera.matchedCameraInfo),
     camera.matchedCameraInfo
   ));
 });


### PR DESCRIPTION
## Description

Detects if a camera mismatch is present in any camera and displays a banner in the dashboard for better visibility to the user.

<img width="1235" alt="image" src="https://github.com/user-attachments/assets/19219a56-c366-4c56-8c4b-cb5a36fe4a04" />

Closes #1920

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
