### PR TITLE
Make targets tab a fixed size

### DIFF
--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -35,7 +35,7 @@ const resetCurrentBuffer = () => {
 <template>
   <div>
     <v-row align="start" class="pb-4">
-      <v-simple-table dense class="pt-2 pb-12">
+      <v-simple-table dense class="pt-2 pb-12 fixed-width-table">
         <template #default>
           <thead>
             <tr>
@@ -141,7 +141,7 @@ const resetCurrentBuffer = () => {
         <v-card-subtitle class="ma-0 pa-0 pb-4" style="font-size: 16px"
           >Multi-tag pose, field-to-camera</v-card-subtitle
         >
-        <v-simple-table dense>
+        <v-simple-table dense class="fixed-width-table">
           <template #default>
             <thead>
               <tr class="white--text">
@@ -154,16 +154,22 @@ const resetCurrentBuffer = () => {
                 <th class="text-center white--text">Tags</th>
               </tr>
             </thead>
-            <tbody v-show="useStateStore().currentPipelineResults?.multitagResult">
+            <tbody>
               <tr>
                 <td class="text-center white--text">
-                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.x.toFixed(3) }}&nbsp;m
+                  {{
+                    useStateStore().currentPipelineResults?.multitagResult?.bestTransform.x.toFixed(3) || "0.000"
+                  }}&nbsp;m
                 </td>
                 <td class="text-center white--text">
-                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(3) }}&nbsp;m
+                  {{
+                    useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(3) || "0.000"
+                  }}&nbsp;m
                 </td>
                 <td class="text-center white--text">
-                  {{ useStateStore().currentPipelineResults?.multitagResult?.bestTransform.z.toFixed(3) }}&nbsp;m
+                  {{
+                    useStateStore().currentPipelineResults?.multitagResult?.bestTransform.y.toFixed(3) || "0.000"
+                  }}&nbsp;m
                 </td>
                 <td class="text-center white--text">
                   {{
@@ -187,7 +193,7 @@ const resetCurrentBuffer = () => {
                   }}&deg;
                 </td>
                 <td class="text-center white--text">
-                  {{ useStateStore().currentPipelineResults?.multitagResult?.fiducialIDsUsed }}
+                  {{ useStateStore().currentPipelineResults?.multitagResult?.fiducialIDsUsed.join(", ") || "None" }}
                 </td>
               </tr>
             </tbody>
@@ -202,7 +208,7 @@ const resetCurrentBuffer = () => {
         <v-btn color="secondary" class="mb-4 mt-1" style="width: min-content" depressed @click="resetCurrentBuffer"
           >Reset Samples</v-btn
         >
-        <v-simple-table dense>
+        <v-simple-table dense class="fixed-width-table">
           <template #default>
             <thead>
               <tr>
@@ -310,5 +316,9 @@ const resetCurrentBuffer = () => {
     background-color: #ffd843;
     border-radius: 10px;
   }
+}
+
+.fixed-width-table {
+  width: 45em;
 }
 </style>

--- a/photon-client/src/components/dashboard/tabs/TargetsTab.vue
+++ b/photon-client/src/components/dashboard/tabs/TargetsTab.vue
@@ -35,7 +35,7 @@ const resetCurrentBuffer = () => {
 <template>
   <div>
     <v-row align="start" class="pb-4">
-      <v-simple-table dense class="pt-2 pb-12 fixed-width-table">
+      <v-simple-table dense class="pt-2 pb-12 fixed-width-table" fixed-header height="16em" style="overflow-y: scroll">
         <template #default>
           <thead>
             <tr>
@@ -141,7 +141,7 @@ const resetCurrentBuffer = () => {
         <v-card-subtitle class="ma-0 pa-0 pb-4" style="font-size: 16px"
           >Multi-tag pose, field-to-camera</v-card-subtitle
         >
-        <v-simple-table dense class="fixed-width-table">
+        <v-simple-table dense fixed-header class="fixed-width-table" height="12em">
           <template #default>
             <thead>
               <tr class="white--text">
@@ -208,7 +208,7 @@ const resetCurrentBuffer = () => {
         <v-btn color="secondary" class="mb-4 mt-1" style="width: min-content" depressed @click="resetCurrentBuffer"
           >Reset Samples</v-btn
         >
-        <v-simple-table dense class="fixed-width-table">
+        <v-simple-table dense fixed-header class="fixed-width-table" height="12em">
           <template #default>
             <thead>
               <tr>
@@ -284,6 +284,7 @@ const resetCurrentBuffer = () => {
       th {
         font-size: 1rem !important;
         color: white !important;
+        background-color: #006492 !important;
       }
     }
   }

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipe.java
@@ -20,15 +20,14 @@ package org.photonvision.vision.pipe.impl;
 import edu.wpi.first.apriltag.AprilTagDetection;
 import edu.wpi.first.apriltag.AprilTagDetector;
 import java.util.List;
-import java.util.Random;
-
 import org.photonvision.vision.apriltag.AprilTagFamily;
 import org.photonvision.vision.opencv.CVMat;
 import org.photonvision.vision.opencv.Releasable;
 import org.photonvision.vision.pipe.CVPipe;
 
 public class AprilTagDetectionPipe
-        extends CVPipe<CVMat, List<AprilTagDetection>, AprilTagDetectionPipe.AprilTagDetectionPipeParams>
+        extends CVPipe<
+                CVMat, List<AprilTagDetection>, AprilTagDetectionPipe.AprilTagDetectionPipeParams>
         implements Releasable {
     private AprilTagDetector m_detector = new AprilTagDetector();
 
@@ -49,22 +48,13 @@ public class AprilTagDetectionPipe
             throw new RuntimeException("Apriltag detector was released!");
         }
 
-        AprilTagDetection[] ret = m_detector.detect(in.getMat());
+        var ret = m_detector.detect(in.getMat());
 
         if (ret == null) {
             return List.of();
         }
 
-        var lret = List.of(ret);
-        Random rand = new Random();
-        if (rand.nextInt(3) == 0) {
-            if (ret.length > 1) {
-                // Can just delete the first one
-                lret = List.of(lret.get(0));
-            }
-        }
-
-        return lret;
+        return List.of(ret);
     }
 
     @Override
@@ -89,6 +79,5 @@ public class AprilTagDetectionPipe
     public static record AprilTagDetectionPipeParams(
             AprilTagFamily family,
             AprilTagDetector.Config detectorParams,
-            AprilTagDetector.QuadThresholdParameters quadParams) {
-    }
+            AprilTagDetector.QuadThresholdParameters quadParams) {}
 }

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/AprilTagDetectionPipe.java
@@ -20,14 +20,15 @@ package org.photonvision.vision.pipe.impl;
 import edu.wpi.first.apriltag.AprilTagDetection;
 import edu.wpi.first.apriltag.AprilTagDetector;
 import java.util.List;
+import java.util.Random;
+
 import org.photonvision.vision.apriltag.AprilTagFamily;
 import org.photonvision.vision.opencv.CVMat;
 import org.photonvision.vision.opencv.Releasable;
 import org.photonvision.vision.pipe.CVPipe;
 
 public class AprilTagDetectionPipe
-        extends CVPipe<
-                CVMat, List<AprilTagDetection>, AprilTagDetectionPipe.AprilTagDetectionPipeParams>
+        extends CVPipe<CVMat, List<AprilTagDetection>, AprilTagDetectionPipe.AprilTagDetectionPipeParams>
         implements Releasable {
     private AprilTagDetector m_detector = new AprilTagDetector();
 
@@ -48,13 +49,22 @@ public class AprilTagDetectionPipe
             throw new RuntimeException("Apriltag detector was released!");
         }
 
-        var ret = m_detector.detect(in.getMat());
+        AprilTagDetection[] ret = m_detector.detect(in.getMat());
 
         if (ret == null) {
             return List.of();
         }
 
-        return List.of(ret);
+        var lret = List.of(ret);
+        Random rand = new Random();
+        if (rand.nextInt(3) == 0) {
+            if (ret.length > 1) {
+                // Can just delete the first one
+                lret = List.of(lret.get(0));
+            }
+        }
+
+        return lret;
     }
 
     @Override
@@ -79,5 +89,6 @@ public class AprilTagDetectionPipe
     public static record AprilTagDetectionPipeParams(
             AprilTagFamily family,
             AprilTagDetector.Config detectorParams,
-            AprilTagDetector.QuadThresholdParameters quadParams) {}
+            AprilTagDetector.QuadThresholdParameters quadParams) {
+    }
 }


### PR DESCRIPTION
## Description

By forcing our v-data-tables to be the same size, we can stop the UI from jumping around. I don't love this, but fixes #1932 .

![image](https://github.com/user-attachments/assets/17f48a78-1251-4d1d-b0fc-f54d83a118ad)
![image](https://github.com/user-attachments/assets/e03d1b58-14bd-461f-9442-1e2f9d8b23af)
![image](https://github.com/user-attachments/assets/40b2663a-d56e-4423-83c6-bf0c83d3e345)
(this last one is -particularly- ugly and I hate it. @GrahamSH-LLK @srimanachanta plz fix)

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
