### PR TITLE
[2027] Add systemcore as a photonlib build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - container: wpilib/systemcore-cross-ubuntu:2025-24.04
+            artifact-name: SystemCore
+            build-options: "-Ponlylinuxsystemcore"
           - container: wpilib/raspbian-cross-ubuntu:bookworm-24.04
             artifact-name: Raspbian
             build-options: "-Ponlylinuxarm32"

--- a/photon-lib/src/generate/photonlib.json.in
+++ b/photon-lib/src/generate/photonlib.json.in
@@ -18,7 +18,7 @@
       "isJar": false,
       "validPlatforms": [
         "windowsx86-64",
-        "linuxathena",
+        "linuxsystemcore",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -35,7 +35,7 @@
       "skipInvalidPlatforms": true,
       "binaryPlatforms": [
         "windowsx86-64",
-        "linuxathena",
+        "linuxsystemcore",
         "linuxx86-64",
         "osxuniversal"
       ]
@@ -50,7 +50,7 @@
       "skipInvalidPlatforms": true,
       "binaryPlatforms": [
         "windowsx86-64",
-        "linuxathena",
+        "linuxsystemcore",
         "linuxx86-64",
         "osxuniversal"
       ]

--- a/photon-targeting/build.gradle
+++ b/photon-targeting/build.gradle
@@ -78,6 +78,7 @@ model {
 
             enableCheckTask project.hasProperty('doJniCheck')
             javaCompileTasks << compileJava
+            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.systemcore)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm32)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm64)

--- a/photon-targeting/build.gradle
+++ b/photon-targeting/build.gradle
@@ -79,7 +79,6 @@ model {
             enableCheckTask project.hasProperty('doJniCheck')
             javaCompileTasks << compileJava
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.systemcore)
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm32)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm64)
 

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -2,6 +2,7 @@
 nativeUtils.addWpiNativeUtils()
 nativeUtils.withCrossLinuxArm32()
 nativeUtils.withCrossLinuxArm64()
+nativeUtils.withCrossSystemCore()
 
 // Configure WPI dependencies.
 nativeUtils.wpi.configureDependencies {


### PR DESCRIPTION
## Description

Added systemcore to a couple of build files in order for `./gradlew publishToMavenLocal` to generate systemcore-compatible dependencies.

Needed to support deploying photonlib to systemcore.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
