### PR TITLE
Update list of coprocessors on quick-install.md

### DIFF
--- a/docs/source/docs/quick-start/quick-install.md
+++ b/docs/source/docs/quick-start/quick-install.md
@@ -3,20 +3,27 @@
 ## Install the latest image of photonvision for your coprocessor
 
 - For the supported coprocessors
-  - RPI 3,4,5
-  - Orange Pi 5
-  - Limelight
+  - RPi 3,4,5
+  - Orange Pi 5, 5B, 5 Max, 5+, 5 Pro
+  - Radxa ROCK 5C
+  - Limelight 2, 3, 3G
 
-For installing on non-supported devices {ref}`see. <docs/advanced-installation/sw_install/index:Software Installation>`
+For installing on non-supported devices {ref}`see here. <docs/advanced-installation/sw_install/index:Software Installation>`
 
 [Download the latest preconfigured image of photonvision for your coprocessor](https://github.com/PhotonVision/photonvision/releases/latest)
 
-| Coprocessor          | Image filename                                       | Jar                                   |
-| -------------------- | ---------------------------------------------------- | ------------------------------------- |
-| OrangePi 5           | photonvision-{version}-linuxarm64_orangepi5.img.xz   | photonvision-{version}-linuxarm64.jar |
-| Raspberry Pi 3, 4, 5 | photonvision-{version}-linuxarm64_RaspberryPi.img.xz | photonvision-{version}-linuxarm64.jar |
-| Limelight 2          | photonvision-{version}-linuxarm64_limelight2.img.xz  | photonvision-{version}-linuxarm64.jar |
-| Limelight 3          | photonvision-{version}-linuxarm64_limelight3.img.xz  | photonvision-{version}-linuxarm64.jar |
+| Coprocessor          | Image filename                                           | Jar                                   |
+| -------------------- | -------------------------------------------------------- | ------------------------------------- |
+| Raspberry Pi 3, 4, 5 | photonvision-{version}-linuxarm64_RaspberryPi.img.xz     | photonvision-{version}-linuxarm64.jar |
+| OrangePi 5           | photonvision-{version}-linuxarm64_orangepi5.img.xz       | photonvision-{version}-linuxarm64.jar |
+| OrangePi 5B          | photonvision-{version}-linuxarm64_orangepi5b.img.xz      | photonvision-{version}-linuxarm64.jar |
+| OrangePi 5 Max       | photonvision-{version}-linuxarm64_orangepi5max.img.xz    | photonvision-{version}-linuxarm64.jar |
+| OrangePi 5+          | photonvision-{version}-linuxarm64_orangepi5plus.img.xz   | photonvision-{version}-linuxarm64.jar |
+| OrangePi 5 Pro       | photonvision-{version}-linuxarm64_orangepi5pro.img.xz    | photonvision-{version}-linuxarm64.jar |
+| Radxa ROCK 5C        | photonvision-{version}-linuxarm64_rock5c.img.xz          | photonvision-{version}-linuxarm64.jar |
+| Limelight 2          | photonvision-{version}-linuxarm64_limelight2.img.xz      | photonvision-{version}-linuxarm64.jar |
+| Limelight 3          | photonvision-{version}-linuxarm64_limelight3.img.xz      | photonvision-{version}-linuxarm64.jar |
+| Limelight 3G         | photonvision-{version}-linuxarm64_limelight3G.img.xz     | photonvision-{version}-linuxarm64.jar |
 
 Use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to flash the image onto the coprocessors microSD card. Select the downloaded `.img.xz` file, select your microSD card, and flash.
 


### PR DESCRIPTION
Updated list of coprocessors with all coprocessors that have PhotonVision images built for them. Also fixed minor grammar problems.

## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->
I updated the list of coprocessors to better reflect the coprocessors that PhotonVision supports, as some coprocessors are missing from the list and have images built for them. This is because I noticed some coprocessors are mentioned elsewhere on the docs but not here (for example, NPU support on OPi 5+, but it missing from the list here). Also fixed some minor grammar mistakes.
<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->
<img width="872" alt="image" src="https://github.com/user-attachments/assets/0baf906d-5123-452a-84b4-9760365eb867" />
<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
