### PR TITLE
Modify build-image to use global variable for image version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -406,7 +406,7 @@ jobs:
   build-image:
     needs: [build-package]
 
-    if: ${{ github.event_name != 'pull_request' }}
+    # if: ${{ github.event_name != 'pull_request' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

I added a global variable under settings, this variable controls the version of the image that is pulled down from https://github.com/PhotonVision/photon-image-modifier.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
