### PR TITLE
Only update UI when there's been a change in conflict detection

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -301,7 +301,7 @@ public class NetworkTablesManager {
         }
 
         if (conflictingHostname != this.conflictingHostname
-                || conflictingCameras.toString().equals(this.conflictingCameras)) {
+                || !conflictingCameras.toString().equals(this.conflictingCameras)) {
             // Only publish the conflict status when it's changed to prevent the settings cards from being
             // forcibly reset
             DataChangeService.getInstance()

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -300,20 +300,21 @@ public class NetworkTablesManager {
             }
         }
 
-        // Publish the conflict status
-        DataChangeService.getInstance()
-                .publishEvent(
-                        new OutgoingUIEvent<>(
-                                "fullsettings",
-                                UIPhotonConfiguration.programStateToUi(ConfigManager.getInstance().getConfig())));
-
-        conflictAlert.setText(
-                conflictingHostname
-                        ? "Hostname conflict detected for " + hostname + "!"
-                        : ""
-                                + (conflictingCameras.isEmpty()
-                                        ? ""
-                                        : " Camera name conflict detected: " + conflictingCameras.toString() + "!"));
+        if (conflictingHostname != this.conflictingHostname
+                || conflictingCameras.toString().equals(this.conflictingCameras)) {
+            // Only publish the conflict status when it's changed to prevent the settings cards from being
+            // forcibly reset
+            DataChangeService.getInstance()
+                    .publishEvent(
+                            new OutgoingUIEvent<>(
+                                    "fullsettings",
+                                    UIPhotonConfiguration.programStateToUi(ConfigManager.getInstance().getConfig())));
+        }
+        if (conflictingHostname) {
+            conflictAlert.setText("Hostname conflict detected for " + hostname + "!");
+        } else if (!conflictingCameras.isEmpty()) {
+            conflictAlert.setText("Camera name conflict detected: " + conflictingCameras + "!");
+        }
         conflictAlert.set(conflictingHostname || !conflictingCameras.isEmpty());
         SmartDashboard.updateValues();
         this.conflictingHostname = conflictingHostname;


### PR DESCRIPTION
## Description

After #1991, the program state was always resent in an attempt to simplify logic, but this had the side effect of causing the settings UI to reset periodically when the hostname check was performed. This restores the original logic in #1791 to check for differences in the conflict state, and to only send the program state if it's changed.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
