### PR TITLE
Set the initial capacity of ArrayLists in getAllUnreadResults()

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -286,11 +286,10 @@ public class PhotonCamera implements AutoCloseable {
         verifyVersion();
         updateDisconnectAlert();
 
-        List<PhotonPipelineResult> ret = new ArrayList<>();
-
         // Grab the latest results. We don't care about the timestamps from NT - the metadata header has
         // this, latency compensated by the Time Sync Client
         var changes = resultSubscriber.getAllChanges();
+        List<PhotonPipelineResult> ret = new ArrayList<>(changes.size());
         for (var c : changes) {
             var result = c.value;
             checkTimeSyncOrWarn(result);

--- a/photon-targeting/src/main/java/org/photonvision/common/networktables/PacketSubscriber.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/networktables/PacketSubscriber.java
@@ -101,11 +101,10 @@ public class PacketSubscriber<T> implements AutoCloseable {
     }
 
     public List<PacketResult<T>> getAllChanges() {
-        List<PacketResult<T>> ret = new ArrayList<>();
-
         // Get /all/ changes since last call to readQueue
         var changes = subscriber.readQueue();
 
+        List<PacketResult<T>> ret = new ArrayList<>(changes.length);
         for (var change : changes) {
             ret.add(parse(change.value, change.timestamp));
         }


### PR DESCRIPTION
If there are more than 10 queued results, PhotonCamera.getAllUnreadResults() would resize two arrays at least once each.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
