### PR TITLE
[photon-lib] Add PhotonPoseEstimator.resetHeadingData()

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -337,11 +337,16 @@ public class PhotonPoseEstimator {
     }
 
     /**
-     * Clear all heading data in the buffer. Useful for preventing estimates from utilizing heading
-     * data provided prior to a pose or rotation reset.
+     * Clears all heading data in the buffer, and adds a new seed. Useful for preventing estimates
+     * from utilizing heading data provided prior to a pose or rotation reset.
+     *
+     * @param timestampSeconds timestamp of the robot heading data.
+     * @param heading Field-relative robot heading at given timestamp. Standard WPILIB field
+     *     coordinates.
      */
-    public void clearHeadingData() {
+    public void resetHeadingData(double timestampSeconds, Rotation2d heading) {
         headingBuffer.clear();
+        addHeadingData(timestampSeconds, heading);
     }
 
     /**

--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -337,8 +337,8 @@ public class PhotonPoseEstimator {
     }
 
     /**
-     * Clear all heading data in the buffer. Useful for preventing estimates from utilizing
-     * heading data provided prior to a pose or rotation reset.
+     * Clear all heading data in the buffer. Useful for preventing estimates from utilizing heading
+     * data provided prior to a pose or rotation reset.
      */
     public void clearHeadingData() {
         headingBuffer.clear();

--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -337,6 +337,14 @@ public class PhotonPoseEstimator {
     }
 
     /**
+     * Clear all heading data in the buffer. Useful for preventing estimates from utilizing
+     * heading data provided prior to a pose or rotation reset.
+     */
+    public void clearHeadingData() {
+        headingBuffer.clear();
+    }
+
+    /**
      * @return The current transform from the center of the robot to the camera mount position
      */
     public Transform3d getRobotToCameraTransform() {


### PR DESCRIPTION
## Description

When using `PNP_DISTANCE_TRIG_SOLVE`, heading data provided prior to a pose or rotation reset (examples including resetting odometry at the start of autonomous, or zeroing the robot's gyro) may be utilized when calculating future pose estimates, which can cause unpredictable behavior in some scenarios. This PR adds `PhotonPoseEstimator.resetHeadingData()`, giving users the option to manually clear the heading buffer to avoid the aforementioned issue.

Here's a log from one of my team's practice matches, where we observed irregular vision measurements at the start of autonomous, after the robot's pose was reset. Afterwards, we copied `PhotonPoseEstimator` into our robot code and implemented the method added by this PR, which resolved the problem. Green ghosts are the poses given by Photon, the solid model is our estimated pose.

https://github.com/user-attachments/assets/58690c7a-ebc6-401e-9ec5-28122aee90a7

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
