### PR TITLE
Disable linkcheck for www.gnu.org

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,7 +147,7 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 linkcheck_ignore = [
     R"https://www.raspberrypi.com/software/",
     R"http://10\..+",
-    R"https://gnu.org/",
+    R"https://www.gnu.org/",
 ]
 
 token = os.environ.get("GITHUB_TOKEN", None)


### PR DESCRIPTION
## Description

#1973 missed the `www.` in the link, which meant it did nothing. This actually properly disables linkcheck for GNU's website.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
