### PR TITLE
Fix 'Resource leak: <variable> is never closed' warnings

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/configuration/LegacyConfigProvider.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/LegacyConfigProvider.java
@@ -32,6 +32,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.*;
+import java.util.stream.Stream;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 import org.photonvision.common.util.file.FileUtils;
@@ -282,9 +283,8 @@ class LegacyConfigProvider extends ConfigProvider {
 
     private HashMap<String, CameraConfiguration> loadCameraConfigs() {
         HashMap<String, CameraConfiguration> loadedConfigurations = new HashMap<>();
-        try {
-            var subdirectories =
-                    Files.list(camerasFolder.toPath()).filter(f -> f.toFile().isDirectory()).toList();
+        try (Stream<Path> files = Files.list(camerasFolder.toPath())) {
+            var subdirectories = files.filter(f -> f.toFile().isDirectory()).toList();
 
             for (var subdir : subdirectories) {
                 var cameraConfigPath = Path.of(subdir.toString(), "config.json");
@@ -325,9 +325,11 @@ class LegacyConfigProvider extends ConfigProvider {
                 // Load pipelines by mapping the files within the pipelines subdir
                 // to their deserialized equivalents
                 var pipelineSubdirectory = Path.of(subdir.toString(), "pipelines");
-                List<CVPipelineSettings> settings =
-                        pipelineSubdirectory.toFile().exists()
-                                ? Files.list(pipelineSubdirectory)
+                List<CVPipelineSettings> settings = Collections.emptyList();
+                if (pipelineSubdirectory.toFile().exists()) {
+                    try (Stream<Path> subdirectoryFiles = Files.list(pipelineSubdirectory)) {
+                        settings =
+                                subdirectoryFiles
                                         .filter(p -> p.toFile().isFile())
                                         .map(
                                                 p -> {
@@ -350,8 +352,9 @@ class LegacyConfigProvider extends ConfigProvider {
                                                     return null;
                                                 })
                                         .filter(Objects::nonNull)
-                                        .toList()
-                                : Collections.emptyList();
+                                        .toList();
+                    }
+                }
 
                 loadedConfig.driveModeSettings = driverMode;
                 loadedConfig.addPipelineSettings(settings);

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 import org.photonvision.common.configuration.NeuralNetworkPropertyManager.ModelProperties;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
@@ -365,8 +366,8 @@ public class NeuralNetworkModelManager {
 
         models = new HashMap<>();
 
-        try {
-            Files.walk(modelsDirectory.toPath())
+        try (Stream<Path> files = Files.walk(modelsDirectory.toPath())) {
+            files
                     .filter(Files::isRegularFile)
                     .filter(
                             path ->
@@ -469,8 +470,8 @@ public class NeuralNetworkModelManager {
         File modelsDirectory = ConfigManager.getInstance().getModelsDirectory();
 
         if (modelsDirectory.exists()) {
-            try {
-                Files.walk(modelsDirectory.toPath())
+            try (Stream<Path> files = Files.walk(modelsDirectory.toPath())) {
+                files
                         .sorted((a, b) -> b.compareTo(a))
                         .forEach(
                                 path -> {

--- a/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
@@ -21,16 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.wpi.first.cscore.UsbCameraInfo;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.photonvision.common.util.TestUtils;
 import org.photonvision.vision.camera.CameraQuirk;
 import org.photonvision.vision.camera.PVCameraInfo;
@@ -39,22 +35,11 @@ import org.photonvision.vision.pipeline.ColoredShapePipelineSettings;
 import org.photonvision.vision.pipeline.ReflectivePipelineSettings;
 
 public class SQLConfigTest {
-    private static Path tmpDir;
+    @TempDir private static Path tmpDir;
 
     @BeforeAll
     public static void init() {
         TestUtils.loadLibraries();
-        try {
-            tmpDir = Files.createTempDirectory("SQLConfigTest");
-        } catch (IOException e) {
-            System.out.println("Couldn't create temporary directory, using current directory");
-            tmpDir = Path.of("jdbc_test", "temp");
-        }
-    }
-
-    @AfterAll
-    public static void cleanUp() throws IOException {
-        Files.walk(tmpDir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
     }
 
     @Test

--- a/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
@@ -100,13 +100,20 @@ public class VideoSimUtil {
     /**
      * Gets the 10x10 (grayscale) image of a specific 36h11 AprilTag.
      *
+     * <p>WARNING: This creates a {@link RawFrame} instance but does not close it, which would result
+     * in a resource leak if the {@link Mat} is garbage-collected. Unfortunately, closing the {@code
+     * RawFrame} inside this function would delete the underlying data that backs the {@code
+     * ByteBuffer} that is passed to the {@code Mat} constructor (see comments on <a
+     * href="https://github.com/PhotonVision/photonvision/pull/2023">PR 2023</a> for details).
+     * Luckily, this method is private and is (as of Aug 2025) only used to populate the {@link
+     * #kTag36h11Images} static map at static-initialization time.
+     *
      * @param id The fiducial id of the desired tag
      */
     private static Mat get36h11TagImage(int id) {
-        try (RawFrame frame = AprilTag.generate36h11AprilTagImage(id)) {
-            return new Mat(
-                    frame.getHeight(), frame.getWidth(), CvType.CV_8UC1, frame.getData(), frame.getStride());
-        }
+        RawFrame frame = AprilTag.generate36h11AprilTagImage(id);
+        return new Mat(
+                frame.getHeight(), frame.getWidth(), CvType.CV_8UC1, frame.getData(), frame.getStride());
     }
 
     /** Gets the points representing the marker(black square) corners. */

--- a/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/VideoSimUtil.java
@@ -103,9 +103,10 @@ public class VideoSimUtil {
      * @param id The fiducial id of the desired tag
      */
     private static Mat get36h11TagImage(int id) {
-        RawFrame frame = AprilTag.generate36h11AprilTagImage(id);
-        return new Mat(
-                frame.getHeight(), frame.getWidth(), CvType.CV_8UC1, frame.getData(), frame.getStride());
+        try (RawFrame frame = AprilTag.generate36h11AprilTagImage(id)) {
+            return new Mat(
+                    frame.getHeight(), frame.getWidth(), CvType.CV_8UC1, frame.getData(), frame.getStride());
+        }
     }
 
     /** Gets the points representing the marker(black square) corners. */

--- a/photon-lib/src/main/java/org/photonvision/simulation/VisionSystemSim.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/VisionSystemSim.java
@@ -122,6 +122,7 @@ public class VisionSystemSim {
      * @return If the camera was present and removed
      */
     public boolean removeCamera(PhotonCameraSim cameraSim) {
+        @SuppressWarnings("resource")
         boolean success = camSimMap.remove(cameraSim.getCamera().getName()) != null;
         camTrfMap.remove(cameraSim);
         return success;

--- a/photon-lib/src/test/java/org/photonvision/PhotonCameraTest.java
+++ b/photon-lib/src/test/java/org/photonvision/PhotonCameraTest.java
@@ -117,31 +117,31 @@ class PhotonCameraTest {
         inst.stopClient();
         inst.startServer();
 
-        var camera = new PhotonCamera(inst, "Arducam_OV2311_USB_Camera");
-        PhotonCamera.setVersionCheckEnabled(false);
+        try (PhotonCamera camera = new PhotonCamera(inst, "Arducam_OV2311_USB_Camera")) {
+            PhotonCamera.setVersionCheckEnabled(false);
 
-        for (int i = 0; i < 5; i++) {
-            Thread.sleep(500);
+            for (int i = 0; i < 5; i++) {
+                Thread.sleep(500);
 
-            var res = camera.getLatestResult();
-            var captureTime = res.getTimestampSeconds();
-            var now = Timer.getFPGATimestamp();
+                var res = camera.getLatestResult();
+                var captureTime = res.getTimestampSeconds();
+                var now = Timer.getFPGATimestamp();
 
-            // expectTrue(captureTime < now);
+                // expectTrue(captureTime < now);
 
-            System.out.println(
-                    "sequence "
-                            + res.metadata.sequenceID
-                            + " image capture "
-                            + captureTime
-                            + " received at "
-                            + res.getTimestampSeconds()
-                            + " now: "
-                            + NetworkTablesJNI.now() / 1e6
-                            + " time since last pong: "
-                            + res.metadata.timeSinceLastPong / 1e6);
+                System.out.println(
+                        "sequence "
+                                + res.metadata.sequenceID
+                                + " image capture "
+                                + captureTime
+                                + " received at "
+                                + res.getTimestampSeconds()
+                                + " now: "
+                                + NetworkTablesJNI.now() / 1e6
+                                + " time since last pong: "
+                                + res.metadata.timeSinceLastPong / 1e6);
+            }
         }
-
         HAL.shutdown();
     }
 
@@ -335,62 +335,62 @@ class PhotonCameraTest {
             Thread.sleep(20);
         }
 
-        // GIVEN a simulated camera
-        var sim = new PhotonCameraSim(camera);
-        // AND a result with a timeSinceLastPong in the past
-        PhotonPipelineResult noPongResult =
-                new PhotonPipelineResult(
-                        new PhotonPipelineMetadata(
-                                1, 2, 3, 10 * 1000000 // 10 seconds -> us since last pong
-                                ),
-                        List.of(),
-                        Optional.empty());
+        // GIVEN a simulated camera AND a result with a timeSinceLastPong in the past
+        try (PhotonCameraSim sim = new PhotonCameraSim(camera)) {
+            PhotonPipelineResult noPongResult =
+                    new PhotonPipelineResult(
+                            new PhotonPipelineMetadata(
+                                    1, 2, 3, 10 * 1000000 // 10 seconds -> us since last pong
+                                    ),
+                            List.of(),
+                            Optional.empty());
 
-        // Loop to hit cases past first iteration
-        for (int i = 0; i < 10; i++) {
-            // AND a PhotonCamera with a "new" result
+            // Loop to hit cases past first iteration
+            for (int i = 0; i < 10; i++) {
+                // AND a PhotonCamera with a "new" result
+                sim.submitProcessedFrame(noPongResult);
+
+                // WHEN we update the camera
+                camera.getAllUnreadResults();
+
+                // AND we tick SmartDashboard
+                SmartDashboard.updateValues();
+
+                // THEN the camera isn't disconnected
+                assertTrue(
+                        Arrays.stream(SmartDashboard.getStringArray("PhotonAlerts/warnings", new String[0]))
+                                .noneMatch(it -> it.equals(disconnectedCameraString)));
+                // AND the alert string looks like a timesync warning
+                assertTrue(
+                        Arrays.stream(SmartDashboard.getStringArray("PhotonAlerts/warnings", new String[0]))
+                                        .filter(it -> it.contains("is not connected to the TimeSyncServer"))
+                                        .count()
+                                == 1);
+
+                Thread.sleep(20);
+            }
+
+            final double HEARTBEAT_TIMEOUT = 0.5;
+
+            // GIVEN a PhotonCamera provided new results
+            SimHooks.pauseTiming();
             sim.submitProcessedFrame(noPongResult);
-
-            // WHEN we update the camera
             camera.getAllUnreadResults();
+            // AND in a connected state
+            assertTrue(camera.isConnected());
 
-            // AND we tick SmartDashboard
-            SmartDashboard.updateValues();
+            // WHEN we wait the timeout
+            SimHooks.stepTiming(HEARTBEAT_TIMEOUT * 1.5);
 
-            // THEN the camera isn't disconnected
-            assertTrue(
-                    Arrays.stream(SmartDashboard.getStringArray("PhotonAlerts/warnings", new String[0]))
-                            .noneMatch(it -> it.equals(disconnectedCameraString)));
-            // AND the alert string looks like a timesync warning
-            assertTrue(
-                    Arrays.stream(SmartDashboard.getStringArray("PhotonAlerts/warnings", new String[0]))
-                                    .filter(it -> it.contains("is not connected to the TimeSyncServer"))
-                                    .count()
-                            == 1);
+            // THEN the camera will not be connected
+            assertFalse(camera.isConnected());
 
-            Thread.sleep(20);
+            // WHEN we then provide new results
+            SimHooks.stepTiming(0.02);
+            sim.submitProcessedFrame(noPongResult);
+            camera.getAllUnreadResults();
+            // THEN the camera will not be connected
+            assertTrue(camera.isConnected());
         }
-
-        final double HEARTBEAT_TIMEOUT = 0.5;
-
-        // GIVEN a PhotonCamera provided new results
-        SimHooks.pauseTiming();
-        sim.submitProcessedFrame(noPongResult);
-        camera.getAllUnreadResults();
-        // AND in a connected state
-        assertTrue(camera.isConnected());
-
-        // WHEN we wait the timeout
-        SimHooks.stepTiming(HEARTBEAT_TIMEOUT * 1.5);
-
-        // THEN the camera will not be connected
-        assertFalse(camera.isConnected());
-
-        // WHEN we then provide new results
-        SimHooks.stepTiming(0.02);
-        sim.submitProcessedFrame(noPongResult);
-        camera.getAllUnreadResults();
-        // THEN the camera will not be connected
-        assertTrue(camera.isConnected());
     }
 }

--- a/photon-lib/src/test/java/org/photonvision/PhotonPoseEstimatorTest.java
+++ b/photon-lib/src/test/java/org/photonvision/PhotonPoseEstimatorTest.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.photonvision.PhotonPoseEstimator.ConstrainedSolvepnpParams;
@@ -72,6 +73,7 @@ import org.photonvision.targeting.TargetCorner;
 
 class PhotonPoseEstimatorTest {
     static AprilTagFieldLayout aprilTags;
+    @AutoClose final PhotonCameraInjector cameraOne = new PhotonCameraInjector();
 
     @BeforeAll
     public static void init() throws UnsatisfiedLinkError, IOException {
@@ -99,7 +101,6 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void testLowestAmbiguityStrategy() {
-        PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         cameraOne.result =
                 new PhotonPipelineResult(
                         0,
@@ -185,7 +186,6 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void testClosestToCameraHeightStrategy() {
-        PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         cameraOne.result =
                 new PhotonPipelineResult(
                         0,
@@ -274,7 +274,6 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void closestToReferencePoseStrategy() {
-        PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         cameraOne.result =
                 new PhotonPipelineResult(
                         0,
@@ -364,7 +363,6 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void closestToLastPose() {
-        PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         cameraOne.result =
                 new PhotonPipelineResult(
                         0,
@@ -529,7 +527,6 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void pnpDistanceTrigSolve() {
-        PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         List<VisionTargetSim> simTargets =
                 aprilTags.getTags().stream()
                         .map((AprilTag x) -> new VisionTargetSim(x.pose, TargetModel.kAprilTag36h11, x.ID))
@@ -591,7 +588,6 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void cacheIsInvalidated() {
-        PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         var result =
                 new PhotonPipelineResult(
                         0,
@@ -668,7 +664,6 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void averageBestPoses() {
-        PhotonCameraInjector cameraOne = new PhotonCameraInjector();
         cameraOne.result =
                 new PhotonPipelineResult(
                         0,
@@ -757,8 +752,7 @@ class PhotonPoseEstimatorTest {
 
     @Test
     void testMultiTagOnRioFallback() {
-        PhotonCameraInjector camera = new PhotonCameraInjector();
-        camera.result =
+        cameraOne.result =
                 new PhotonPipelineResult(
                         0,
                         11 * 1_000_000,
@@ -811,7 +805,7 @@ class PhotonPoseEstimatorTest {
                 new PhotonPoseEstimator(aprilTags, PoseStrategy.MULTI_TAG_PNP_ON_RIO, Transform3d.kZero);
         estimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
 
-        Optional<EstimatedRobotPose> estimatedPose = estimator.update(camera.result);
+        Optional<EstimatedRobotPose> estimatedPose = estimator.update(cameraOne.result);
         Pose3d pose = estimatedPose.get().estimatedPose;
         // Make sure values match what we'd expect for the LOWEST_AMBIGUITY strategy
         assertAll(

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -336,14 +336,10 @@ public class RequestHandler {
             return;
         }
 
-        try {
-            Path filePath =
-                    Paths.get(ProgramDirectoryUtilities.getProgramDirectory(), "photonvision.jar");
-            File targetFile = new File(filePath.toString());
-            var stream = new FileOutputStream(targetFile);
-
-            file.content().transferTo(stream);
-            stream.close();
+        Path targetPath =
+                Paths.get(ProgramDirectoryUtilities.getProgramDirectory(), "photonvision.jar");
+        try (InputStream fileSteam = file.content()) {
+            Files.copy(fileSteam, targetPath);
 
             ctx.status(200);
             ctx.result(
@@ -655,8 +651,8 @@ public class RequestHandler {
                 return;
             }
 
-            try (FileOutputStream out = new FileOutputStream(modelPath.toFile())) {
-                modelFile.content().transferTo(out);
+            try (InputStream modelFileStream = modelFile.content()) {
+                Files.copy(modelFileStream, modelPath);
             }
 
             ModelProperties modelProperties =

--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -46,9 +46,10 @@ dependencies {
     implementation "commons-cli:commons-cli:1.5.0"
     implementation "org.apache.commons:commons-exec:1.3"
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+    testImplementation(platform('org.junit:junit-bom:5.11.4'))
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 test {

--- a/shared/javacommon.gradle
+++ b/shared/javacommon.gradle
@@ -145,9 +145,10 @@ dependencies {
     implementation group: "org.ejml", name: "ejml-simple", version: wpi.versions.ejmlVersion.get()
     implementation group: "us.hebi.quickbuf", name: "quickbuf-runtime", version: wpi.versions.quickbufVersion.get();
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+    testImplementation(platform('org.junit:junit-bom:5.11.4'))
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 jacoco {


### PR DESCRIPTION
Fix numerous places where using AutoCloseable objects without closing them.

Changes:
- Upgrade JUnit from 5.10.0 to 5.11.4 (so `@AutoClose` can be used)
- Use `Files.copy()` to copy files
- Use try-with-resources when calling `Files.list()` or `Files.walk()`
- Use try-with-resources or `@AutoClose` to close `PhotonCamera` and
  `PhotonCameraSim` objects created by tests
- Update `SQLConfigTest` to use `@TempDir`

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
