### PR TITLE
Upgrade to 2027 alpha 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "cpp"
     id "com.diffplug.spotless" version "6.24.0"
     id "edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin" version "2025.0"
-    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-1"
+    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-2"
     id 'edu.wpi.first.WpilibTools' version '1.3.0'
     id 'com.google.protobuf' version '0.9.3' apply false
     id 'edu.wpi.first.GradleJni' version '1.1.0'
@@ -34,7 +34,7 @@ ext.allOutputsFolder = file("$project.buildDir/outputs")
 apply from: "versioningHelper.gradle"
 
 ext {
-    wpilibVersion = "2027.0.0-alpha-1"
+    wpilibVersion = "2027.0.0-alpha-2"
     wpimathVersion = wpilibVersion
     openCVYear = "2025"
     openCVversion = "4.10.0-3"

--- a/photonlib-cpp-examples/aimandrange/build.gradle
+++ b/photonlib-cpp-examples/aimandrange/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-1"
+    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-2"
 }
 
 // Define my targets (SystemCore) and artifacts (deployable files)

--- a/photonlib-cpp-examples/aimattarget/build.gradle
+++ b/photonlib-cpp-examples/aimattarget/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-1"
+    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-2"
 }
 
 // Define my targets (SystemCore) and artifacts (deployable files)

--- a/photonlib-cpp-examples/poseest/build.gradle
+++ b/photonlib-cpp-examples/poseest/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-1"
+    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-2"
 }
 
 // Define my targets (SystemCore) and artifacts (deployable files)

--- a/photonlib-java-examples/aimandrange/build.gradle
+++ b/photonlib-java-examples/aimandrange/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-1"
+    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-2"
 }
 
 java {

--- a/photonlib-java-examples/aimattarget/build.gradle
+++ b/photonlib-java-examples/aimattarget/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-1"
+    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-2"
 }
 
 java {

--- a/photonlib-java-examples/poseest/build.gradle
+++ b/photonlib-java-examples/poseest/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-1"
+    id "edu.wpi.first.GradleRIO2027" version "2027.0.0-alpha-2"
 }
 
 java {


### PR DESCRIPTION
## Description

Replaced references to 2027.0.0-alpha-1 with alpha 2.

Wpilib appears to have kept the os version '2027 alpha1' so 'frcYear' has not been touched.

Validated that photonlib built with alpha2 can start up on systemcore, though not all features are tested in our competition code. 

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
