### PR TITLE
Restore original video mode index order

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
@@ -25,9 +25,11 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.util.PixelFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.photonvision.common.configuration.CameraConfiguration;
 import org.photonvision.vision.camera.CameraQuirk;
 import org.photonvision.vision.processes.VisionSourceSettables;
@@ -287,11 +289,14 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
         var sortedList =
                 videoModesList.stream()
                         .distinct() // remove redundant video mode entries
-                        .sorted(((a, b) -> (a.width + a.height) - (b.width + b.height)))
-                        .toList();
+                        .sorted(((a, b) -> (b.width + b.height) - (a.width + a.height)))
+                        .collect(Collectors.toList());
+        // The ordering is usually more logical when done like this. It typically puts higher FPSes
+        // closer to the bottom.
+        Collections.reverse(sortedList);
 
-        for (VideoMode videoMode : sortedList) {
-            videoModes.put(sortedList.indexOf(videoMode), videoMode);
+        for (int i = 0; i < sortedList.size(); i++) {
+            videoModes.put(i, sortedList.get(i));
         }
 
         // If after all that we still have no video modes, not much we can do besides


### PR DESCRIPTION
## Description

#1830 changed made a slight change to how video modes were cached. The original method was to do a backwards sort and then reverse the order. It was removed because it looked redundant, but it caused video modes of the same resolution, but a different FPS/format to be put in reverse order. This restores that original logic, with a comment so future contributors don't touch it.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
