### PR TITLE
Update metrics publisher hostname when hostname is changed

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -17,6 +17,7 @@
 
 package org.photonvision.common.hardware.metrics;
 
+import edu.wpi.first.cscore.CameraServerJNI;
 import edu.wpi.first.networktables.ProtobufPublisher;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -46,9 +47,7 @@ public class MetricsManager {
             NetworkTablesManager.getInstance()
                     .kRootTable
                     .getSubTable("/metrics")
-                    .getProtobufTopic(
-                            ConfigManager.getInstance().getConfig().getNetworkConfig().hostname,
-                            DeviceMetrics.proto)
+                    .getProtobufTopic(CameraServerJNI.getHostname(), DeviceMetrics.proto)
                     .publish();
 
     private final ShellExec runCommand = new ShellExec(true, true);
@@ -247,19 +246,14 @@ public class MetricsManager {
         logger.debug("Publishing Metrics...");
 
         // Check that the hostname hasn't changed
-        if (!metricPublisher
-                .getTopic()
-                .getName()
-                .equals(ConfigManager.getInstance().getConfig().getNetworkConfig().hostname)) {
+        if (!metricPublisher.getTopic().getName().equals(CameraServerJNI.getHostname())) {
             logger.warn("Metrics publisher name does not match hostname! Reinitializing publisher...");
             metricPublisher.close();
             metricPublisher =
                     NetworkTablesManager.getInstance()
                             .kCoprocTable
                             .getSubTable("/metrics")
-                            .getProtobufTopic(
-                                    ConfigManager.getInstance().getConfig().getNetworkConfig().hostname,
-                                    DeviceMetrics.proto)
+                            .getProtobufTopic(CameraServerJNI.getHostname(), DeviceMetrics.proto)
                             .publish();
         }
 

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -251,7 +251,7 @@ public class MetricsManager {
             metricPublisher.close();
             metricPublisher =
                     NetworkTablesManager.getInstance()
-                            .kCoprocTable
+                            .kRootTable
                             .getSubTable("/metrics")
                             .getProtobufTopic(CameraServerJNI.getHostname(), DeviceMetrics.proto)
                             .publish();


### PR DESCRIPTION
## Description

When the hostname changes, the key of the metrics publisher will not be immediately updated. To fix this, we will check the key against the hostname and re-initialize the publisher if they do not match.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] Figure out a way to only extract models for the relevant hardware (ideally only pack the necessary models, but idk how viable that is since it necessitates a different JAR per)
