### PR TITLE
Fix most gradle deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'edu.wpi.first.WpilibTools' version '1.3.0'
     id 'com.google.protobuf' version '0.9.3' apply false
     id 'edu.wpi.first.GradleJni' version '1.1.0'
-    id "org.ysb33r.doxygen" version "1.0.4" apply false
+    id "org.ysb33r.doxygen" version "2.0.0" apply false
     id 'com.gradleup.shadow' version '8.3.4' apply false
     id "com.github.node-gradle.node" version "7.0.1" apply false
 }
@@ -101,7 +101,7 @@ spotless {
 }
 
 wrapper {
-    gradleVersion '8.14.3'
+    gradleVersion = '8.14.3'
 }
 
 ext.getCurrentArch = {

--- a/photon-docs/build.gradle
+++ b/photon-docs/build.gradle
@@ -39,13 +39,10 @@ doxygen {
     }
 }
 
-doxygen {
-    option 'generate_html', true
-    option 'html_extra_stylesheet', 'theme.css'
-
+doxygen.sourceSets.main {
     cppProjectZips.each {
-        dependsOn it
-        source it.source
+        doxygenDox.dependsOn it
+        sources it.source
         it.ext.includeDirs.each {
             cppIncludeRoots.add(it.absolutePath)
         }
@@ -100,7 +97,7 @@ tasks.register("zipCppDocs", Zip) {
 // Java
 configurations {
     javaSource {
-        transitive false
+        transitive = false
     }
 }
 
@@ -158,22 +155,22 @@ publishing {
             artifact zipJavaDocs
 
             artifactId = "${baseArtifactIdJava}"
-            groupId artifactGroupIdJava
-            version pubVersion
+            groupId = artifactGroupIdJava
+            version = pubVersion
         }
         cpp(MavenPublication) {
             artifact zipCppDocs
 
             artifactId = "${baseArtifactIdCpp}"
-            groupId artifactGroupIdCpp
-            version pubVersion
+            groupId = artifactGroupIdCpp
+            version = pubVersion
         }
     }
 
     repositories {
         maven {
             // Just throw everything into build/maven
-            url(localMavenURL)
+            url = localMavenURL
         }
     }
 }

--- a/photon-lib/build.gradle
+++ b/photon-lib/build.gradle
@@ -282,7 +282,7 @@ if (!project.hasProperty('copyOfflineArtifacts')) {
 
                 artifactId = "${nativeName}-json"
                 groupId = "org.photonvision"
-                version "1.0"
+                version = "1.0"
             }
         }
     }
@@ -344,8 +344,8 @@ publishing {
                 artifact combinedHeadersZip
 
                 artifactId = "${nativeName}-combinedcpp"
-                groupId artifactGroupId
-                version pubVersion
+                groupId = artifactGroupId
+                version = pubVersion
             }
         }
     }

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -14,8 +14,8 @@ dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
 }
 
-group 'org.photonvision'
-version versionString + (project.hasProperty('pionly') ? "-raspi" : "")
+group = 'org.photonvision'
+version  = versionString + (project.hasProperty('pionly') ? "-raspi" : "")
 
 application {
     mainClass = 'org.photonvision.Main'

--- a/photon-targeting/build.gradle
+++ b/photon-targeting/build.gradle
@@ -217,8 +217,8 @@ publishing {
                 classifier = null
             }
             artifactId = "${nativeName}-rawjava"
-            groupId artifactGroupId
-            version pubVersion
+            groupId = artifactGroupId
+            version = pubVersion
         }
     }
 }

--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -67,7 +67,7 @@ tasks.register('testHeadless', Test) {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed", "standardOut", "standardError"
-        exceptionFormat "full"
+        exceptionFormat = "full"
         showStandardStreams = true
     }
     exclude '**/*BenchmarkTest*'

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -45,7 +45,7 @@ model {
 
 task copyAllOutputs(type: Copy) {
     def outputsFolder = file("$project.buildDir/outputs")
-    destinationDir outputsFolder
+    destinationDir = outputsFolder
 }
 
 ext.addTaskToCopyAllOutputs = { task ->

--- a/shared/javacommon.gradle
+++ b/shared/javacommon.gradle
@@ -85,8 +85,8 @@ publishing {
             artifact javadocJar
 
             artifactId = "${baseArtifactId}-java"
-            groupId artifactGroupId
-            version pubVersion
+            groupId = artifactGroupId
+            version = pubVersion
         }
     }
 
@@ -97,10 +97,10 @@ publishing {
             if (project.hasProperty('copyOfflineArtifacts')) {
                 url(localMavenURL)
             } else {
-                url(photonMavenURL)
+                url = photonMavenURL
                 credentials {
-                    username 'ghactions'
-                    password System.getenv("ARTIFACTORY_API_KEY")
+                    username = 'ghactions'
+                    password =  System.getenv("ARTIFACTORY_API_KEY")
                 }
             }
         }
@@ -112,7 +112,7 @@ test {
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
     testLogging {
         events "failed"
-        exceptionFormat "full"
+        exceptionFormat = "full"
         showStandardStreams = true
     }
     forkEvery = 1

--- a/versioningHelper.gradle
+++ b/versioningHelper.gradle
@@ -8,7 +8,7 @@ gradle.allprojects {
         def stdout = new ByteArrayOutputStream()
         String tagIsh
         try {
-            exec {
+            Project.getProviders().exec {
                 commandLine 'git', 'describe', '--tags', "--match=v*"
                 standardOutput = stdout
             }


### PR DESCRIPTION
## Description

Fixed most Gradle deprecation warnings. Only one left that I can see and I believe its from a WPI dependency that hasn't been updated. Fixed these so we can update to 9.0 eventually

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
