### PR TITLE
Make dashboard theme transition smooth and fix link color

### DIFF
--- a/photon-client/src/components/dashboard/ConfigOptions.vue
+++ b/photon-client/src/components/dashboard/ConfigOptions.vue
@@ -151,6 +151,11 @@ const onBeforeTabUpdate = () => {
 </template>
 
 <style>
+.v-slide-group {
+  transition-duration: 0.28s;
+  transition-property: box-shadow, opacity, background;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
 .v-slide-group__next--disabled,
 .v-slide-group__prev--disabled {
   display: none !important;

--- a/photon-client/src/views/DashboardView.vue
+++ b/photon-client/src/views/DashboardView.vue
@@ -126,7 +126,7 @@ const showCameraSetupDialog = ref(useCameraSettingsStore().needsCameraConfigurat
         <v-card-title>Set up some cameras to get started!</v-card-title>
         <v-card-text class="pt-0">
           No cameras activated - head to the
-          <router-link to="/cameraConfigs" color="buttonActive">camera matching tab</router-link> to set some up!
+          <router-link to="/cameraConfigs">camera matching tab</router-link> to set some up!
         </v-card-text>
       </v-card>
     </v-dialog>
@@ -135,6 +135,7 @@ const showCameraSetupDialog = ref(useCameraSettingsStore().needsCameraConfigurat
 
 <style scoped>
 a:link {
+  color: rgb(var(--v-theme-buttonActive));
   background-color: transparent;
   text-decoration: none;
 }


### PR DESCRIPTION
## Description

Poking around in DevTools allowed me to find the CSS class needed to apply the theme transition to the dashboard tabs. Now the dashboard tabs transition smoothly with the rest of the card when the theme changes. Also changed the link color to be yellow, which looks much nicer than before.

Old:
<img width="1066" height="761" alt="image" src="https://github.com/user-attachments/assets/9d0b7ca8-2daa-4b74-8e64-3726eb27f3b7" />

New:
<img width="1059" height="760" alt="image" src="https://github.com/user-attachments/assets/a4efc2b7-945c-4cd2-bc92-e2aafc035fa5" />

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
