### PR TITLE
Fix buildAndCopyUI and update build instructions

### DIFF
--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -12,7 +12,11 @@ This section contains the build instructions from the source code available at [
 
 **Node JS:**
 
- The UI is written in Node JS. To compile the UI, Node 22.15.0 is required. To install Node JS follow the instructions for your platform [on the official Node JS website](https://nodejs.org/en/download/).
+ The UI is written in Node JS. To compile the UI, Node 22 or later is required. To install Node JS, follow the instructions for your platform [on the official Node JS website](https://nodejs.org/en/download/).
+
+**pnpm:**
+
+ [pnpm](https://pnpm.io/) is the package manager used to download dependencies for the UI. To install pnpm, follow [the instructions on the official pnpm website](https://pnpm.io/installation).
 
 ## Compiling Instructions
 
@@ -197,7 +201,7 @@ Similarly, a local instance of PhotonVision can be debugged in the same way usin
 
 Set up a VSCode configuration in {code}`launch.json`
 
-```
+```json
 {
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -44,8 +44,13 @@ tasks.register('copyClientUIToResources', Copy) {
     into "${projectDir}/src/main/resources/web/"
 }
 
-tasks.register("buildAndCopyUI") {
-    dependsOn "pnpm_run_build"
+tasks.register('buildClient', PnpmTask) {
+    args = ["build"]
+    dependsOn "pnpmInstall"
+}
+
+tasks.register('buildAndCopyUI') {
+    dependsOn "buildClient"
     finalizedBy "copyClientUIToResources"
 }
 


### PR DESCRIPTION
## Description

The Gradle plugin we use for invoking Node and npm seems to not support the same tasks for pnpm. Define our own task for building the UI. Add install instructions for pnpm because you need it installed globally for the task to work. (minor fix to code block because it was easy to fix while updating the instructions.)

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
