### PR TITLE
Use deploy-utils instead of an external ssh plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Note that these are case sensitive!
     * linuxarm64
     * linuxathena
 - `-PtgtIP`: Specifies where `./gradlew deploy` should try to copy the fat JAR to
+- `-PtgtUser`: Specifies custom username for `./gradlew deploy` to SSH into
+- `-PtgtPw`: Specifies custom password for `./gradlew deploy` to SSH into
 - `-Pprofile`: enables JVM profiling
 - `-PwithSanitizers`: On Linux, enables `-fsanitize=address,undefined,leak`
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
     id "org.ysb33r.doxygen" version "1.0.4" apply false
     id 'com.gradleup.shadow' version '8.3.4' apply false
     id "com.github.node-gradle.node" version "7.0.1" apply false
-    id "org.hidetake.ssh" version "2.11.2" apply false
 }
 
 allprojects {

--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -113,7 +113,7 @@ Running the following command under the root directory will build the jar under 
 
 ### Build and Run PhotonVision on a Raspberry Pi Coprocessor
 
-As a convenience, the build has a built-in `deploy` command which builds, deploys, and starts the current source code on a coprocessor.
+As a convenience, the build has a built-in `deploy` command which builds, deploys, and starts the current source code on a coprocessor. It uses [deploy-utils](https://github.com/wpilibsuite/deploy-utils/blob/main/README.md), so it works very similarly to deploys on robot projects.
 
 An architecture override is required to specify the deploy target's architecture.
 

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -82,8 +82,16 @@ deploy {
                     } else {
                         address = "photonvision.local"
                     }
-                    user = "pi"
-                    password = "raspberry"
+                    if (project.hasProperty('tgtUser')) {
+                        user = tgtUser
+                    } else {
+                        user = "pi"
+                    }
+                    if (project.hasProperty('tgtPw')) {
+                        password = tgtPw
+                    } else {
+                        password = "raspberry"
+                    }
                 }
             }
             artifacts {

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: "org.hidetake.ssh"
 apply plugin: "com.github.node-gradle.node"
 apply plugin: 'com.gradleup.shadow'
 apply plugin: "application"
@@ -68,72 +67,63 @@ run {
     }
 }
 
-remotes {
-    pi {
-        host = 'photonvision.local'
-        user = 'pi'
-        password = 'raspberry'
-        knownHosts = allowAnyHosts
-    }
-}
-
-task findDeployTarget {
-    doLast {
-        if(project.hasProperty('tgtIP')){
-            //If user specified IP, default to using the PI profile
-            // but adjust hostname to match the provided IP address
-            findDeployTarget.ext.rmt = remotes.pi
-            findDeployTarget.ext.rmt.host=tgtIP
-        } else {
-            findDeployTarget.ext.rmt = null
-            for(testRmt in remotes){
-                println "Checking for " + testRmt.host
-                boolean canContact = false;
-                try {
-                    InetAddress testAddr = InetAddress.getByName(testRmt.host)
-                    canContact = testAddr.isReachable(2000)
-                } catch(UnknownHostException e) {
-                    canContact = false;
-                }
-                if(canContact){
-                    println "Found!"
-                    findDeployTarget.ext.rmt = testRmt
-                    break
-                } else {
-                    println "Not Found."
+import edu.wpi.first.deployutils.deploy.artifact.*
+import edu.wpi.first.deployutils.deploy.target.RemoteTarget
+import edu.wpi.first.deployutils.deploy.target.location.SshDeployLocation
+deploy {
+    targets {
+        pi(RemoteTarget) {
+            // Can't login as root, so deploy our file to /tmp, which is owned by pi
+            directory = '/tmp'
+            locations {
+                ssh(SshDeployLocation) {
+                    if (project.hasProperty('tgtIP')) {
+                        address = tgtIP
+                    } else {
+                        address = "photonvision.local"
+                    }
+                    user = "pi"
+                    password = "raspberry"
                 }
             }
-            if(findDeployTarget.ext.rmt == null ){
-                throw new GradleException("Could not find a supported target for deployment!")
-            }
-        }
-    }
-}
-
-task deploy {
-    dependsOn findDeployTarget
-    dependsOn 'shadowJar'
-
-    doLast {
-        println 'Starting deployment to ' + findDeployTarget.rmt.host
-        println 'targetArch = ' + wpilibTools.platformMapper.currentPlatform.platformName
-        ssh.run{
-            session(findDeployTarget.rmt) {
-                //Stop photonvision before manipulating its files
-                execute 'sudo systemctl stop photonvision.service'
-                // gerth2 - I was having issues with the .jar being in use still - waiting a tiny bit here seems to get rid of it on a pi4
-                execute 'sleep 3'
-                // Copy into a folder owned by PI. Mostly because, as far as I can tell, the put command doesn't support sudo.
-                put from: "${projectDir}/build/libs/photonvision-${project.version}-${wpilibTools.platformMapper.currentPlatform.platformName}.jar", into: "/tmp/photonvision.jar"
-                //belt-and-suspenders. Make sure the old jar is gone first.
-                execute 'sudo rm -f /opt/photonvision/photonvision.jar'
-                //Copy in the new .jar and make sure it's executable
-                execute 'sudo mv /tmp/photonvision.jar /opt/photonvision/photonvision.jar'
-                execute 'sudo chmod +x /opt/photonvision/photonvision.jar'
-                //Fire up photonvision again
-                execute 'sudo systemctl start photonvision.service'
-                //Cleanup
-                execute 'sudo rm -f /tmp/photonvision.jar'
+            artifacts {
+                stop(CommandArtifact) {
+                    predeploy << {
+                        println 'Starting deployment to ' + deploy.targets.pi.locations.ssh.address
+                        println 'targetArch = ' + wpilibTools.platformMapper.currentPlatform.platformName
+                    }
+                    //Stop photonvision before manipulating its files
+                    command = "sudo systemctl stop photonvision.service"
+                }
+                sleep(CommandArtifact) {
+                    // gerth2 - I was having issues with the .jar being in use still - waiting a tiny bit here seems to get rid of it on a pi4
+                    command = "sleep 3"
+                    dependsOn artifacts.stop.deployTask
+                }
+                photonvisionJar(JavaArtifact) {
+                    jarTask = shadowJar
+                    filename = "photonvision.jar"
+                    dependsOn artifacts.sleep.deployTask
+                }
+                moveJar(CommandArtifact) {
+                    //belt-and-suspenders. Make sure the old jar is gone first before moving in the new .jar
+                    command = "sudo rm -f /opt/photonvision/photonvision.jar && sudo mv /tmp/photonvision.jar /opt/photonvision/photonvision.jar"
+                    dependsOn artifacts.photonvisionJar.deployTask
+                }
+                chmodJar(CommandArtifact) {
+                    //Make sure it's executable
+                    command = "sudo chmod +x /opt/photonvision/photonvision.jar"
+                    dependsOn artifacts.moveJar.deployTask
+                }
+                start(CommandArtifact) {
+                    //Fire up photonvision again
+                    command = "sudo systemctl start photonvision.service"
+                    dependsOn artifacts.chmodJar.deployTask
+                }
+                cleanUp(CommandArtifact) {
+                    command = 'sudo rm -f /tmp/photonvision.jar'
+                    dependsOn artifacts.moveJar.deployTask
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

deploy-utils is bundled as part of GradleRIO, so we may as well use it instead of using an external ssh plugin.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
