### PR TITLE
Update logic for metric publisher topic name

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -18,6 +18,7 @@
 package org.photonvision.common.hardware.metrics;
 
 import edu.wpi.first.cscore.CameraServerJNI;
+import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.ProtobufPublisher;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -245,10 +246,9 @@ public class MetricsManager {
     public void publishMetrics() {
         logger.debug("Publishing Metrics...");
 
-        String[] topicParts = metricPublisher.getTopic().getName().split("/");
-
         // Check that the hostname hasn't changed
-        if (!CameraServerJNI.getHostname().equals(topicParts[topicParts.length - 1])) {
+        if (!CameraServerJNI.getHostname()
+                .equals(NetworkTable.basenameKey(metricPublisher.getTopic().getName()))) {
             logger.warn("Metrics publisher name does not match hostname! Reinitializing publisher...");
             metricPublisher.close();
             metricPublisher =

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -17,6 +17,7 @@
 
 package org.photonvision.common.hardware.metrics;
 
+import edu.wpi.first.cscore.CameraServerJNI;
 import edu.wpi.first.networktables.ProtobufPublisher;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -46,9 +47,7 @@ public class MetricsManager {
             NetworkTablesManager.getInstance()
                     .kRootTable
                     .getSubTable("/metrics")
-                    .getProtobufTopic(
-                            ConfigManager.getInstance().getConfig().getNetworkConfig().hostname,
-                            DeviceMetrics.proto)
+                    .getProtobufTopic(CameraServerJNI.getHostname(), DeviceMetrics.proto)
                     .publish();
 
     private final ShellExec runCommand = new ShellExec(true, true);
@@ -247,19 +246,14 @@ public class MetricsManager {
         logger.debug("Publishing Metrics...");
 
         // Check that the hostname hasn't changed
-        if (!metricPublisher
-                .getTopic()
-                .getName()
-                .equals(ConfigManager.getInstance().getConfig().getNetworkConfig().hostname)) {
+        if (!metricPublisher.getTopic().getName().equals(CameraServerJNI.getHostname())) {
             logger.warn("Metrics publisher name does not match hostname! Reinitializing publisher...");
             metricPublisher.close();
             metricPublisher =
                     NetworkTablesManager.getInstance()
                             .kCoprocTable
                             .getSubTable("/metrics")
-                            .getProtobufTopic(
-                                    ConfigManager.getInstance().getConfig().getNetworkConfig().hostname,
-                                    DeviceMetrics.proto)
+                            .getProtobufTopic(CameraServerJNI.getHostname(), DeviceMetrics.proto)
                             .publish();
         }
 

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -251,7 +251,7 @@ public class MetricsManager {
             metricPublisher.close();
             metricPublisher =
                     NetworkTablesManager.getInstance()
-                            .kCoprocTable
+                            .kRootTable
                             .getSubTable("/metrics")
                             .getProtobufTopic(CameraServerJNI.getHostname(), DeviceMetrics.proto)
                             .publish();

--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -244,9 +244,13 @@ public class MetricsManager {
 
     public void publishMetrics() {
         logger.debug("Publishing Metrics...");
+        logger.debug("Hostname: " + CameraServerJNI.getHostname());
+        logger.debug(metricPublisher.getTopic().getName());
+
+        String[] topicParts = metricPublisher.getTopic().getName().split("/");
 
         // Check that the hostname hasn't changed
-        if (!metricPublisher.getTopic().getName().equals(CameraServerJNI.getHostname())) {
+        if (!CameraServerJNI.getHostname().equals(topicParts[topicParts.length - 1])) {
             logger.warn("Metrics publisher name does not match hostname! Reinitializing publisher...");
             metricPublisher.close();
             metricPublisher =


### PR DESCRIPTION
`getName()` gives the full string, not just the title of the topic. Therefore, it needs to be split in order to get the title of the topic.

Let this be a lesson to test things when something has changed before they are merged.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
