### PR TITLE
Fix camera calibration buttons

### DIFF
--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -589,8 +589,5 @@ th {
   .calib-btn-icon {
     margin: 0 !important;
   }
-  .calib-btn-label {
-    display: none;
-  }
 }
 </style>


### PR DESCRIPTION
Camera calibration buttons were hidden during the Vue 3 migration. This unhides them, so calibrations work again.