### PR TITLE
Disable 3d mode for OD and colored shapes

### DIFF
--- a/photon-client/src/components/dashboard/StreamConfigCard.vue
+++ b/photon-client/src/components/dashboard/StreamConfigCard.vue
@@ -46,7 +46,8 @@ const processingMode = computed<number>({
             :disabled="
               !useCameraSettingsStore().hasConnected ||
               !useCameraSettingsStore().isCurrentVideoFormatCalibrated ||
-              useCameraSettingsStore().currentPipelineSettings.pipelineType == PipelineType.ObjectDetection
+              useCameraSettingsStore().currentPipelineSettings.pipelineType == PipelineType.ObjectDetection ||
+              useCameraSettingsStore().currentPipelineSettings.pipelineType == PipelineType.ColoredShape
             "
             :variant="theme.global.name.value === 'LightTheme' ? 'elevated' : 'outlined'"
             class="w-50"

--- a/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/PipelineManager.java
@@ -491,7 +491,8 @@ public class PipelineManager {
 
                 // Object detection doesn't support 3D mode, so we gotta make sure that gets
                 // turned off when we switch from a pipeline that had 3D mode enabled.
-                if (newType == PipelineType.ObjectDetection.baseIndex
+                if ((newType == PipelineType.ObjectDetection.baseIndex
+                                || newType == PipelineType.ColoredShape.baseIndex)
                         && field.getName().equals("solvePNPEnabled")) {
                     field.set(newSettings, false);
                     continue;


### PR DESCRIPTION
## Description

There isn't anything that 3D mode adds for OD/colored shape, and the results are typically messed up. Thus, we disable 3D mode when we're using an OD/colored shape pipeline.

closes #2069 
closes #1684

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
