### PR TITLE
Revert "Use Timer object to calculate FPS"

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/CalculateFPSPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/CalculateFPSPipe.java
@@ -24,12 +24,19 @@ import org.photonvision.vision.pipe.CVPipe;
 public class CalculateFPSPipe
         extends CVPipe<Void, Integer, CalculateFPSPipe.CalculateFPSPipeParams> {
     private final LinearFilter fpsFilter = LinearFilter.movingAverage(20);
-    private final Timer timer = new Timer();
+
+    // roll my own Timer, since this is so trivial
+    double lastTime = -1;
 
     @Override
     protected Integer process(Void in) {
-        var dtSeconds = timer.get();
-        timer.reset();
+        if (lastTime < 0) {
+            lastTime = Timer.getFPGATimestamp();
+        }
+
+        var now = Timer.getFPGATimestamp();
+        var dtSeconds = now - lastTime;
+        lastTime = now;
 
         // If < 1 uS between ticks, something is probably wrong
         int fps;


### PR DESCRIPTION
This reverts commit a4295275ed5479c164276076d5fc51a69dd3fc49.

## Description

This commit broke the FPS counter because I forgot to start the timer. I could just use `restart`, and then it would only be wrong for the very first pipeline run, but that's a hack, and frankly, the old way was fine.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
