### PR TITLE
Run metrics with debug false to reduce log spam

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/metrics/MetricsManager.java
@@ -280,7 +280,7 @@ public class MetricsManager {
 
     public synchronized String execute(String command) {
         try {
-            runCommand.executeBashCommand(command);
+            runCommand.executeBashCommand(command, true, false);
             return runCommand.getOutput();
         } catch (Exception e) {
             StringWriter sw = new StringWriter();


### PR DESCRIPTION
## Description

Because our metrics are updating every five seconds, our previous approach of logging all the commands we run for metrics results in a lot of debug log spam.  This adjusts the shellExec for metrics so that we no longer spam.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [x] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [x] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [x] If this PR addresses a bug, a regression test for it is added
