### PR TITLE
Set a more sane timeout for WS connections and log WS errors

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/DataSocketHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/DataSocketHandler.java
@@ -69,8 +69,7 @@ public class DataSocketHandler {
 
     public void onConnect(WsConnectContext context) {
         users.add(context);
-        context.session.setIdleTimeout(
-                Duration.ofMillis(Long.MAX_VALUE)); // TODO: determine better value
+        context.session.setIdleTimeout(Duration.ofMillis(5000));
         var remote = (InetSocketAddress) context.session.getRemoteAddress();
         var host = remote.getAddress().toString() + ":" + remote.getPort();
         logger.info("New websocket connection from " + host);

--- a/photon-server/src/main/java/org/photonvision/server/Server.java
+++ b/photon-server/src/main/java/org/photonvision/server/Server.java
@@ -109,6 +109,7 @@ public class Server {
                 ws -> {
                     ws.onConnect(dsHandler::onConnect);
                     ws.onClose(dsHandler::onClose);
+                    ws.onError(e -> logger.error(e.toString(), e.error()));
                     ws.onBinaryMessage(dsHandler::onBinaryMessage);
                 });
 


### PR DESCRIPTION
## Description

As described in https://github.com/PhotonVision/photonvision/issues/1827#issuecomment-3043686610, setting the idle timeout to 5 seconds, as done here, seems to fix the WebSockets connection dying "permanently." Now, Javalin will throw a TimeoutException after a short time, after which the WebSockets connection becomes functional again. The behavior is a little strange though; disconnecting my Ethernet cable, reconnecting it to get the same IP address, then opening the page will sometimes work, and continue to work after refreshing multiple times, until one refresh will show the broken UI briefly, before it starts working again. Or it might be time based and refreshes have nothing to do with it, unsure. Regardless, the logs will record a new WebSocket connection, the TimeoutException getting thrown, then the closing of the WebSockets connection with a UUID. The timeout does seem to help; during one testing session, the placeholder UI showed up after a refresh, stayed visible for multiple seconds, and then everything loaded in; the exception was thrown right around the same time the UI came back up, which gives me confidence that the timeout will allow PV to eventually recover without needing a reboot even in scenarios where the WebSocket connection might be unstable. It does appear that the connection was simply being kept open for too long, causing issues when a new one was made with the same IP address, and simply allowing it to close fixes it. I personally tested quite a few disconnect-reconnect loops, and reproed multiple times on main, and zero times with this branch where the UI didn't recover.

I also want to note that when the connection is severed and left alone, the TimeoutException is _not_ thrown after 5 seconds, but instead seems to take upwards of a minute. I'm unsure as to why, but I assume it's something deeper in the networking stack. I've also seen ClosedChannelException get thrown instead of TimeoutException, which [appears to be normal according to Javalin.](https://javalin.io/documentation#jetty-debug-logs)

I've also added logging for when WebSocket errors are thrown. I believe the exceptions are thrown anyways by DataChangeService, but they seem a bit different, and more details is always better.
Closes #1827, closes #1320, closes #1182.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
