### PR TITLE
Fix labeler labelling everything as backend

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,8 @@
 "backend":
-  - changed-files:
-      - any-glob-to-any-file: [photon-core/**, photon-server/**]
-      - all-globs-to-all-files: "!photon-server/src/main/resources/web/index.html"
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: [photon-core/**, photon-server/**]
+          - all-globs-to-all-files: "!photon-server/src/main/resources/web/index.html"
 "documentation":
   - changed-files:
       - any-glob-to-any-file: [docs/**, photon-docs/**]


### PR DESCRIPTION
## Description

When the labeler is provided with multiple match objects, the default behavior is to apply the label if any of them match. This causes all PRs to be incorrectly labeled as "backend", since they will usually match the glob of not modifying photon-server's index.html. This changes the logic so that all match objects must be true, which means the criteria for the "backend" label to be applied now requires a PR to either have modified photon-core or photon-server, and for photon-server's index.html file to not be modified.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
