### PR TITLE
Disable linkcheck for gnu.org

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,7 +144,11 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 
 # Excluded links for linkcheck
 # These should be periodically checked by hand to ensure that they are still functional
-linkcheck_ignore = [R"https://www.raspberrypi.com/software/", R"http://10\..+"]
+linkcheck_ignore = [
+    R"https://www.raspberrypi.com/software/",
+    R"http://10\..+",
+    R"https://gnu.org/",
+]
 
 token = os.environ.get("GITHUB_TOKEN", None)
 if token:


### PR DESCRIPTION
## Description

Our docs builds keep stalling when linkcheck tries to check gnu.org. Added to the ignore list because those links are probably super stable and won't change.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
