### PR TITLE
Refactor LibCameraJNILoader to use PhotonJNICommon

### DIFF
--- a/photon-core/src/main/java/org/photonvision/raspi/LibCameraJNILoader.java
+++ b/photon-core/src/main/java/org/photonvision/raspi/LibCameraJNILoader.java
@@ -17,60 +17,34 @@
 
 package org.photonvision.raspi;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import org.photonvision.common.logging.LogGroup;
-import org.photonvision.common.logging.Logger;
+import java.util.List;
+import org.photonvision.jni.PhotonJNICommon;
 
-/**
- * Helper for extracting photon-libcamera-gl-driver shared library files. TODO: Refactor to use
- * PhotonJNICommon
- */
-public class LibCameraJNILoader {
+/** Helper for extracting photon-libcamera-gl-driver shared library files. */
+public class LibCameraJNILoader extends PhotonJNICommon {
     private static boolean libraryLoaded = false;
-    private static final Logger logger = new Logger(LibCameraJNILoader.class, LogGroup.Camera);
+    private static LibCameraJNILoader instance = null;
+
+    public static synchronized LibCameraJNILoader getInstance() {
+        if (instance == null) instance = new LibCameraJNILoader();
+
+        return instance;
+    }
 
     public static synchronized void forceLoad() throws IOException {
-        if (libraryLoaded) return;
+        forceLoad(
+                LibCameraJNILoader.getInstance(), LibCameraJNILoader.class, List.of("photonlibcamera"));
+    }
 
-        var libraryName = "photonlibcamera";
+    @Override
+    public boolean isLoaded() {
+        return libraryLoaded;
+    }
 
-        try {
-            // We always extract the shared object (we could hash each so, but that's a lot of work)
-            var arch_name = "linuxarm64";
-            var nativeLibName = System.mapLibraryName(libraryName);
-            var resourcePath = "/nativelibraries/" + arch_name + "/" + nativeLibName;
-            var in = LibCameraJNILoader.class.getResourceAsStream(resourcePath);
-
-            if (in == null) {
-                logger.error("Failed to find internal native library at path " + resourcePath);
-                libraryLoaded = false;
-                return;
-            }
-
-            // It's important that we don't mangle the names of these files on Windows at least
-            File temp = new File(System.getProperty("java.io.tmpdir"), nativeLibName);
-            FileOutputStream fos = new FileOutputStream(temp);
-
-            int read = -1;
-            byte[] buffer = new byte[1024];
-            while ((read = in.read(buffer)) != -1) {
-                fos.write(buffer, 0, read);
-            }
-            fos.close();
-            in.close();
-
-            System.load(temp.getAbsolutePath());
-
-            logger.info("Successfully loaded shared object " + temp.getName());
-
-        } catch (UnsatisfiedLinkError e) {
-            logger.error("Couldn't load shared object " + libraryName, e);
-            e.printStackTrace();
-            // logger.error(System.getProperty("java.library.path"));
-        }
-        libraryLoaded = true;
+    @Override
+    public void setLoaded(boolean state) {
+        libraryLoaded = state;
     }
 
     public static boolean isSupported() {


### PR DESCRIPTION
## Description

This fixes a bug where the library would always be reported as loaded, causing `isSupported` to throw an exception if the library wasn't able to be loaded, which also caused start up issues when the library failed to load.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
