### PR TITLE
Remove MacOS builds from releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -557,7 +557,8 @@ jobs:
           rm: true
           files: |
             **/*.xz
-            **/*.jar
+            **/*linux*.jar
+            **/*win*.jar
             **/photonlib*.json
             **/photonlib*.zip
         if: github.event_name == 'push'

--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -283,3 +283,9 @@ Using the [GitHub CLI](https://cli.github.com/), we can download artifacts from 
 ```
 ~/photonvision$ gh run download 11759699679 -n jar-Linux
 ```
+
+#### MacOS Builds
+
+MacOS builds are not published to releases as MacOS is not an officially
+supported platform. However, MacOS builds are still available from the MacOS
+build action, which can be found [here](https://github.com/PhotonVision/photonvision/actions/workflows/build.yml).


### PR DESCRIPTION
## Description

We don't support MacOS, so why have it in releases? Note: we still continue to build for MacOS, we just don't publish releases for it.