### PR TITLE
Make testHeadless output the same stuff as test from photon-lib

### DIFF
--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -64,6 +64,11 @@ tasks.register('testHeadless', Test) {
     group = "verification"
     systemProperty("java.awt.headless", "true")
     useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+        exceptionFormat "full"
+        showStandardStreams = true
+    }
     exclude '**/*BenchmarkTest*'
     workingDir = "../"
 }


### PR DESCRIPTION
## Description

After #1837, Gradle log output was significantly reduced in CI, which was the intent, but a little too much was removed. This fixes that by making testHeadless output the same amount of information as the test task does from photon-lib and photon-targetting.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
