### PR TITLE
Expose and document NMS slider

### DIFF
--- a/docs/source/docs/objectDetection/about-object-detection.md
+++ b/docs/source/docs/objectDetection/about-object-detection.md
@@ -18,7 +18,7 @@ This model output means that while its fairly easy to say that "this rectangle p
 
 ## Tuning and Filtering
 
-Compared to other pipelines, object detection exposes very few tuning handles. The Confidence slider changes the minimum confidence that the model needs to have in a given detection to consider it valid, as a number between 0 and 1 (with 0 meaning completely uncertain and 1 meaning maximally certain).
+Compared to other pipelines, object detection exposes very few tuning handles. The Confidence slider changes the minimum confidence that the model needs to have in a given detection to consider it valid, as a number between 0 and 1 (with 0 meaning completely uncertain and 1 meaning maximally certain). The Non-Maximum Suppresion (NMS) Threshold slider is used to filter out overlapping detections. Lower values mean more detections are allowed through, but may result in false positives. It's generally recommended that teams leave this set at the default, unless they find they're unable to get usable results with solely the Confidence slider.
 
 ```{raw} html
 <video width="85%" controls>

--- a/photon-client/src/components/dashboard/tabs/ObjectDetectionTab.vue
+++ b/photon-client/src/components/dashboard/tabs/ObjectDetectionTab.vue
@@ -85,6 +85,17 @@ const selectedModel = computed({
         (value) => useCameraSettingsStore().changeCurrentPipelineSetting({ confidence: value }, false)
       "
     />
+    <pv-slider
+      v-model="currentPipelineSettings.nms"
+      class="pt-2"
+      :slider-cols="interactiveCols"
+      label="NMS Threshold"
+      tooltip="The Non-Maximum Suppression threshold used to filter out overlapping detections. Lower values mean more detections are allowed through, but may result in false positives."
+      :min="0"
+      :max="1"
+      :step="0.01"
+      @update:modelValue="(value) => useCameraSettingsStore().changeCurrentPipelineSetting({ nms: value }, false)"
+    />
     <pv-range-slider
       v-model="contourArea"
       label="Area"


### PR DESCRIPTION
## Description

The Non-Maximum Suppresion (NMS) Threshold slider is used to filter out overlapping detections. Lower values mean more detections are allowed through, but may result in false positives. It's generally recommended that teams leave this set at the default, unless they find they're unable to get usable results with solely the Confidence slider.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [x] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [x] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [x] If this PR addresses a bug, a regression test for it is added
