### PR TITLE
Add an overload of resetHeadingData() which takes in a Rotation3d

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -316,7 +316,7 @@ public class PhotonPoseEstimator {
      * Add robot heading data to buffer. Must be called periodically for the
      * <b>PNP_DISTANCE_TRIG_SOLVE</b> strategy.
      *
-     * @param timestampSeconds timestamp of the robot heading data.
+     * @param timestampSeconds Timestamp of the robot heading data.
      * @param heading Field-relative robot heading at given timestamp. Standard WPILIB field
      *     coordinates.
      */
@@ -328,7 +328,7 @@ public class PhotonPoseEstimator {
      * Add robot heading data to buffer. Must be called periodically for the
      * <b>PNP_DISTANCE_TRIG_SOLVE</b> strategy.
      *
-     * @param timestampSeconds timestamp of the robot heading data.
+     * @param timestampSeconds Timestamp of the robot heading data.
      * @param heading Field-relative robot heading at given timestamp. Standard WPILIB field
      *     coordinates.
      */
@@ -340,7 +340,20 @@ public class PhotonPoseEstimator {
      * Clears all heading data in the buffer, and adds a new seed. Useful for preventing estimates
      * from utilizing heading data provided prior to a pose or rotation reset.
      *
-     * @param timestampSeconds timestamp of the robot heading data.
+     * @param timestampSeconds Timestamp of the robot heading data.
+     * @param heading Field-relative robot heading at given timestamp. Standard WPILIB field
+     *     coordinates.
+     */
+    public void resetHeadingData(double timestampSeconds, Rotation3d heading) {
+        headingBuffer.clear();
+        addHeadingData(timestampSeconds, heading);
+    }
+
+    /**
+     * Clears all heading data in the buffer, and adds a new seed. Useful for preventing estimates
+     * from utilizing heading data provided prior to a pose or rotation reset.
+     *
+     * @param timestampSeconds Timestamp of the robot heading data.
      * @param heading Field-relative robot heading at given timestamp. Standard WPILIB field
      *     coordinates.
      */


### PR DESCRIPTION
## Description

In PR #1933 `PhotonPoseEstimator.resetHeadingData(double, Rotation2d)` was added to
give users the option to manually clear the heading buffer and add an initial
heading, specified as a `Rotation2d`. This works for teams that pass `Rotation2d` data
to `addHeadingData()`, but teams that prefer to use `Rotation3d` for headings need
to provide an initial heading as a `Rotation2d` in order to clear the heading buffer.

This change adds an overload of `resetHeadingData()` that takes in a `Rotation3d`,
mirroring the overloads for `addHeadingData()`.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
