### PR TITLE
Add notebook for Rubik Model conversion

### DIFF
--- a/scripts/rubik_conversion.ipynb
+++ b/scripts/rubik_conversion.ipynb
@@ -17,19 +17,21 @@
       "source": [
         "#### Requirements\n",
         "\n",
-        "This notebook can be run on colab.\n",
+        "This notebook can be run on Colab. However, Colab has some incompatibility issues that result in needing to restart the notebook in the middle of the run. This is normal, and after restarting you should rerun the below cell.\n",
         "\n",
-        "Prior to running the notebook, it is necessary to make an account on [Qualcomm's AI Hub](https://app.aihub.qualcomm.com/account/), and obtain your API key.\n",
+        "Prior to running the notebook, it is necessary to make an account on [Qualcomm's AI Hub](https://app.aihub.qualcomm.com/account/), and obtain your API token. Then, replace <YOUR_API_TOKEN> with your API token in the cell below.\n",
         "\n",
         "Documentation for the Qualcomm AI Hub can be found [here](https://app.aihub.qualcomm.com/docs/index.html).\n",
         "\n",
-        "You should also have a PyTorch model (ending in `.pt`) that's been uploaded to the runtime that you intend to convert.\n",
+        "You should also have a PyTorch model (ending in `.pt`) that's been uploaded to the runtime that you intend to convert. After uploading, copy it's absolute path by right-clicking on the file, and replace /PATH/TO/WEIGHTS.\n",
         "\n",
-        "Please note that your API key will be listed in the output, and should therefore be redacted if the output is shared.\n",
+        "**NOTE: your API key will be listed in the output, and should therefore be redacted if the output is shared.**\n",
         "\n",
         "At some point during the run of this cell, it will prompt you to choose whether to clone a repo. You should click on the text box next to the prompt, and answer *y/yes*.\n",
         "\n",
-        "Once the run has finished, open the AI Hub link, and download the tflite model for the job you just ran."
+        "Once the run has finished, open the AI Hub link, and download the tflite model for the job you just ran.\n",
+        "\n",
+        "If you want to use this notebook to convert a yolo11 model, you'll need to replace all instances of `yolov8` in the cell below with `yolov11`."
       ]
     },
     {


### PR DESCRIPTION
## Description

Adds a notebook that can be run on Google Colab for converting a PyTorch model to tflite for Rubik Pi.

closes #1951
closes #1953
closes #1435 

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [x] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [x] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [x] If this PR addresses a bug, a regression test for it is added
