### PR TITLE
[docs] Reorganize getting started pages

### DIFF
--- a/photon-client/vite.config.ts
+++ b/photon-client/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       sass: {
-        additionalData: ["@import \"@/assets/styles/variables.scss\"", ""].join("\n")
+        additionalData: ['@import "@/assets/styles/variables.scss"', ""].join("\n")
       }
     }
   },


### PR DESCRIPTION
## Description

Pages under the getting started section are becoming quite heavy, including lots of information that a first time PhotonVision user does not need. This PR aims to reduce the amount of clutter under the getting started page, and make a more opinionated first-time user experience. More advanced settings and configuration are moved to a separate section.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
