### PR TITLE
Clean up build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ ext {
     wpimathVersion = wpilibVersion
     openCVYear = "2025"
     openCVversion = "4.10.0-3"
-    joglVersion = "2.4.0"
     javalinVersion = "5.6.2"
     libcameraDriverVersion = "v2025.0.3"
     rknnVersion = "dev-v2025.0.0-1-g33b6263"

--- a/photon-core/build.gradle
+++ b/photon-core/build.gradle
@@ -26,12 +26,6 @@ nativeConfig.dependencies.add wpilibTools.deps.wpilib("hal")
 nativeConfig.dependencies.add wpilibTools.deps.wpilibOpenCv("frc" + openCVYear, wpi.versions.opencvVersion.get())
 
 dependencies {
-    // JOGL stuff (currently we only distribute for aarch64, which is Pi 4)
-    implementation "org.jogamp.gluegen:gluegen-rt:$joglVersion"
-    implementation "org.jogamp.jogl:jogl-all:$joglVersion"
-    implementation "org.jogamp.gluegen:gluegen-rt:$joglVersion:natives-linux-aarch64"
-    implementation "org.jogamp.jogl:jogl-all:$joglVersion:natives-linux-aarch64"
-
     // Zip
     implementation 'org.zeroturnaround:zt-zip:1.14'
 

--- a/photon-docs/build.gradle
+++ b/photon-docs/build.gradle
@@ -132,29 +132,8 @@ task generateJavaDocs(type: Javadoc) {
     title = "PhotonVision $pubVersion"
     ext.entryPoint = "$destinationDir/index.html"
 
-    if (JavaVersion.current().isJava8Compatible() && project.hasProperty('docWarningsAsErrors')) {
-        // Treat javadoc warnings as errors.
-        //
-        // The second argument '-quiet' is a hack. The one parameter
-        // addStringOption() doesn't work, so we add '-quiet', which is added
-        // anyway by gradle. See https://github.com/gradle/gradle/issues/2354.
-        //
-        // See JDK-8200363 (https://bugs.openjdk.java.net/browse/JDK-8200363)
-        // for information about the nonstandard -Xwerror option. JDK 15+ has
-        // -Werror.
-        options.addStringOption('Xwerror', '-quiet')
-    }
-
-    if (JavaVersion.current().isJava11Compatible()) {
-        if (!JavaVersion.current().isJava12Compatible()) {
-            options.addBooleanOption('-no-module-directories', true)
-        }
-        doLast {
-            // This is a work-around for https://bugs.openjdk.java.net/browse/JDK-8211194. Can be removed once that issue is fixed on JDK's side
-            // Since JDK 11, package-list is missing from javadoc output files and superseded by element-list file, but a lot of external tools still need it
-            // Here we generate this file manually
-            new File(destinationDir, 'package-list').text = new File(destinationDir, 'element-list').text
-        }
+    if (project.hasProperty('docWarningsAsErrors')) {
+        options.addBooleanOption('Werror', true)
     }
 }
 

--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -68,40 +68,6 @@ tasks.register('testHeadless', Test) {
     workingDir = "../"
 }
 
-tasks.register('generateJavaDocs', Javadoc) {
-    source = sourceSets.main.allJava
-    classpath = sourceSets.main.compileClasspath
-    destinationDir = file("${projectDir}/build/docs")
-
-    options.addBooleanOption("Xdoclint:html,missing,reference,syntax", true)
-    options.addBooleanOption('html5', true)
-
-    if (JavaVersion.current().isJava8Compatible() && project.hasProperty('docWarningsAsErrors')) {
-        // Treat javadoc warnings as errors.
-        //
-        // The second argument '-quiet' is a hack. The one parameter
-        // addStringOption() doesn't work, so we add '-quiet', which is added
-        // anyway by gradle. See https://github.com/gradle/gradle/issues/2354.
-        //
-        // See JDK-8200363 (https://bugs.openjdk.java.net/browse/JDK-8200363)
-        // for information about the nonstandard -Xwerror option. JDK 15+ has
-        // -Werror.
-        options.addStringOption('Xwerror', '-quiet')
-    }
-
-    if (JavaVersion.current().isJava11Compatible()) {
-        if (!JavaVersion.current().isJava12Compatible()) {
-            options.addBooleanOption('-no-module-directories', true)
-        }
-        doLast {
-            // This is a work-around for https://bugs.openjdk.java.net/browse/JDK-8211194. Can be removed once that issue is fixed on JDK's side
-            // Since JDK 11, package-list is missing from javadoc output files and superseded by element-list file, but a lot of external tools still need it
-            // Here we generate this file manually
-            new File(destinationDir, 'package-list').text = new File(destinationDir, 'element-list').text
-        }
-    }
-}
-
 jacoco {
     toolVersion = "0.8.10"
     reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -135,32 +135,6 @@ ext.createComponentZipTasks = { components, names, base, type, project, func ->
     return taskList
 }
 
-ext.createAllCombined = { list, name, base, type, project ->
-    def outputsFolder = file("$project.buildDir/outputs")
-
-    def task = project.tasks.create(base + "-all", type) {
-        description = "Creates component archive for all classifiers"
-        destinationDirectory = outputsFolder
-        classifier = "all"
-        archiveBaseName = base
-        duplicatesStrategy = 'exclude'
-
-        list.each {
-            if (it.name.endsWith('debug')) return
-                from project.zipTree(it.archiveFile)
-            dependsOn it
-        }
-    }
-
-    project.build.dependsOn task
-
-    project.artifacts {
-        task
-    }
-
-    return task
-}
-
 // Create the standard ZIP format for the dependencies.
 ext.includeStandardZipFormat = { task, value ->
     value.each { binary ->


### PR DESCRIPTION
## Description

I noticed that some of our Gradle files had some unnecessary code, so I decided to do some housekeeping and remove them.
There's a bunch of version checks in the Javadoc task that simply isn't necessary anymore because we've moved to Java 17. Java 17 also allows us to change `Xwerror` argument into `Werror`. Next, there was another `generateJavaDocs` task that was in a Gradle file included by photon-core and photon-server. We no longer generate Javadoc for either, nor do we want to, so it's been removed. There was also a `createAllCombined` task that created an artifact with an `-all` classifier. It is unused, so it has been removed.

Finally, the jogamp dependency has been removed, as it is no longer needed after `GPUAcceleratedHSVPipe` was removed in #1830.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
