### PR TITLE
Make metrics commands more sane

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/LinuxCmds.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/LinuxCmds.java
@@ -27,7 +27,7 @@ public class LinuxCmds extends CmdBase {
         // TODO: boards have lots of thermal devices. Hard to pick the CPU
 
         cpuUtilizationCommand =
-                "top -bn1 | grep \"Cpu(s)\" | sed \"s/.*, *\\([0-9.]*\\)%* id.*/\\1/\" | awk '{print 100 - $1}'";
+                "top -bn1 | grep \"Cpu(s)\" | sed \"s/.*, *\\([0-9.]*\\)%* id.*/\\1/\" | awk '{print 100 - $1}' | cut -d'%' -f1";
 
         cpuUptimeCommand = "awk '{print $1}' /proc/uptime";
 

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/LinuxCmds.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/cmds/LinuxCmds.java
@@ -29,12 +29,12 @@ public class LinuxCmds extends CmdBase {
         cpuUtilizationCommand =
                 "top -bn1 | grep \"Cpu(s)\" | sed \"s/.*, *\\([0-9.]*\\)%* id.*/\\1/\" | awk '{print 100 - $1}'";
 
-        cpuUptimeCommand = "uptime -p | cut -c 4-";
+        cpuUptimeCommand = "awk '{print $1}' /proc/uptime";
 
         // RAM
         ramUsageCommand = "free -m | awk 'FNR == 2 {print $3}'";
 
         // Disk
-        diskUsageCommand = "df ./ --output=pcent | tail -n +2";
+        diskUsageCommand = "df ./ --output=pcent | tail -n +2 | cut -d'%' -f1";
     }
 }


### PR DESCRIPTION
Remove appended percent signs, and make metrics outputs solely numbers, moving away from strings.