### PR TITLE
Fix opencv version checking error

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -234,8 +234,8 @@ public class PhotonCamera implements AutoCloseable {
                     + """
                     >>>                                          \s
                     >>> This is neither tested nor supported.    \s
-                    >>> You MUST update PhotonVision,            \s
-                    >>> PhotonLib, or both.                      \s
+                    >>> You MUST update WPILib, PhotonLib, or    \s
+                    >>> both.                                    \s
                     >>> Verify the output of `./gradlew dependencies`
                     >>>                                          \s
                     >>> Your code will now crash.                \s

--- a/photon-lib/src/main/native/cpp/photon/PhotonCamera.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonCamera.cpp
@@ -104,7 +104,7 @@ inline void verifyDependencies() {
     bfw +=
         "\n>>>                                          \n"
         ">>> This is neither tested nor supported.    \n"
-        ">>> You MUST update PhotonVision,            \n"
+        ">>> You MUST update WPILib,            \n"
         ">>> PhotonLib, or both.                      \n"
         ">>> Verify the output of `./gradlew dependencies` \n"
         ">>>                                          \n"


### PR DESCRIPTION
## Description

Fixed the error in the OpenCV version checking crash.

Reported on chief https://www.chiefdelphi.com/t/opencv-is-version-4-6-0-and-needs-to-be-4-10-0/501751/7

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
