### PR TITLE
Fix documentation tab set syncing

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,6 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.todo",
-    "sphinx_tabs.tabs",
     "notfound.extension",
     "sphinxext.remoteliteralinclude",
     "sphinxext.opengraph",

--- a/docs/source/docs/apriltag-pipelines/multitag.md
+++ b/docs/source/docs/apriltag-pipelines/multitag.md
@@ -28,7 +28,7 @@ This multi-target pose estimate can be accessed using PhotonLib. We suggest usin
 ```{eval-rst}
 .. tab-set-code::
 
-    .. code-block:: Java
+    .. code-block:: java
 
         var results = camera.getAllUnreadResults();
         for (var result : results) {
@@ -39,7 +39,7 @@ This multi-target pose estimate can be accessed using PhotonLib. We suggest usin
         }
 
 
-    .. code-block:: C++
+    .. code-block:: c++
 
       auto results = camera.GetAllUnreadResults();
       for (auto &result : results)
@@ -51,7 +51,7 @@ This multi-target pose estimate can be accessed using PhotonLib. We suggest usin
       }
 
 
-    .. code-block:: Python
+    .. code-block:: python
 
       results = camera.getAllUnreadResults()
       for result in results:

--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -61,14 +61,17 @@ To compile and run the project, issue the following command in the root director
 .. tab-set::
 
    .. tab-item:: Linux
+      :sync: linux
 
       ``./gradlew run``
 
    .. tab-item:: macOS
+      :sync: macos
 
       ``./gradlew run``
 
    .. tab-item:: Windows (cmd)
+      :sync: windows
 
       ``gradlew run``
 ```
@@ -79,14 +82,17 @@ Running the following command under the root directory will build the jar under 
 .. tab-set::
 
    .. tab-item:: Linux
+      :sync: linux
 
       ``./gradlew shadowJar``
 
    .. tab-item:: macOS
+      :sync: macos
 
       ``./gradlew shadowJar``
 
    .. tab-item:: Windows (cmd)
+      :sync: windows
 
       ``gradlew shadowJar``
 ```
@@ -101,18 +107,21 @@ An architecture override is required to specify the deploy target's architecture
 .. tab-set::
 
    .. tab-item:: Linux
+      :sync: linux
 
       ``./gradlew clean``
 
       ``./gradlew deploy -PArchOverride=linuxarm64``
 
    .. tab-item:: macOS
+      :sync: macos
 
       ``./gradlew clean``
 
       ``./gradlew deploy -PArchOverride=linuxarm64``
 
    .. tab-item:: Windows (cmd)
+      :sync: windows
 
       ``gradlew clean``
 
@@ -131,14 +140,17 @@ The photonlib source can be published to your local maven repository after build
 .. tab-set::
 
    .. tab-item:: Linux
+      :sync: linux
 
       ``./gradlew publishToMavenLocal``
 
    .. tab-item:: macOS
+      :sync: macos
 
       ``./gradlew publishToMavenLocal``
 
    .. tab-item:: Windows (cmd)
+      :sync: windows
 
       ``gradlew publishToMavenLocal``
 ```

--- a/docs/source/docs/examples/aimandrange.md
+++ b/docs/source/docs/examples/aimandrange.md
@@ -14,8 +14,10 @@ To do this, we'll use the _pitch_ of the target in the camera image and trigonom
 
 ```{eval-rst}
 .. tab-set::
+    :sync-group: code
 
     .. tab-item:: Java
+       :sync: java
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/aimandrange/src/main/java/frc/robot/Robot.java
          :language: java
@@ -24,6 +26,7 @@ To do this, we'll use the _pitch_ of the target in the camera image and trigonom
          :lineno-start: 84
 
     .. tab-item:: C++ (Header)
+       :sync: c++
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/aimandrange/src/main/include/Robot.h
          :language: c++
@@ -32,6 +35,7 @@ To do this, we'll use the _pitch_ of the target in the camera image and trigonom
          :lineno-start: 25
 
     .. tab-item:: C++ (Source)
+       :sync: c++
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/aimandrange/src/main/cpp/Robot.cpp
          :language: c++
@@ -40,6 +44,7 @@ To do this, we'll use the _pitch_ of the target in the camera image and trigonom
          :lineno-start: 58
 
     .. tab-item:: Python
+       :sync: python
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/aimandrange/robot.py
          :language: python

--- a/docs/source/docs/examples/aimingatatarget.md
+++ b/docs/source/docs/examples/aimingatatarget.md
@@ -19,8 +19,10 @@ In this example, while the operator holds a button down, the robot will turn tow
 
 ```{eval-rst}
 .. tab-set::
+    :sync-group: code
 
     .. tab-item:: Java
+       :sync: java
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/aimattarget/src/main/java/frc/robot/Robot.java
          :language: java
@@ -29,6 +31,7 @@ In this example, while the operator holds a button down, the robot will turn tow
          :lineno-start: 77
 
     .. tab-item:: C++ (Header)
+       :sync: c++
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/aimattarget/src/main/include/Robot.h
          :language: c++
@@ -37,6 +40,7 @@ In this example, while the operator holds a button down, the robot will turn tow
          :lineno-start: 25
 
     .. tab-item:: C++ (Source)
+       :sync: c++
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/aimattarget/src/main/cpp/Robot.cpp
          :language: c++
@@ -45,6 +49,7 @@ In this example, while the operator holds a button down, the robot will turn tow
          :lineno-start: 56
 
     .. tab-item:: Python
+       :sync: python
 
        .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/aimattarget/robot.py
          :language: python

--- a/docs/source/docs/examples/poseest.md
+++ b/docs/source/docs/examples/poseest.md
@@ -133,7 +133,7 @@ Then, we add configure the simulated vision system to match the camera system be
       :linenos:
       :lineno-start: 53
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 ```

--- a/docs/source/docs/examples/poseest.md
+++ b/docs/source/docs/examples/poseest.md
@@ -21,32 +21,24 @@ Please reference the [WPILib documentation](https://docs.wpilib.org/en/stable/do
 We use the 2024 game's AprilTag Locations:
 
 ```{eval-rst}
-.. tab-set::
+.. tab-set-code::
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
+      :language: java
+      :lines: 68-68
+      :linenos:
+      :lineno-start: 68
 
-    .. tab-item:: Java
-       :sync: java
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Constants.h
+      :language: c++
+      :lines: 42-43
+      :linenos:
+      :lineno-start: 42
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
-         :language: java
-         :lines: 68-68
-         :linenos:
-         :lineno-start: 68
-
-    .. tab-item:: C++
-
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Constants.h
-         :language: c++
-         :lines: 42-43
-         :linenos:
-         :lineno-start: 42
-
-    .. tab-item:: Python
-
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/poseest/robot.py
-         :language: python
-         :lines: 46-46
-         :linenos:
-         :lineno-start: 46
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/poseest/robot.py
+      :language: python
+      :lines: 46-46
+      :linenos:
+      :lineno-start: 46
 
 ```
 
@@ -56,63 +48,47 @@ To incorporate PhotonVision, we need to create a {code}`PhotonCamera`:
 
 
 ```{eval-rst}
-.. tab-set::
+.. tab-set-code::
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
+      :language: java
+      :lines: 57-57
+      :linenos:
+      :lineno-start: 57
 
-    .. tab-item:: Java
-       :sync: java
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Vision.h
+      :language: c++
+      :lines: 145-145
+      :linenos:
+      :lineno-start: 145
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
-         :language: java
-         :lines: 57-57
-         :linenos:
-         :lineno-start: 57
-
-    .. tab-item:: C++
-
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Vision.h
-         :language: c++
-         :lines: 145-145
-         :linenos:
-         :lineno-start: 145
-
-    .. tab-item:: Python
-
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/poseest/robot.py
-         :language: python
-         :lines: 44-44
-         :linenos:
-         :lineno-start: 44
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/poseest/robot.py
+      :language: python
+      :lines: 44-44
+      :linenos:
+      :lineno-start: 44
 ```
 
 During periodic execution, we read back camera results. If we see AprilTags in the image, we calculate the camera-measured pose of the robot and pass it to the {code}`Drivetrain`.
 
 ```{eval-rst}
-.. tab-set::
+.. tab-set-code::
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Robot.java
+      :language: java
+      :lines: 64-74
+      :linenos:
+      :lineno-start: 64
 
-    .. tab-item:: Java
-       :sync: java
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/cpp/Robot.cpp
+      :language: c++
+      :lines: 38-46
+      :linenos:
+      :lineno-start: 38
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Robot.java
-         :language: java
-         :lines: 64-74
-         :linenos:
-         :lineno-start: 64
-
-    .. tab-item:: C++
-
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/cpp/Robot.cpp
-         :language: c++
-         :lines: 38-46
-         :linenos:
-         :lineno-start: 38
-
-    .. tab-item:: Python
-
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/poseest/robot.py
-         :language: python
-         :lines: 54-56
-         :linenos:
-         :lineno-start: 54
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-python-examples/poseest/robot.py
+      :language: python
+      :lines: 54-56
+      :linenos:
+      :lineno-start: 54
 
 ```
 
@@ -121,56 +97,45 @@ During periodic execution, we read back camera results. If we see AprilTags in t
 First, we create a new {code}`VisionSystemSim` to represent our camera and coprocessor running PhotonVision, and moving around our simulated field.
 
 ```{eval-rst}
-.. tab-set::
+.. tab-set-code::
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
+      :language: java
+      :lines: 65-69
+      :linenos:
+      :lineno-start: 65
 
-    .. tab-item:: Java
-       :sync: java
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Vision.h
+      :language: c++
+      :lines: 49-52
+      :linenos:
+      :lineno-start: 49
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
-         :language: java
-         :lines: 65-69
-         :linenos:
-         :lineno-start: 65
+   .. code-block:: python
 
-    .. tab-item:: C++
-
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Vision.h
-         :language: c++
-         :lines: 49-52
-         :linenos:
-         :lineno-start: 49
-
-    .. tab-item:: Python
-
-       # Coming Soon!
+      # Coming Soon!
 
 ```
 
 Then, we add configure the simulated vision system to match the camera system being simulated.
 
 ```{eval-rst}
-.. tab-set::
+.. tab-set-code::
 
-    .. tab-item:: Java
-       :sync: java
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
+      :language: java
+      :lines: 69-82
+      :linenos:
+      :lineno-start: 69
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Vision.java
-         :language: java
-         :lines: 69-82
-         :linenos:
-         :lineno-start: 69
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Vision.h
+      :language: c++
+      :lines: 53-65
+      :linenos:
+      :lineno-start: 53
 
-    .. tab-item:: C++
+   .. code-block:: Python
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/include/Vision.h
-         :language: c++
-         :lines: 53-65
-         :linenos:
-         :lineno-start: 53
-
-    .. tab-item:: Python
-
-       # Coming Soon!
+      # Coming Soon!
 ```
 
 
@@ -179,28 +144,23 @@ Then, we add configure the simulated vision system to match the camera system be
 During simulation, we periodically update the simulated vision system.
 
 ```{eval-rst}
-.. tab-set::
+.. tab-set-code::
 
-    .. tab-item:: Java
-       :sync: java
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Robot.java
+      :language: java
+      :lines: 114-132
+      :linenos:
+      :lineno-start: 114
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-java-examples/poseest/src/main/java/frc/robot/Robot.java
-         :language: java
-         :lines: 114-132
-         :linenos:
-         :lineno-start: 114
+   .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/cpp/Robot.cpp
+      :language: c++
+      :lines: 95-109
+      :linenos:
+      :lineno-start: 95
 
-    .. tab-item:: C++
+   .. code-block:: python
 
-       .. rli:: https://raw.githubusercontent.com/PhotonVision/photonvision/abe95dfaa055bbe3609f72cfcaaba0f96ee7978c/photonlib-cpp-examples/poseest/src/main/cpp/Robot.cpp
-         :language: c++
-         :lines: 95-109
-         :linenos:
-         :lineno-start: 95
-
-    .. tab-item:: Python
-
-       # Coming Soon!
+      # Coming Soon!
 ```
 
 The rest is done behind the scenes.

--- a/docs/source/docs/integration/advancedStrategies.md
+++ b/docs/source/docs/integration/advancedStrategies.md
@@ -43,7 +43,7 @@ A simple way to use a pose estimate is to activate robot functions automatically
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       Pose3d robotPose;
       boolean launcherSpinCmd;

--- a/docs/source/docs/programming/photonlib/controlling-led.md
+++ b/docs/source/docs/programming/photonlib/controlling-led.md
@@ -4,17 +4,17 @@ You can control the vision LEDs of supported hardware via PhotonLib using the `s
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Blink the LEDs.
       camera.setLED(VisionLEDMode.kBlink);
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Blink the LEDs.
       camera.SetLED(photonlib::VisionLEDMode::kBlink);
 
-   .. code-block:: Python
+   .. code-block:: python
 
         # Coming Soon!
 ```

--- a/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
+++ b/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
@@ -9,17 +9,17 @@ You can use the `setDriverMode()`/`SetDriverMode()` (Java and C++ respectively) 
 ```{eval-rst}
 .. tab-set-code::
 
-    .. code-block:: Java
+    .. code-block:: java
 
         // Set driver mode to on.
         camera.setDriverMode(true);
 
-    .. code-block:: C++
+    .. code-block:: c++
 
         // Set driver mode to on.
         camera.SetDriverMode(true);
 
-    .. code-block:: Python
+    .. code-block:: python
 
         # Coming Soon!
 ```
@@ -31,17 +31,17 @@ You can use the `setPipelineIndex()`/`SetPipelineIndex()` (Java and C++ respecti
 ```{eval-rst}
 .. tab-set-code::
 
-    .. code-block:: Java
+    .. code-block:: java
 
         // Change pipeline to 2
         camera.setPipelineIndex(2);
 
-    .. code-block:: C++
+    .. code-block:: c++
 
         // Change pipeline to 2
         camera.SetPipelineIndex(2);
 
-    .. code-block:: Python
+    .. code-block:: python
 
         # Coming Soon!
 ```
@@ -52,17 +52,17 @@ You can also get the pipeline latency from a pipeline result using the `getLaten
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Get the pipeline latency.
       double latencySeconds = result.getLatencyMillis() / 1000.0;
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Get the pipeline latency.
       units::second_t latency = result.GetLatency();
 
-   .. code-block:: Python
+   .. code-block:: python
 
         # Coming Soon!
 ```

--- a/docs/source/docs/programming/photonlib/getting-target-data.md
+++ b/docs/source/docs/programming/photonlib/getting-target-data.md
@@ -20,7 +20,7 @@ The `PhotonCamera` class has two constructors: one that takes a `NetworkTable` a
         :language: c++
         :lines: 42-43
 
-     .. code-block:: Python
+     .. code-block:: python
 
          # Change this to match the name of your camera as shown in the web ui
          self.camera = PhotonCamera("your_camera_name_here")
@@ -51,7 +51,7 @@ Use the `getLatestResult()`/`GetLatestResult()` (Java and C++ respectively) to o
          :language: c++
          :lines: 35-36
 
-     .. code-block:: Python
+     .. code-block:: python
 
          # Query the latest result from PhotonVision
          result = self.camera.getLatestResult()
@@ -69,17 +69,17 @@ Each pipeline result has a `hasTargets()`/`HasTargets()` (Java and C++ respectiv
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Check if the latest result has any targets.
       boolean hasTargets = result.hasTargets();
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Check if the latest result has any targets.
       bool hasTargets = result.HasTargets();
 
-   .. code-block:: Python
+   .. code-block:: python
 
      # Check if the latest result has any targets.
       hasTargets = result.hasTargets()
@@ -99,17 +99,17 @@ You can get a list of tracked targets using the `getTargets()`/`GetTargets()` (J
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Get a list of currently tracked targets.
       List<PhotonTrackedTarget> targets = result.getTargets();
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Get a list of currently tracked targets.
       wpi::ArrayRef<photonlib::PhotonTrackedTarget> targets = result.GetTargets();
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Get a list of currently tracked targets.
       targets = result.getTargets()
@@ -121,18 +121,18 @@ You can get the {ref}`best target <docs/reflectiveAndShape/contour-filtering:Con
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Get the current best target.
       PhotonTrackedTarget target = result.getBestTarget();
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Get the current best target.
       photonlib::PhotonTrackedTarget target = result.GetBestTarget();
 
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 
@@ -149,7 +149,7 @@ You can get the {ref}`best target <docs/reflectiveAndShape/contour-filtering:Con
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Get information from target.
       double yaw = target.getYaw();
@@ -159,7 +159,7 @@ You can get the {ref}`best target <docs/reflectiveAndShape/contour-filtering:Con
       Transform2d pose = target.getCameraToTarget();
       List<TargetCorner> corners = target.getCorners();
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Get information from target.
       double yaw = target.GetYaw();
@@ -169,7 +169,7 @@ You can get the {ref}`best target <docs/reflectiveAndShape/contour-filtering:Con
       frc::Transform2d pose = target.GetCameraToTarget();
       wpi::SmallVector<std::pair<double, double>, 4> corners = target.GetCorners();
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Get information from target.
       yaw = target.getYaw()
@@ -193,7 +193,7 @@ All of the data above (**except skew**) is available when using AprilTags.
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Get information from target.
       int targetID = target.getFiducialId();
@@ -201,7 +201,7 @@ All of the data above (**except skew**) is available when using AprilTags.
       Transform3d bestCameraToTarget = target.getBestCameraToTarget();
       Transform3d alternateCameraToTarget = target.getAlternateCameraToTarget();
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Get information from target.
       int targetID = target.GetFiducialId();
@@ -209,7 +209,7 @@ All of the data above (**except skew**) is available when using AprilTags.
       frc::Transform3d bestCameraToTarget = target.getBestCameraToTarget();
       frc::Transform3d alternateCameraToTarget = target.getAlternateCameraToTarget();
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Get information from target.
       targetID = target.getFiducialId()
@@ -227,7 +227,7 @@ Images are stored within the PhotonVision configuration directory. Running the "
 ```{eval-rst}
 .. tab-set-code::
 
-    .. code-block:: Java
+    .. code-block:: java
 
       // Capture pre-process camera stream image
       camera.takeInputSnapshot();
@@ -235,7 +235,7 @@ Images are stored within the PhotonVision configuration directory. Running the "
       // Capture post-process camera stream image
       camera.takeOutputSnapshot();
 
-    .. code-block:: C++
+    .. code-block:: c++
 
       // Capture pre-process camera stream image
       camera.TakeInputSnapshot();
@@ -243,7 +243,7 @@ Images are stored within the PhotonVision configuration directory. Running the "
       // Capture post-process camera stream image
       camera.TakeOutputSnapshot();
 
-    .. code-block:: Python
+    .. code-block:: python
 
       # Capture pre-process camera stream image
       camera.takeInputSnapshot()

--- a/docs/source/docs/programming/photonlib/using-target-data.md
+++ b/docs/source/docs/programming/photonlib/using-target-data.md
@@ -8,17 +8,17 @@ A `PhotonUtils` class with helpful common calculations is included within `Photo
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Calculate robot's field relative pose
       if (aprilTagFieldLayout.getTagPose(target.getFiducialId()).isPresent()) {
         Pose3d robotPose = PhotonUtils.estimateFieldToRobotAprilTag(target.getBestCameraToTarget(), aprilTagFieldLayout.getTagPose(target.getFiducialId()).get(), cameraToRobot);
       }
-   .. code-block:: C++
+   .. code-block:: c++
 
      //TODO
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 ```
@@ -29,19 +29,19 @@ You can get your robot's `Pose2D` on the field using various camera data, target
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Calculate robot's field relative pose
       Pose2D robotPose = PhotonUtils.estimateFieldToRobot(
         kCameraHeight, kTargetHeight, kCameraPitch, kTargetPitch, Rotation2d.fromDegrees(-target.getYaw()), gyro.getRotation2d(), targetPose, cameraToRobot);
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Calculate robot's field relative pose
       frc::Pose2D robotPose = photonlib::EstimateFieldToRobot(
         kCameraHeight, kTargetHeight, kCameraPitch, kTargetPitch, frc::Rotation2d(units::degree_t(-target.GetYaw())), frc::Rotation2d(units::degree_t(gyro.GetRotation2d)), targetPose, cameraToRobot);
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 
@@ -54,15 +54,15 @@ If your camera is at a fixed height on your robot and the height of the target i
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // TODO
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // TODO
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 
@@ -78,15 +78,15 @@ The C++ version of PhotonLib uses the Units library. For more information, see [
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       double distanceToTarget = PhotonUtils.getDistanceToPose(robotPose, targetPose);
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       //TODO
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 ```
@@ -97,19 +97,19 @@ You can get a [translation](https://docs.wpilib.org/en/latest/docs/software/adva
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       // Calculate a translation from the camera to the target.
       Translation2d translation = PhotonUtils.estimateCameraToTargetTranslation(
         distanceMeters, Rotation2d.fromDegrees(-target.getYaw()));
 
-   .. code-block:: C++
+   .. code-block:: c++
 
       // Calculate a translation from the camera to the target.
       frc::Translation2d translation = photonlib::PhotonUtils::EstimateCameraToTargetTranslation(
         distance, frc::Rotation2d(units::degree_t(-target.GetYaw())));
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 
@@ -125,14 +125,14 @@ We are negating the yaw from the camera from CV (computer vision) conventions to
 
 ```{eval-rst}
 .. tab-set-code::
-   .. code-block:: Java
+   .. code-block:: java
 
       Rotation2d targetYaw = PhotonUtils.getYawToPose(robotPose, targetPose);
-   .. code-block:: C++
+   .. code-block:: c++
 
      //TODO
 
-   .. code-block:: Python
+   .. code-block:: python
 
       # Coming Soon!
 ```

--- a/docs/source/docs/quick-start/networking.md
+++ b/docs/source/docs/quick-start/networking.md
@@ -75,15 +75,15 @@ If you would like to access your Ethernet-connected vision device from a compute
 ```{eval-rst}
 .. tab-set-code::
 
-    .. code-block:: Java
+    .. code-block:: java
 
         PortForwarder.add(5800, "photonvision.local", 5800);
 
-    .. code-block:: C++
+    .. code-block:: c++
 
         wpi::PortForwarder::GetInstance().Add(5800, "photonvision.local", 5800);
 
-    .. code-block:: Python
+    .. code-block:: python
 
         # Coming Soon!
 ```

--- a/docs/source/docs/simulation/simulation-java.md
+++ b/docs/source/docs/simulation/simulation-java.md
@@ -54,7 +54,7 @@ A `VisionSystemSim` represents the simulated world for one or more cameras, and 
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // A vision system sim labelled as "main" in NetworkTables
       VisionSystemSim visionSim = new VisionSystemSim("main");
@@ -67,7 +67,7 @@ Vision targets require a `TargetModel`, which describes the shape of the target.
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // A 0.5 x 0.25 meter rectangular target
       TargetModel targetModel = new TargetModel(0.5, 0.25);
@@ -78,7 +78,7 @@ These `TargetModel` are paired with a target pose to create a `VisionTargetSim`.
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // The pose of where the target is on the field.
       // Its rotation determines where "forward" or the target x-axis points.
@@ -100,7 +100,7 @@ For convenience, an `AprilTagFieldLayout` can also be added to automatically cre
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // The layout of AprilTags which we want to add to the vision system
       AprilTagFieldLayout tagLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.kDefaultField.m_resourceFile);
@@ -121,7 +121,7 @@ Before adding a simulated camera, we need to define its properties. This is done
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // The simulated camera properties
       SimCameraProperties cameraProp = new SimCameraProperties();
@@ -132,7 +132,7 @@ By default, this will create a 960 x 720 resolution camera with a 90 degree diag
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // A 640 x 480 camera with a 100 degree diagonal FOV.
       cameraProp.setCalibration(640, 480, Rotation2d.fromDegrees(100));
@@ -150,7 +150,7 @@ These properties are used in a `PhotonCameraSim`, which handles generating captu
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // The PhotonCamera used in the real robot code.
       PhotonCamera camera = new PhotonCamera("cameraName");
@@ -164,7 +164,7 @@ The `PhotonCameraSim` can now be added to the `VisionSystemSim`. We have to defi
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // Our camera is mounted 0.1 meters forward and 0.5 meters up from the robot pose,
       // (Robot pose is considered the center of rotation at the floor level, or Z = 0)
@@ -186,7 +186,7 @@ If the camera is mounted on a mobile mechanism (like a turret) this transform ca
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // The turret the camera is mounted on is rotated 5 degrees
       Rotation3d turretRotation = new Rotation3d(0, 0, Math.toRadians(5));
@@ -203,7 +203,7 @@ To update the `VisionSystemSim`, we simply have to pass in the simulated robot p
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // Update with the simulated drivetrain pose. This should be called every loop in simulation.
       visionSim.update(robotPoseMeters);
@@ -218,7 +218,7 @@ Each `VisionSystemSim` has its own built-in `Field2d` for displaying object pose
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // Get the built-in Field2d used by this VisionSystemSim
       visionSim.getDebugField();
@@ -233,7 +233,7 @@ A `PhotonCameraSim` can also draw and publish generated camera frames to a MJPEG
 ```{eval-rst}
 .. tab-set-code::
 
-   .. code-block:: Java
+   .. code-block:: java
 
       // Enable the raw and processed streams. These are enabled by default.
       cameraSim.enableRawStream(true);


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

This fixes tab syncing for the documentation in all places where multiple tab sets with the same/similar headers appear. In the build instructions, the selected OS is now synced. In the code snippets and examples, the language tag was updated to be consistently lowercase, and the examples are now synchronized with the other code snippets. Of note, two of the examples have both C++ source and headers, which both share the same sync ID. The last tab is selected in this case of conflict while restoring the selected tab.

Indentation for the RST blocks seemed to be very inconsistent, but averaging 3 spaces, so I went with that when changing indentation levels.

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
