### PR TITLE
Support a custom username and password with the deploy script

### DIFF
--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -137,6 +137,8 @@ An architecture override is required to specify the deploy target's architecture
 
 The `deploy` command is tested against Raspberry Pi coprocessors. Other similar coprocessors may work too.
 
+The `deploy` command also supports a custom username and password, via the `user` and `password` flags. If you want to build the UI while deploying, pass in the `withBuildAndCopyUI` flag.
+
 ### Using PhotonLib Builds
 
 The build process automatically generates a vendordep JSON of your local build at `photon-lib/build/generated/vendordeps/photonlib.json`.

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -44,6 +44,10 @@ tasks.register('copyClientUIToResources', Copy) {
     into "${projectDir}/src/main/resources/web/"
 }
 
+tasks.named('processResources') {
+    dependsOn 'copyClientUIToResources'
+}
+
 tasks.register("buildAndCopyUI") {
     dependsOn "npm_run_build"
     finalizedBy "copyClientUIToResources"
@@ -74,7 +78,13 @@ remotes {
 
 task findDeployTarget {
     doLast {
-        if(project.hasProperty('tgtIP')){
+        if(project.hasProperty('tgtIP') && project.hasProperty('user') && project.hasProperty('password')){
+            //If user specified IP, user, and password, use those to deploy
+            findDeployTarget.ext.rmt = remotes.pi
+            findDeployTarget.ext.rmt.host = tgtIP
+            findDeployTarget.ext.rmt.user = user
+            findDeployTarget.ext.rmt.password = password
+        } else if(project.hasProperty('tgtIP')){
             //If user specified IP, default to using the PI profile
             // but adjust hostname to match the provided IP address
             findDeployTarget.ext.rmt = remotes.pi
@@ -106,8 +116,12 @@ task findDeployTarget {
 }
 
 task deploy {
+    if(project.hasProperty("withBuildAndCopyUI")){
+        dependsOn 'buildAndCopyUI'
+    }
     dependsOn findDeployTarget
     dependsOn 'shadowJar'
+
 
     doLast {
         println 'Starting deployment to ' + findDeployTarget.rmt.host


### PR DESCRIPTION
## Description

It's convenient to be able to run the deploy script with a custom username and password, if they happen to be different from the default. This PR also adds the ability to run the `deploy` task with a new UI build, using the `withBuildAndCopyUI` flag.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
