### PR TITLE
Add PNP_DISTANCE_TRIG_SOLVE strategy to C++

### DIFF
--- a/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
@@ -44,6 +44,7 @@
 #include <opencv2/calib3d.hpp>
 #include <opencv2/core/mat.hpp>
 #include <opencv2/core/types.hpp>
+#include <units/angle.h>
 #include <units/math.h>
 #include <units/time.h>
 
@@ -73,7 +74,8 @@ PhotonPoseEstimator::PhotonPoseEstimator(frc::AprilTagFieldLayout tags,
       m_robotToCamera(robotToCamera),
       lastPose(frc::Pose3d()),
       referencePose(frc::Pose3d()),
-      poseCacheTimestamp(-1_s) {
+      poseCacheTimestamp(-1_s),
+      headingBuffer(frc::TimeInterpolatableBuffer<frc::Rotation2d>(1_s)) {
   HAL_Report(HALUsageReporting::kResourceType_PhotonPoseEstimator,
              InstanceCount);
   InstanceCount++;
@@ -158,6 +160,9 @@ std::optional<EstimatedRobotPose> PhotonPoseEstimator::Update(
                         "No camera calibration provided to multi-tag-on-rio!",
                         "");
       }
+      break;
+    case PNP_DISTANCE_TRIG_SOLVE:
+      ret = PnpDistanceTrigSolveStrategy(result);
       break;
     default:
       FRC_ReportError(frc::warn::Warning, "Invalid Pose Strategy selected!",
@@ -427,6 +432,53 @@ std::optional<EstimatedRobotPose> PhotonPoseEstimator::MultiTagOnRioStrategy(
   return photon::EstimatedRobotPose(pose.TransformBy(m_robotToCamera.Inverse()),
                                     result.GetTimestamp(), result.GetTargets(),
                                     MULTI_TAG_PNP_ON_RIO);
+}
+
+std::optional<EstimatedRobotPose>
+PhotonPoseEstimator::PnpDistanceTrigSolveStrategy(PhotonPipelineResult result) {
+  PhotonTrackedTarget bestTarget = result.GetBestTarget();
+  std::optional<frc::Rotation2d> headingSampleOpt =
+      headingBuffer.Sample(result.GetTimestamp());
+  if (!headingSampleOpt) {
+    FRC_ReportError(frc::warn::Warning,
+                    "There was no heading data! Use AddHeadingData to add it!");
+    return std::nullopt;
+  }
+
+  frc::Rotation2d headingSample = headingSampleOpt.value();
+
+  frc::Translation2d camToTagTranslation =
+      frc::Translation3d(
+          bestTarget.GetBestCameraToTarget().Translation().Norm(),
+          frc::Rotation3d(0_rad, -units::degree_t(bestTarget.GetPitch()),
+                          -units::degree_t(bestTarget.GetYaw())))
+          .RotateBy(m_robotToCamera.Rotation())
+          .ToTranslation2d()
+          .RotateBy(headingSample);
+
+  std::optional<frc::Pose3d> fiducialPose =
+      aprilTags.GetTagPose(bestTarget.GetFiducialId());
+  if (!fiducialPose) {
+    FRC_ReportError(frc::warn::Warning,
+                    "Tried to get pose of unknown April Tag: {}",
+                    bestTarget.GetFiducialId());
+    return std::nullopt;
+  }
+
+  frc::Pose2d tagPose = fiducialPose.value().ToPose2d();
+
+  frc::Translation2d fieldToCameraTranslation =
+      tagPose.Translation() - camToTagTranslation;
+
+  frc::Translation2d camToRobotTranslation =
+      (-m_robotToCamera.Translation().ToTranslation2d())
+          .RotateBy(headingSample);
+
+  frc::Pose2d robotPose = frc::Pose2d(
+      fieldToCameraTranslation + camToRobotTranslation, headingSample);
+
+  return EstimatedRobotPose{frc::Pose3d(robotPose), result.GetTimestamp(),
+                            result.GetTargets(), PNP_DISTANCE_TRIG_SOLVE};
 }
 
 std::optional<EstimatedRobotPose>

--- a/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
@@ -177,8 +177,6 @@ class PhotonPoseEstimator {
   /**
    * Add robot heading data to the buffer. Must be called periodically for the
    * PNP_DISTANCE_TRIG_SOLVE strategy.
-   * The side effects of this method are only used for the
-   * PNP_DISTANCE_TRIG_SOLVE strategy.
    *
    * @param timestamp timestamp of the robot heading data
    * @param heading Field-relative heading at the given timestamp. Standard
@@ -191,8 +189,6 @@ class PhotonPoseEstimator {
 
   /**
    * Add robot heading data to the buffer. Must be called periodically for the
-   * PNP_DISTANCE_TRIG_SOLVE strategy.
-   * The side effects of this method are only used for the
    * PNP_DISTANCE_TRIG_SOLVE strategy.
    *
    * @param timestamp timestamp of the robot heading data

--- a/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
@@ -205,9 +205,13 @@ class PhotonPoseEstimator {
   }
 
   /**
-   * Reset the heading data, and then add robot heading data to the buffer life
-   * AddHeadingData. Used for the PNP_DISTANCE_TRIG_SOLVE strategy, and won't
-   * have any effect for other strategies
+   * Clears all heading data in the buffer, and adds a new seed. Useful for
+   * preventing estimates from utilizing heading data provided prior to a pose
+   * or rotation reset.
+   *
+   * @param timestamp Timestamp of the robot heading data.
+   * @param heading Field-relative robot heading at given timestamp. Standard
+   * WPILIB field coordinates.
    */
   inline void ResetHeadingData(units::second_t timestamp,
                                frc::Rotation2d heading) {
@@ -216,9 +220,13 @@ class PhotonPoseEstimator {
   }
 
   /**
-   * Reset the heading data, and then add robot heading data to the buffer life
-   * AddHeadingData. Used for the PNP_DISTANCE_TRIG_SOLVE strategy, and won't
-   * have any effect for other strategies
+   * Clears all heading data in the buffer, and adds a new seed. Useful for
+   * preventing estimates from utilizing heading data provided prior to a pose
+   * or rotation reset.
+   *
+   * @param timestamp Timestamp of the robot heading data.
+   * @param heading Field-relative robot heading at given timestamp. Standard
+   * WPILIB field coordinates.
    */
   inline void ResetHeadingData(units::second_t timestamp,
                                frc::Rotation3d heading) {

--- a/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
@@ -178,7 +178,7 @@ class PhotonPoseEstimator {
    * Add robot heading data to the buffer. Must be called periodically for the
    * PNP_DISTANCE_TRIG_SOLVE strategy.
    *
-   * @param timestamp timestamp of the robot heading data
+   * @param timestamp Timestamp of the robot heading data.
    * @param heading Field-relative heading at the given timestamp. Standard
    * WPILIB field coordinates.
    */
@@ -191,7 +191,7 @@ class PhotonPoseEstimator {
    * Add robot heading data to the buffer. Must be called periodically for the
    * PNP_DISTANCE_TRIG_SOLVE strategy.
    *
-   * @param timestamp timestamp of the robot heading data
+   * @param timestamp Timestamp of the robot heading data.
    * @param heading Field-relative heading at the given timestamp. Standard
    * WPILIB coordinates.
    */

--- a/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
@@ -180,9 +180,9 @@ class PhotonPoseEstimator {
    * The side effects of this method are only used for the
    * PNP_DISTANCE_TRIG_SOLVE strategy.
    *
-   * @param timestamp timestamp of the heading data
-   * @param heading Field-relative heading at the given timestamp. In the
-   * standard WPILIB coordinates.
+   * @param timestamp timestamp of the robot heading data
+   * @param heading Field-relative heading at the given timestamp. Standard
+   * WPILIB field coordinates.
    */
   inline void AddHeadingData(units::second_t timestamp,
                              frc::Rotation2d heading) {
@@ -195,9 +195,9 @@ class PhotonPoseEstimator {
    * The side effects of this method are only used for the
    * PNP_DISTANCE_TRIG_SOLVE strategy.
    *
-   * @param timestamp timestamp of the heading data
-   * @param heading Field-relative heading at the given timestamp. In the
-   * standard WPILIB coordinates.
+   * @param timestamp timestamp of the robot heading data
+   * @param heading Field-relative heading at the given timestamp. Standard
+   * WPILIB coordinates.
    */
   inline void AddHeadingData(units::second_t timestamp,
                              frc::Rotation3d heading) {

--- a/photon-lib/src/test/native/cpp/PhotonPoseEstimatorTest.cpp
+++ b/photon-lib/src/test/native/cpp/PhotonPoseEstimatorTest.cpp
@@ -310,8 +310,7 @@ TEST(PhotonPoseEstimatorTest, ClosestToLastPose) {
 
 TEST(PhotonPoseEstimatorTest, PnpDistanceTrigSolve) {
   photon::PhotonCamera cameraOne = photon::PhotonCamera("test");
-  photon::PhotonCameraSim cameraOneSim = photon::PhotonCameraSim(
-      &cameraOne, photon::SimCameraProperties::PERFECT_90DEG());
+  cameraOne.test = true;
 
   std::vector<photon::VisionTargetSim> targets;
   targets.reserve(tags.size());
@@ -319,23 +318,23 @@ TEST(PhotonPoseEstimatorTest, PnpDistanceTrigSolve) {
     targets.push_back(
         photon::VisionTargetSim(tag.pose, photon::kAprilTag36h11, tag.ID));
   }
-
-  /* real pose of the robot base to test against */
-  frc::Pose3d realPose =
-      frc::Pose3d(7.3_m, 4.42_m, 0_m, frc::Rotation3d(0_rad, 0_rad, 2.197_rad));
+  photon::PhotonCameraSim cameraOneSim = photon::PhotonCameraSim(
+      &cameraOne, photon::SimCameraProperties::PERFECT_90DEG());
 
   /* Compound Rolled + Pitched + Yaw */
-
   frc::Transform3d compoundTestTransform = frc::Transform3d(
       -12_in, -11_in, 3_m, frc::Rotation3d(37_deg, 6_deg, 60_deg));
 
   photon::PhotonPoseEstimator estimator(
       aprilTags, photon::PNP_DISTANCE_TRIG_SOLVE, compoundTestTransform);
 
+  /* real pose of the robot base to test against */
+  frc::Pose3d realPose =
+      frc::Pose3d(7.3_m, 4.42_m, 0_m, frc::Rotation3d(0_rad, 0_rad, 2.197_rad));
+
   photon::PhotonPipelineResult result = cameraOneSim.Process(
       1_ms, realPose.TransformBy(estimator.GetRobotToCameraTransform()),
       targets);
-  cameraOne.test = true;
   cameraOne.testResult = {result};
   cameraOne.testResult[0].SetReceiveTimestamp(17_s);
 
@@ -357,9 +356,9 @@ TEST(PhotonPoseEstimatorTest, PnpDistanceTrigSolve) {
               units::unit_cast<double>(pose.Z()), .01);
 
   /* Straight on */
-
   frc::Transform3d straightOnTestTransform =
       frc::Transform3d(0_m, 0_m, 3_m, frc::Rotation3d(0_rad, 0_rad, 0_rad));
+
   estimator.SetRobotToCameraTransform(straightOnTestTransform);
   realPose = frc::Pose3d(4.81_m, 2.38_m, 0_m,
                          frc::Rotation3d(0_rad, 0_rad, 2.818_rad));


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->


Port of the Java `PNP_DISTANCE_TRIG_SOLVE` strategy  to C++. Includes both the actual strategy, and the unit test for it.
This is mostly identical to the Java version, with some differences listed below:
* Like other strategies in C++, a warning is emitted upon a failure to get the position of the tag
* A warning is emitted if `Update` was called, but `AddHeadingData` was never called
* The unit test calls `Update`  in a loop for every unread result like the other C++ tests for `PhotonPoseEstimator`

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
