### PR TITLE
Swap after creating or duplicating pipeline

### DIFF
--- a/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
+++ b/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
@@ -146,10 +146,7 @@ const createNewPipeline = () => {
   const type = newPipelineType.value;
   if (type === WebsocketPipelineType.DriverMode || type === WebsocketPipelineType.Calib3d) return;
   useCameraSettingsStore().createNewPipeline(newPipelineName.value, type);
-  useCameraSettingsStore().changeCurrentPipelineIndex(
-    useCameraSettingsStore().pipelineNames.length - 1,
-    true
-  );
+  useCameraSettingsStore().changeCurrentPipelineIndex(useCameraSettingsStore().pipelineNames.length - 1, true);
   showPipelineCreationDialog.value = false;
 };
 const cancelPipelineCreation = () => {
@@ -212,10 +209,7 @@ const cancelChangePipelineType = () => {
 // Pipeline duplication
 const duplicateCurrentPipeline = () => {
   useCameraSettingsStore().duplicatePipeline(useCameraSettingsStore().currentCameraSettings.currentPipelineIndex);
-  useCameraSettingsStore().changeCurrentPipelineIndex(
-    useCameraSettingsStore().pipelineNames.length - 1,
-    true
-  );
+  useCameraSettingsStore().changeCurrentPipelineIndex(useCameraSettingsStore().pipelineNames.length - 1, true);
 };
 
 // Change Props whenever the pipeline settings are changed


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

Currently, after creating/duplicating a pipeline it's necessary to manually change to the new pipeline. As a QoL feature, this change makes that switch occur automatically.

This solution is guaranteed to work because when creating/dupeing a pipeline, we set it's index to int.max_value (heh another max_value @Gold856) and re-assign indexes. This reassignment will result in the new pipelines index being the largest, meaning we can choose the highest index to get that pipeline.

closes #960

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
