### PR TITLE
Fix Broken Docs

### DIFF
--- a/.github/workflows/photon-api-docs.yml
+++ b/.github/workflows/photon-api-docs.yml
@@ -83,7 +83,7 @@ jobs:
           HOST: ${{ secrets.WEBMASTER_SSH_HOST }}
           USER: ${{ secrets.WEBMASTER_SSH_USERNAME }}
           KEY: ${{secrets.WEBMASTER_SSH_KEY}}
-          TARGET: /var/www/html/photonvision-docs/development
+          TARGET: /var/www/html/photonvision-docs/development/
       - name: Publish Docs To Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: up9cloud/action-rsync@v1.4

--- a/.github/workflows/photon-api-docs.yml
+++ b/.github/workflows/photon-api-docs.yml
@@ -42,8 +42,8 @@ jobs:
           name: built-demo
           path: photon-client/dist/
 
-  run_api_docs:
-    name: Build API Docs
+  run_java_cpp_docs:
+    name: Build Java and C++ API Docs
     runs-on: "ubuntu-22.04"
     steps:
     - name: Checkout code
@@ -63,18 +63,18 @@ jobs:
         ./gradlew photon-docs:generateJavaDocs photon-docs:doxygen
     - uses: actions/upload-artifact@v4
       with:
-        name: built-docs
+        name: docs-java-cpp
         path: photon-docs/build/docs
 
   publish_api_docs:
     name: Publish API Docs
-    needs: [run_api_docs]
+    needs: [run_java_cpp_docs]
     runs-on: ubuntu-22.04
     steps:
       # Download docs artifact
       - uses: actions/download-artifact@v4
         with:
-          name: built-docs
+          pattern: docs-*
       - run: find .
       - name: Publish Docs To Development
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Some dummy updated the [Caddyfile](https://github.com/PhotonVision/ansible-playbooks/blob/main/files/caddy/Caddyfile) on the server but never updated the playbook repo or the CI on main to reflect that. :shrug: Anyways, we're keeping the new Caddyfile because it makes pydocs work, and it more accurately reflects our CI process.