### PR TITLE
Fix file uploads not overwriting existing files

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -339,7 +339,7 @@ public class RequestHandler {
         Path targetPath =
                 Paths.get(ProgramDirectoryUtilities.getProgramDirectory(), "photonvision.jar");
         try (InputStream fileSteam = file.content()) {
-            Files.copy(fileSteam, targetPath);
+            Files.copy(fileSteam, targetPath, StandardCopyOption.REPLACE_EXISTING);
 
             ctx.status(200);
             ctx.result(
@@ -652,7 +652,7 @@ public class RequestHandler {
             }
 
             try (InputStream modelFileStream = modelFile.content()) {
-                Files.copy(modelFileStream, modelPath);
+                Files.copy(modelFileStream, modelPath, StandardCopyOption.REPLACE_EXISTING);
             }
 
             ModelProperties modelProperties =


### PR DESCRIPTION
## Description

#2023 changed how file uploads were handled to use `Files.copy`, but incorrectly didn't specify the `REPLACE_EXISTING` copy option, causing file uploads to fail if the file already existed.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
