### PR TITLE
Only make vendor-json-repo PR if the repo is ours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -604,4 +604,4 @@ jobs:
           vendordep_file: ${{ github.workspace }}/photonlib-${{ github.ref_name }}.json
           pr_title: Update photonlib to ${{ github.ref_name }}
           pr_branch: photonlib-${{ github.ref_name }}
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.repository == 'PhotonVision/photonvision' && startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Description

This prevents jobs from failing on forks of the repo.
Closes #1975.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
