### PR TITLE
Disable Alerts test in PhotonCameraTest

### DIFF
--- a/photon-lib/src/test/java/org/photonvision/PhotonCameraTest.java
+++ b/photon-lib/src/test/java/org/photonvision/PhotonCameraTest.java
@@ -305,6 +305,8 @@ class PhotonCameraTest {
 
     @Test
     public void testAlerts() throws InterruptedException {
+        // See https://github.com/PhotonVision/photonvision/pull/1969. Flaky on Linux
+        assumeTrue(false);
         // GIVEN a fresh NT instance
 
         var cameraName = "foobar";


### PR DESCRIPTION
## Description

Disable the Alerts test in PhotonCameraTest because it's consistently failing on Linux.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
