### PR TITLE
[docs] Add System Architecture Diagrams

### DIFF
--- a/docs/source/docs/contributing/assets/photon-architecture.drawio
+++ b/docs/source/docs/contributing/assets/photon-architecture.drawio
@@ -1,37 +1,37 @@
-<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (X11; Linux x86_64; rv:143.0) Gecko/20100101 Firefox/143.0" version="28.2.7">
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0" version="29.3.3">
   <diagram name="Page-1" id="EKQzKkHL_5VG4IE7c2P8">
-    <mxGraphModel dx="920" dy="1238" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+    <mxGraphModel dx="2235" dy="1238" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-49" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-1" target="BMCkvyzXnp6Wfy262DpX-48" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-49" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-48" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-1" value="main()" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="200" y="60" width="80" height="41.25" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-1" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="main()" vertex="1">
+          <mxGeometry height="41.25" width="80" x="200" y="60" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-98" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-2" target="BMCkvyzXnp6Wfy262DpX-4" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-98" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-4">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-2" value="Start server" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="430" y="560" width="90" height="40" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-2" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Start server" vertex="1">
+          <mxGeometry height="40" width="90" x="430" y="560" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-7" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-4" target="BMCkvyzXnp6Wfy262DpX-6" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-7" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-6" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-4" value="Set up APIs" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="560" y="560" width="80" height="40" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-4" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Set up APIs" vertex="1">
+          <mxGeometry height="40" width="80" x="560" y="560" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-6" value="&lt;div&gt;Invoke Javalin&lt;/div&gt;&lt;div&gt;(App start)&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="680" y="560" width="120" height="40" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-6" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;div&gt;Invoke Javalin&lt;/div&gt;&lt;div&gt;(App start)&lt;/div&gt;" vertex="1">
+          <mxGeometry height="40" width="120" x="680" y="560" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-56" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-11" target="BMCkvyzXnp6Wfy262DpX-55" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-56" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-55" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-11" value="Extract and Discover Object Detection Models" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="150" y="150" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-11" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Extract and Discover Object Detection Models" vertex="1">
+          <mxGeometry height="60" width="120" x="150" y="150" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-95" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-15" target="BMCkvyzXnp6Wfy262DpX-63" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-95" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-15" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-63">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="310" y="355" />
@@ -40,10 +40,10 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-15" value="Init VisionSourceManager and Load Camera Configurations" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="230" y="295" width="170" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-15" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Init VisionSourceManager and Load Camera Configurations" vertex="1">
+          <mxGeometry height="60" width="170" x="230" y="295" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-82" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-20" target="BMCkvyzXnp6Wfy262DpX-81" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-82" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-20" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-81">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="540" y="400" />
@@ -53,42 +53,42 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-20" value="&lt;div&gt;NetworkTableManager Timed Tasks&lt;/div&gt;" style="swimlane;whiteSpace=wrap;html=1;swimlaneLine=1;startSize=25;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="540" y="270" width="260" height="245" as="geometry">
-            <mxRectangle x="10" y="130" width="320" height="30" as="alternateBounds" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-20" parent="1" style="swimlane;whiteSpace=wrap;html=1;swimlaneLine=1;startSize=25;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="&lt;div&gt;NetworkTableManager Timed Tasks&lt;/div&gt;" vertex="1">
+          <mxGeometry height="245" width="260" x="540" y="270" as="geometry">
+            <mxRectangle height="30" width="320" x="10" y="130" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-30" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="BMCkvyzXnp6Wfy262DpX-20" source="BMCkvyzXnp6Wfy262DpX-23" target="BMCkvyzXnp6Wfy262DpX-25" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-30" edge="1" parent="BMCkvyzXnp6Wfy262DpX-20" source="BMCkvyzXnp6Wfy262DpX-23" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-25">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-23" value="Start Time Sync" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-20" vertex="1">
-          <mxGeometry x="55" y="40" width="150" height="30" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-23" parent="BMCkvyzXnp6Wfy262DpX-20" style="rounded=0;whiteSpace=wrap;html=1;" value="Start Time Sync" vertex="1">
+          <mxGeometry height="30" width="150" x="55" y="40" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-31" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="BMCkvyzXnp6Wfy262DpX-20" source="BMCkvyzXnp6Wfy262DpX-25" target="BMCkvyzXnp6Wfy262DpX-27" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-31" edge="1" parent="BMCkvyzXnp6Wfy262DpX-20" source="BMCkvyzXnp6Wfy262DpX-25" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-27">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-25" value="Restart NT until connected to Robot Controller(every 5 sec)" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-20" vertex="1">
-          <mxGeometry x="55" y="85" width="150" height="65" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-25" parent="BMCkvyzXnp6Wfy262DpX-20" style="rounded=0;whiteSpace=wrap;html=1;" value="Restart NT until connected to Robot Controller(every 5 sec)" vertex="1">
+          <mxGeometry height="65" width="150" x="55" y="85" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-27" value="Add Hostname/Camera Name Check Task (runs every 10 sec)" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-20" vertex="1">
-          <mxGeometry x="55" y="170" width="150" height="50" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-27" parent="BMCkvyzXnp6Wfy262DpX-20" style="rounded=0;whiteSpace=wrap;html=1;" value="Add Hostname/Camera Name Check Task (runs every 10 sec)" vertex="1">
+          <mxGeometry height="50" width="150" x="55" y="170" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-47" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;PhotonVision Initialization&lt;/h1&gt;&lt;p&gt;From executable run to the steady-state event loop&lt;/p&gt;&lt;p&gt;Date: 2025-10-09&lt;/p&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="10" y="10" width="180" height="140" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-47" parent="1" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;PhotonVision Initialization&lt;/h1&gt;&lt;p&gt;From executable run to the steady-state event loop&lt;/p&gt;&lt;p&gt;Date: 2025-10-09&lt;/p&gt;" vertex="1">
+          <mxGeometry height="140" width="180" x="10" y="10" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-51" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-48" target="BMCkvyzXnp6Wfy262DpX-50" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-51" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-48" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-50" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-48" value="Setup Loggers" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="320" y="58.75" width="80" height="42.5" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-48" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Setup Loggers" vertex="1">
+          <mxGeometry height="42.5" width="80" x="320" y="58.75" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-53" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-50" target="BMCkvyzXnp6Wfy262DpX-52" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-53" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-50" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-52" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-50" value="Init ConfigManager and Save" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="440" y="57.5" width="120" height="45" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-50" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Init ConfigManager and Save" vertex="1">
+          <mxGeometry height="45" width="120" x="440" y="57.5" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-54" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-52" target="BMCkvyzXnp6Wfy262DpX-11" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-54" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-52" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="BMCkvyzXnp6Wfy262DpX-11">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="700" y="130" />
@@ -96,28 +96,28 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-52" value="Init NeuralNetworkModelManager" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="600" y="57.5" width="200" height="45" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-52" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Init NeuralNetworkModelManager" vertex="1">
+          <mxGeometry height="45" width="200" x="600" y="57.5" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-58" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-55" target="BMCkvyzXnp6Wfy262DpX-57" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-58" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-55" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-57" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-55" value="Init HardwareManager" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="310" y="150" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-55" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Init HardwareManager" vertex="1">
+          <mxGeometry height="60" width="120" x="310" y="150" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-60" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-57" target="BMCkvyzXnp6Wfy262DpX-59" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-60" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-57" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-59" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-57" value="Init NetworkManager" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="470" y="150" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-57" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Init NetworkManager" vertex="1">
+          <mxGeometry height="60" width="120" x="470" y="150" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-62" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-59" target="BMCkvyzXnp6Wfy262DpX-20" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-62" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-59" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-20">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-59" value="Init NetworkTablesManager" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="630" y="150" width="160" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-59" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Init NetworkTablesManager" vertex="1">
+          <mxGeometry height="60" width="160" x="630" y="150" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-99" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-63" target="BMCkvyzXnp6Wfy262DpX-2" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-99" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-63" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-2">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="380" y="835" />
@@ -125,107 +125,107 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-63" value="&lt;div&gt;VisionSourceManager CameraDeviceExplorer Task&lt;/div&gt;" style="swimlane;whiteSpace=wrap;html=1;swimlaneLine=1;startSize=35;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="60" y="630" width="260" height="320" as="geometry">
-            <mxRectangle x="10" y="130" width="320" height="30" as="alternateBounds" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-63" parent="1" style="swimlane;whiteSpace=wrap;html=1;swimlaneLine=1;startSize=35;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="&lt;div&gt;VisionSourceManager CameraDeviceExplorer Task&lt;/div&gt;" vertex="1">
+          <mxGeometry height="320" width="260" x="60" y="630" as="geometry">
+            <mxRectangle height="30" width="320" x="10" y="130" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-42" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="BMCkvyzXnp6Wfy262DpX-63" source="BMCkvyzXnp6Wfy262DpX-39" target="BMCkvyzXnp6Wfy262DpX-41" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-42" edge="1" parent="BMCkvyzXnp6Wfy262DpX-63" source="BMCkvyzXnp6Wfy262DpX-39" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-41" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-39" value="Get connected cameras" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-63" vertex="1">
-          <mxGeometry x="60" y="50" width="140" height="45" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-39" parent="BMCkvyzXnp6Wfy262DpX-63" style="rounded=0;whiteSpace=wrap;html=1;" value="Get connected cameras" vertex="1">
+          <mxGeometry height="45" width="140" x="60" y="50" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-44" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="BMCkvyzXnp6Wfy262DpX-63" source="BMCkvyzXnp6Wfy262DpX-41" target="BMCkvyzXnp6Wfy262DpX-43" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-44" edge="1" parent="BMCkvyzXnp6Wfy262DpX-63" source="BMCkvyzXnp6Wfy262DpX-41" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-43" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-41" value="Filter to allowed devices" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-63" vertex="1">
-          <mxGeometry x="60" y="120" width="140" height="45" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-41" parent="BMCkvyzXnp6Wfy262DpX-63" style="rounded=0;whiteSpace=wrap;html=1;" value="Filter to allowed devices" vertex="1">
+          <mxGeometry height="45" width="140" x="60" y="120" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-46" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="BMCkvyzXnp6Wfy262DpX-63" source="BMCkvyzXnp6Wfy262DpX-43" target="BMCkvyzXnp6Wfy262DpX-45" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-46" edge="1" parent="BMCkvyzXnp6Wfy262DpX-63" source="BMCkvyzXnp6Wfy262DpX-43" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-45" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-43" value="Apply disabled configs" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-63" vertex="1">
-          <mxGeometry x="60" y="190" width="140" height="45" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-43" parent="BMCkvyzXnp6Wfy262DpX-63" style="rounded=0;whiteSpace=wrap;html=1;" value="Apply disabled configs" vertex="1">
+          <mxGeometry height="45" width="140" x="60" y="190" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-45" value="Push to UI" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-63" vertex="1">
-          <mxGeometry x="60" y="260" width="140" height="45" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-45" parent="BMCkvyzXnp6Wfy262DpX-63" style="rounded=0;whiteSpace=wrap;html=1;" value="Push to UI" vertex="1">
+          <mxGeometry height="45" width="140" x="60" y="260" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-84" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-81" target="BMCkvyzXnp6Wfy262DpX-83" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-84" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-81" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-83" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-90" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-81" target="BMCkvyzXnp6Wfy262DpX-15" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-90" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-81" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-15">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-81" value="If this is Test Mode" style="rhombus;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="50" y="260" width="140" height="130" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-81" parent="1" style="rhombus;whiteSpace=wrap;html=1;" value="If this is Test Mode" vertex="1">
+          <mxGeometry height="130" width="140" x="50" y="260" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-92" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-83" target="BMCkvyzXnp6Wfy262DpX-63" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-92" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-83" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-63">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="569.6470588235293" y="610" as="targetPoint" />
             <Array as="points">
               <mxPoint x="140" y="490" />
               <mxPoint x="140" y="560" />
               <mxPoint x="190" y="560" />
             </Array>
+            <mxPoint x="569.6470588235293" y="610" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-83" value="Load test sources" style="whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="60" y="430" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-83" parent="1" style="whiteSpace=wrap;html=1;" value="Load test sources" vertex="1">
+          <mxGeometry height="60" width="120" x="60" y="430" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-85" value="Yes" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="110" y="390" width="60" height="30" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-85" parent="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" value="Yes" vertex="1">
+          <mxGeometry height="30" width="60" x="110" y="390" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-86" value="No" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="180" y="290" width="60" height="30" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-86" parent="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" value="No" vertex="1">
+          <mxGeometry height="30" width="60" x="180" y="290" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-96" value="TimedTaskManager" style="swimlane;whiteSpace=wrap;html=1;startSize=23;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="480" y="640" width="320" height="280" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-96" parent="1" style="swimlane;whiteSpace=wrap;html=1;startSize=23;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="TimedTaskManager" vertex="1">
+          <mxGeometry height="280" width="320" x="480" y="640" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-101" value="&lt;div&gt;TimeSync Tick&lt;/div&gt;&lt;div&gt;(1000 ms)&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-96" vertex="1">
-          <mxGeometry x="20" y="40" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-101" parent="BMCkvyzXnp6Wfy262DpX-96" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;div&gt;TimeSync Tick&lt;/div&gt;&lt;div&gt;(1000 ms)&lt;/div&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="20" y="40" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-102" value="&lt;div&gt;Status LED Update&lt;/div&gt;&lt;div&gt;(150 ms)&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-96" vertex="1">
-          <mxGeometry x="180" y="40" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-102" parent="BMCkvyzXnp6Wfy262DpX-96" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;div&gt;Status LED Update&lt;/div&gt;&lt;div&gt;(150 ms)&lt;/div&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="180" y="40" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-103" value="&lt;div&gt;Print Kernel Logs&lt;/div&gt;&lt;div&gt;(1000 ms)&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-96" vertex="1">
-          <mxGeometry x="20" y="120" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-103" parent="BMCkvyzXnp6Wfy262DpX-96" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;div&gt;Print Kernel Logs&lt;/div&gt;&lt;div&gt;(1000 ms)&lt;/div&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="20" y="120" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-104" value="&lt;div&gt;Device Network Status Monitor&lt;/div&gt;&lt;div&gt;(5000 ms)&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-96" vertex="1">
-          <mxGeometry x="180" y="120" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-104" parent="BMCkvyzXnp6Wfy262DpX-96" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;div&gt;Device Network Status Monitor&lt;/div&gt;&lt;div&gt;(5000 ms)&lt;/div&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="180" y="120" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-105" value="&lt;div&gt;ScriptRunner&amp;nbsp;&lt;/div&gt;&lt;div&gt;(10 ms)&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-96" vertex="1">
-          <mxGeometry x="20" y="200" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-105" parent="BMCkvyzXnp6Wfy262DpX-96" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;div&gt;ScriptRunner&amp;nbsp;&lt;/div&gt;&lt;div&gt;(10 ms)&lt;/div&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="20" y="200" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-106" value="&lt;div&gt;Camera Device Explorer&lt;/div&gt;&lt;div&gt;(1000ms)&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="BMCkvyzXnp6Wfy262DpX-96" vertex="1">
-          <mxGeometry x="180" y="200" width="120" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-106" parent="BMCkvyzXnp6Wfy262DpX-96" style="rounded=0;whiteSpace=wrap;html=1;" value="&lt;div&gt;Camera Device Explorer&lt;/div&gt;&lt;div&gt;(1000ms)&lt;/div&gt;" vertex="1">
+          <mxGeometry height="60" width="120" x="180" y="200" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-107" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;PhotonVision Vision Dataflow&lt;/h1&gt;&lt;div&gt;Coprocessor data flow of frames and targets&lt;/div&gt;&lt;p&gt;Date: 2025-10-09&lt;/p&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="870" y="10.63" width="210" height="140" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-107" parent="1" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;PhotonVision Vision Dataflow&lt;/h1&gt;&lt;div&gt;Coprocessor data flow of frames and targets&lt;/div&gt;&lt;p&gt;Date: 2025-10-09&lt;/p&gt;" vertex="1">
+          <mxGeometry height="140" width="210" x="870" y="10.63" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-110" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-108" target="BMCkvyzXnp6Wfy262DpX-109" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-110" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-108" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-109" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-108" value="Init VisionSourceManager" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="1100" y="30" width="180" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-108" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Init VisionSourceManager" vertex="1">
+          <mxGeometry height="60" width="180" x="1100" y="30" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-60" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-109" target="BMCkvyzXnp6Wfy262DpX-113" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-60" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-109" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-113">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-109" value="Verify Camera Names/Paths are unique" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="1320" y="30" width="160" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-109" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Verify Camera Names/Paths are unique" vertex="1">
+          <mxGeometry height="60" width="160" x="1320" y="30" as="geometry" />
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-116" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="BMCkvyzXnp6Wfy262DpX-113" target="BMCkvyzXnp6Wfy262DpX-115" edge="1">
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-116" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-113" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="BMCkvyzXnp6Wfy262DpX-115" value="">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="1600" y="160" />
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-113" value="Create VisionSources for each camera" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="1520" y="30" width="160" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-113" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Create VisionSources for each camera" vertex="1">
+          <mxGeometry height="60" width="160" x="1520" y="30" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-19" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-115" target="S9g8uFfFkQZEvXXLItgG-1" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-19" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-115" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="S9g8uFfFkQZEvXXLItgG-1">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="1250" y="260" />
@@ -233,10 +233,10 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-115" value="Turn them into VisionModules and add to VisionModuleManager" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="1170" y="130" width="160" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-115" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Turn them into VisionModules and add to VisionModuleManager" vertex="1">
+          <mxGeometry height="60" width="160" x="1170" y="130" as="geometry" />
         </mxCell>
-        <mxCell id="zbKhoK3Aaxo4YHnxXPtB-49" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-118" target="S9g8uFfFkQZEvXXLItgG-21" edge="1">
+        <mxCell id="zbKhoK3Aaxo4YHnxXPtB-49" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-118" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="S9g8uFfFkQZEvXXLItgG-21">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="1110" y="970" />
@@ -246,7 +246,7 @@
             <mxPoint x="1380" y="250" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="zbKhoK3Aaxo4YHnxXPtB-50" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="BMCkvyzXnp6Wfy262DpX-118" target="S9g8uFfFkQZEvXXLItgG-39" edge="1">
+        <mxCell id="zbKhoK3Aaxo4YHnxXPtB-50" edge="1" parent="1" source="BMCkvyzXnp6Wfy262DpX-118" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="S9g8uFfFkQZEvXXLItgG-39">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="1110" y="970" />
@@ -256,175 +256,175 @@
             <mxPoint x="1390" y="370" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="BMCkvyzXnp6Wfy262DpX-118" value="Start all VisionModules and note all disabled ones" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="885" y="940" width="170" height="60" as="geometry" />
+        <mxCell id="BMCkvyzXnp6Wfy262DpX-118" parent="1" style="rounded=0;whiteSpace=wrap;html=1;" value="Start all VisionModules and note all disabled ones" vertex="1">
+          <mxGeometry height="60" width="170" x="885" y="940" as="geometry" />
         </mxCell>
-        <mxCell id="zbKhoK3Aaxo4YHnxXPtB-45" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;PhotonVision Pipelines&lt;/h1&gt;&lt;p&gt;DataFlow&lt;/p&gt;&lt;p&gt;Date: 2026-10-09&lt;/p&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="10" y="1110" width="210" height="140" as="geometry" />
+        <mxCell id="zbKhoK3Aaxo4YHnxXPtB-45" parent="1" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;PhotonVision Pipelines&lt;/h1&gt;&lt;p&gt;DataFlow&lt;/p&gt;&lt;p&gt;Date: 2026-10-09&lt;/p&gt;" vertex="1">
+          <mxGeometry height="140" width="210" x="10" y="1110" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-20" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="S9g8uFfFkQZEvXXLItgG-1" target="BMCkvyzXnp6Wfy262DpX-118" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-20" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="BMCkvyzXnp6Wfy262DpX-118">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-1" value="VisionModule Init" style="swimlane;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="870" y="300" width="200" height="590" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-1" parent="1" style="swimlane;whiteSpace=wrap;html=1;" value="VisionModule Init" vertex="1">
+          <mxGeometry height="590" width="200" x="870" y="300" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-4" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-2" target="S9g8uFfFkQZEvXXLItgG-3" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-4" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-3" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-2" value="Get and Apply Camera Quirks" style="rounded=0;whiteSpace=wrap;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="30" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-2" parent="S9g8uFfFkQZEvXXLItgG-1" style="rounded=0;whiteSpace=wrap;html=1;" value="Get and Apply Camera Quirks" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="30" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-6" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-3" target="S9g8uFfFkQZEvXXLItgG-5" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-6" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-5" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-3" value="Set up stream runnable and change subscriber" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="90" width="120" height="60" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-3" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Set up stream runnable and change subscriber" vertex="1">
+          <mxGeometry height="60" width="120" x="40" y="90" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-8" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-5" target="S9g8uFfFkQZEvXXLItgG-7" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-8" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-5" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-7" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-5" value="Create video stream" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="170" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-5" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Create video stream" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="170" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-10" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-7" target="S9g8uFfFkQZEvXXLItgG-9" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-10" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-9" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-7" value="Start publishing data to NT, UI, LEDs" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="230" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-7" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Start publishing data to NT, UI, LEDs" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="230" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-12" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-9" target="S9g8uFfFkQZEvXXLItgG-11" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-12" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-11" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-9" value="Set up latest best target caching" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="290" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-9" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Set up latest best target caching" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="290" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-14" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-11" target="S9g8uFfFkQZEvXXLItgG-13" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-14" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-13" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-11" value="Set initial pipeline" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="350" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-11" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Set initial pipeline" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="350" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-16" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-13" target="S9g8uFfFkQZEvXXLItgG-15" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-16" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-15" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-13" value="Set FOV if vendor camera" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="410" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-13" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Set FOV if vendor camera" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="410" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-18" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-15" target="S9g8uFfFkQZEvXXLItgG-17" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-18" edge="1" parent="S9g8uFfFkQZEvXXLItgG-1" source="S9g8uFfFkQZEvXXLItgG-15" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-17" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-15" value="Configure LEDs" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="470" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-15" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Configure LEDs" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="470" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-17" value="Save data and publish to UI" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-1" vertex="1">
-          <mxGeometry x="40" y="530" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-17" parent="S9g8uFfFkQZEvXXLItgG-1" style="whiteSpace=wrap;html=1;rounded=0;" value="Save data and publish to UI" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="530" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-21" value="StreamRunnable run()" style="swimlane;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="1150" y="337.5" width="200" height="310" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-21" parent="1" style="swimlane;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="StreamRunnable run()" vertex="1">
+          <mxGeometry height="310" width="200" x="1150" y="337.5" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-22" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-21" source="S9g8uFfFkQZEvXXLItgG-23" target="S9g8uFfFkQZEvXXLItgG-25" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-22" edge="1" parent="S9g8uFfFkQZEvXXLItgG-21" source="S9g8uFfFkQZEvXXLItgG-23" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-25" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-23" value="Move latest frame, settings, targets, shouldRun into thread" style="rounded=0;whiteSpace=wrap;html=1;" parent="S9g8uFfFkQZEvXXLItgG-21" vertex="1">
-          <mxGeometry x="40" y="30" width="120" height="70" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-23" parent="S9g8uFfFkQZEvXXLItgG-21" style="rounded=0;whiteSpace=wrap;html=1;" value="Move latest frame, settings, targets, shouldRun into thread" vertex="1">
+          <mxGeometry height="70" width="120" x="40" y="30" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-24" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-21" source="S9g8uFfFkQZEvXXLItgG-25" target="S9g8uFfFkQZEvXXLItgG-27" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-24" edge="1" parent="S9g8uFfFkQZEvXXLItgG-21" source="S9g8uFfFkQZEvXXLItgG-25" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-27" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-25" value="Wait for shouldRun" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-21" vertex="1">
-          <mxGeometry x="40" y="120" width="120" height="30" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-25" parent="S9g8uFfFkQZEvXXLItgG-21" style="whiteSpace=wrap;html=1;rounded=0;" value="Wait for shouldRun" vertex="1">
+          <mxGeometry height="30" width="120" x="40" y="120" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-26" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-21" source="S9g8uFfFkQZEvXXLItgG-27" target="S9g8uFfFkQZEvXXLItgG-29" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-26" edge="1" parent="S9g8uFfFkQZEvXXLItgG-21" source="S9g8uFfFkQZEvXXLItgG-27" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-29" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-27" value="Run the pipeline (draw on the stream) and consume the results" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-21" vertex="1">
-          <mxGeometry x="40" y="170" width="120" height="60" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-27" parent="S9g8uFfFkQZEvXXLItgG-21" style="whiteSpace=wrap;html=1;rounded=0;" value="Run the pipeline (draw on the stream) and consume the results" vertex="1">
+          <mxGeometry height="60" width="120" x="40" y="170" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-29" value="Release the frame" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-21" vertex="1">
-          <mxGeometry x="40" y="250" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-29" parent="S9g8uFfFkQZEvXXLItgG-21" style="whiteSpace=wrap;html=1;rounded=0;" value="Release the frame" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="250" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-39" value="VisionRunner update()" style="swimlane;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="1390" y="337.5" width="200" height="710" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-39" parent="1" style="swimlane;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="VisionRunner update()" vertex="1">
+          <mxGeometry height="710" width="200" x="1390" y="337.5" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-40" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-41" target="S9g8uFfFkQZEvXXLItgG-43" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-40" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-41" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-43" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-41" value="Wait for camera to connect" style="rounded=0;whiteSpace=wrap;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="30" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-41" parent="S9g8uFfFkQZEvXXLItgG-39" style="rounded=0;whiteSpace=wrap;html=1;" value="Wait for camera to connect" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="30" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-42" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-43" target="S9g8uFfFkQZEvXXLItgG-45" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-42" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-43" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-45" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-43" value="Publish settings to UI" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="90" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-43" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Publish settings to UI" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="90" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-44" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-45" target="S9g8uFfFkQZEvXXLItgG-47" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-44" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-45" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-47" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-45" value="Process any settings changes" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="150" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-45" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Process any settings changes" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="150" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-46" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-47" target="S9g8uFfFkQZEvXXLItgG-49" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-46" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-47" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-49" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-47" value="Run any requested runnables for that cycle" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="210" width="120" height="60" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-47" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Run any requested runnables for that cycle" vertex="1">
+          <mxGeometry height="60" width="120" x="40" y="210" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-48" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-49" target="S9g8uFfFkQZEvXXLItgG-51" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-48" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-49" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-51" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-49" value="Grab pipeline object" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="290" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-49" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Grab pipeline object" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="290" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-50" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-51" target="S9g8uFfFkQZEvXXLItgG-53" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-50" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-51" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-53" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-51" value="Get threshold type and HSV settings" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="350" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-51" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Get threshold type and HSV settings" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="350" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-52" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-53" target="S9g8uFfFkQZEvXXLItgG-55" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-52" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-53" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-55" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-53" value="Request frame crop/rotation" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="410" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-53" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Request frame crop/rotation" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="410" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-54" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-55" target="S9g8uFfFkQZEvXXLItgG-56" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-54" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-55" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-56" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-55" value="Get the newest frame" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="470" width="120" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-55" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Get the newest frame" vertex="1">
+          <mxGeometry height="40" width="120" x="40" y="470" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-58" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-56" target="S9g8uFfFkQZEvXXLItgG-57" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-58" edge="1" parent="S9g8uFfFkQZEvXXLItgG-39" source="S9g8uFfFkQZEvXXLItgG-56" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="S9g8uFfFkQZEvXXLItgG-57" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-56" value="Run pipeline (abstract process() method in each pipeline type" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="530" width="120" height="70" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-56" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Run pipeline (abstract process() method in each pipeline type" vertex="1">
+          <mxGeometry height="70" width="120" x="40" y="530" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-57" value="Send result to each consumer callback (NT, UI, stream, etc.)" style="whiteSpace=wrap;html=1;rounded=0;" parent="S9g8uFfFkQZEvXXLItgG-39" vertex="1">
-          <mxGeometry x="40" y="620" width="120" height="70" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-57" parent="S9g8uFfFkQZEvXXLItgG-39" style="whiteSpace=wrap;html=1;rounded=0;" value="Send result to each consumer callback (NT, UI, stream, etc.)" vertex="1">
+          <mxGeometry height="70" width="120" x="40" y="620" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-61" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;font style=&quot;font-size: 18px;&quot;&gt;AprilTagPipeline&lt;/font&gt;&lt;/h1&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="10" y="1260" width="165" height="50" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-61" parent="1" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;font style=&quot;font-size: 18px;&quot;&gt;AprilTagPipeline&lt;/font&gt;&lt;/h1&gt;" vertex="1">
+          <mxGeometry height="50" width="165" x="10" y="1260" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-64" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" parent="1" source="S9g8uFfFkQZEvXXLItgG-62" target="S9g8uFfFkQZEvXXLItgG-63" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-64" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-62" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" target="S9g8uFfFkQZEvXXLItgG-63" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-62" value="Set frame type to greyscale" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="35" y="1310" width="180" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-62" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="Set frame type to greyscale" vertex="1">
+          <mxGeometry height="40" width="180" x="35" y="1310" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-66" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" parent="1" source="S9g8uFfFkQZEvXXLItgG-63" target="S9g8uFfFkQZEvXXLItgG-65" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-66" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-63" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" target="S9g8uFfFkQZEvXXLItgG-65" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-63" value="Configure AprilTagDetector" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="235" y="1310" width="180" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-63" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="Configure AprilTagDetector" vertex="1">
+          <mxGeometry height="40" width="180" x="235" y="1310" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-68" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" parent="1" source="S9g8uFfFkQZEvXXLItgG-65" target="S9g8uFfFkQZEvXXLItgG-67" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-68" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-65" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" target="S9g8uFfFkQZEvXXLItgG-67" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-65" value="Load camera calibration" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="440" y="1310" width="180" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-65" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="Load camera calibration" vertex="1">
+          <mxGeometry height="40" width="180" x="440" y="1310" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-70" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" parent="1" source="S9g8uFfFkQZEvXXLItgG-67" target="S9g8uFfFkQZEvXXLItgG-69" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-70" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-67" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" target="S9g8uFfFkQZEvXXLItgG-69" value="">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="740" y="1380" />
@@ -432,59 +432,59 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-67" value="Load camera calibration" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="650" y="1310" width="180" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-67" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="Load camera calibration" vertex="1">
+          <mxGeometry height="40" width="180" x="650" y="1310" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-73" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-69" target="S9g8uFfFkQZEvXXLItgG-72" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-73" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-69" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-72" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-69" value="Run detector pipe" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="677.5" y="1395" width="125" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-69" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Run detector pipe" vertex="1">
+          <mxGeometry height="40" width="125" x="677.5" y="1395" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-71" value="&lt;b&gt;NOTE: &lt;/b&gt;&quot;Pipes&quot; are modular processing stages that are sequenced together to create pipelines." style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="240" y="1160" width="170" height="30" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-71" parent="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" value="&lt;b&gt;NOTE: &lt;/b&gt;&quot;Pipes&quot; are modular processing stages that are sequenced together to create pipelines." vertex="1">
+          <mxGeometry height="30" width="170" x="240" y="1160" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-110" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-72" target="S9g8uFfFkQZEvXXLItgG-76" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-110" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-72" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-76">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-72" value="Filter out detected tags based on hamming distance and decision margin" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="470" y="1385" width="180" height="60" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-72" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Filter out detected tags based on hamming distance and decision margin" vertex="1">
+          <mxGeometry height="60" width="180" x="470" y="1385" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-111" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-76" target="S9g8uFfFkQZEvXXLItgG-78" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-111" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-76" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-78">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-76" value="Create TrackedTargets out of remaining detections&amp;nbsp;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="260" y="1385" width="180" height="60" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-76" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Create TrackedTargets out of remaining detections&amp;nbsp;" vertex="1">
+          <mxGeometry height="60" width="180" x="260" y="1385" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-112" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-78" target="S9g8uFfFkQZEvXXLItgG-80" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-112" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-78" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-80">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-78" value="Run Multi and Single tag PNP to estimate poses from tracked tags" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="35" y="1385" width="180" height="60" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-78" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Run Multi and Single tag PNP to estimate poses from tracked tags" vertex="1">
+          <mxGeometry height="60" width="180" x="35" y="1385" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-80" value="Return target list and multi-tag pose estimate" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="35" y="1475" width="180" height="60" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-80" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Return target list and multi-tag pose estimate" vertex="1">
+          <mxGeometry height="60" width="180" x="35" y="1475" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-82" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;font style=&quot;font-size: 18px;&quot;&gt;ObjectDetectionPipeline&lt;/font&gt;&lt;/h1&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="10" y="1615" width="230" height="50" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-82" parent="1" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;&lt;font style=&quot;font-size: 18px;&quot;&gt;ObjectDetectionPipeline&lt;/font&gt;&lt;/h1&gt;" vertex="1">
+          <mxGeometry height="50" width="230" x="10" y="1615" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-85" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" parent="1" source="S9g8uFfFkQZEvXXLItgG-86" target="S9g8uFfFkQZEvXXLItgG-88" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-85" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-86" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" target="S9g8uFfFkQZEvXXLItgG-88" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-86" value="Get Model instance based on model path from NeuralNetworkModelManager" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="35" y="1662.5" width="245" height="45" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-86" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="Get Model instance based on model path from NeuralNetworkModelManager" vertex="1">
+          <mxGeometry height="45" width="245" x="35" y="1662.5" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-87" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" parent="1" source="S9g8uFfFkQZEvXXLItgG-88" target="S9g8uFfFkQZEvXXLItgG-90" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-87" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-88" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" target="S9g8uFfFkQZEvXXLItgG-90" value="">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="555" y="1685" />
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-88" value="Set object detector parameters" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="295" y="1665" width="180" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-88" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="Set object detector parameters" vertex="1">
+          <mxGeometry height="40" width="180" x="295" y="1665" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-89" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" parent="1" source="S9g8uFfFkQZEvXXLItgG-90" target="S9g8uFfFkQZEvXXLItgG-92" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-89" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-90" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#1ba1e2;strokeColor=#006EAF;" target="S9g8uFfFkQZEvXXLItgG-92" value="">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
               <mxPoint x="559" y="1720" />
@@ -492,152 +492,53 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-90" value="Configure offset, contour, collect targets pipes" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="500" y="1665" width="180" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-90" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="Configure offset, contour, collect targets pipes" vertex="1">
+          <mxGeometry height="40" width="180" x="500" y="1665" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-91" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-92" target="S9g8uFfFkQZEvXXLItgG-95" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-91" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-92" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-95" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-92" value="Run detector pipe" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="496.25" y="1730" width="125" height="40" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-92" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Run detector pipe" vertex="1">
+          <mxGeometry height="40" width="125" x="496.25" y="1730" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-94" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-95" target="S9g8uFfFkQZEvXXLItgG-97" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-94" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-95" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-97" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-95" value="Get object class names" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="318.75" y="1732.19" width="140" height="35.63" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-95" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Get object class names" vertex="1">
+          <mxGeometry height="35.63" width="140" x="318.75" y="1732.19" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-107" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-97" target="S9g8uFfFkQZEvXXLItgG-99" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-107" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-97" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-99">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-97" value="Run contour filter" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="173.75" y="1734.37" width="120" height="35.63" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-97" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Run contour filter" vertex="1">
+          <mxGeometry height="35.63" width="120" x="173.75" y="1734.37" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-98" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-99" target="S9g8uFfFkQZEvXXLItgG-101" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-98" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-99" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-101" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-99" value="Sort contours" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="36.25" y="1737.1799999999998" width="95" height="30" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-99" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Sort contours" vertex="1">
+          <mxGeometry height="30" width="95" x="36.25" y="1737.1799999999998" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-100" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" parent="1" source="S9g8uFfFkQZEvXXLItgG-101" target="S9g8uFfFkQZEvXXLItgG-102" edge="1">
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-100" edge="1" parent="1" source="S9g8uFfFkQZEvXXLItgG-101" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fillColor=#008a00;strokeColor=#005700;" target="S9g8uFfFkQZEvXXLItgG-102" value="">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-101" value="Collect targets" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="35" y="1804.37" width="97.5" height="35" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-101" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Collect targets" vertex="1">
+          <mxGeometry height="35" width="97.5" x="35" y="1804.37" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-102" value="Return collected target list, names" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="173.75" y="1804.37" width="180" height="35" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-102" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="Return collected target list, names" vertex="1">
+          <mxGeometry height="35" width="180" x="173.75" y="1804.37" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-105" value="&lt;b&gt;Thread&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="870" y="170" width="170" height="30" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-105" parent="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="&lt;b&gt;Thread&lt;/b&gt;" vertex="1">
+          <mxGeometry height="30" width="170" x="870" y="170" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-106" value="&lt;b&gt;Pipeline process()&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" parent="1" vertex="1">
-          <mxGeometry x="460" y="1210" width="170" height="30" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-106" parent="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=#008a00;fontColor=#ffffff;strokeColor=#005700;" value="&lt;b&gt;Pipeline process()&lt;/b&gt;" vertex="1">
+          <mxGeometry height="30" width="170" x="460" y="1210" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-108" value="&lt;b&gt;Main Thread&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=none;strokeColor=default;" parent="1" vertex="1">
-          <mxGeometry x="870" y="215" width="170" height="30" as="geometry" />
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-108" parent="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=none;strokeColor=default;" value="&lt;b&gt;Main Thread&lt;/b&gt;" vertex="1">
+          <mxGeometry height="30" width="170" x="870" y="215" as="geometry" />
         </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-109" value="&lt;b&gt;VisionRunner Thread&lt;/b&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-          <mxGeometry x="460" y="1157.5" width="170" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-113" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;PhotonVision Neural Network Model Manager&lt;/h1&gt;&lt;p&gt;Date: 2026-10-09&lt;/p&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;" parent="1" vertex="1">
-          <mxGeometry x="860" y="1110" width="210" height="140" as="geometry" />
-        </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-118" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="S9g8uFfFkQZEvXXLItgG-116" target="S9g8uFfFkQZEvXXLItgG-117" edge="1">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-116" value="Check if given model supports current platform" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="920" y="1259.37" width="120" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="S9g8uFfFkQZEvXXLItgG-117" value="Return Model object" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="1080" y="1259.37" width="120" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-3" value="loadModel" style="swimlane;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="1310" y="1470" width="250" height="400.63" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-4" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-3" source="TSCiUmVzXHveZjrjVy07-5" target="TSCiUmVzXHveZjrjVy07-7">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-5" value="Create models HashMap if null" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-3">
-          <mxGeometry x="65" y="40.629999999999995" width="120" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-6" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-3" source="TSCiUmVzXHveZjrjVy07-7" target="TSCiUmVzXHveZjrjVy07-9">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-7" value="Get model properties from NeuralNetworkPropertyManager using the path" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-3">
-          <mxGeometry x="25" y="100.63" width="200" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-8" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-3" source="TSCiUmVzXHveZjrjVy07-9" target="TSCiUmVzXHveZjrjVy07-11">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-9" value="Check for backend support" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-3">
-          <mxGeometry x="65" y="180.63" width="120" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-10" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-3" source="TSCiUmVzXHveZjrjVy07-11" target="TSCiUmVzXHveZjrjVy07-13">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-11" value="if no models of this family have been loaded, insert it into the map with an empty List as the value" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-3">
-          <mxGeometry x="10" y="250.63" width="230" height="59.37" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-13" value="Add RKNN or Rubik model to the list based on the family of this model" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-3">
-          <mxGeometry x="25" y="330.63" width="200" height="50.63" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-23" value="Important Members" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="1290" y="1210" width="140" height="170" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-24" value="&lt;b&gt;models&lt;/b&gt; - HashMap of model families (RKNN, Rubik) to lists of models in those families" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-23">
-          <mxGeometry y="30" width="140" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-25" value="Item 2" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-23">
-          <mxGeometry y="110" width="140" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-26" value="Item 3" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-23">
-          <mxGeometry y="140" width="140" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-27" value="discoverModels" style="swimlane;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="900" y="1360" width="250" height="470" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-28" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-27" source="TSCiUmVzXHveZjrjVy07-29" target="TSCiUmVzXHveZjrjVy07-31">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-29" value="Get models folder" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-27">
-          <mxGeometry x="65" y="40.629999999999995" width="120" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-30" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-27" source="TSCiUmVzXHveZjrjVy07-31" target="TSCiUmVzXHveZjrjVy07-33">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-31" value="Filter files in models folder based on the paths demanded by the model families" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-27">
-          <mxGeometry x="25" y="100.63" width="200" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-32" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-27" source="TSCiUmVzXHveZjrjVy07-33" target="TSCiUmVzXHveZjrjVy07-35">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-33" value="Load each resulting model" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-27">
-          <mxGeometry x="65" y="180.63" width="120" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-34" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-27" source="TSCiUmVzXHveZjrjVy07-35" target="TSCiUmVzXHveZjrjVy07-36">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-35" value="if no models of this family have been loaded, insert it into the map with an empty List as the value" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-27">
-          <mxGeometry x="10" y="250.63" width="230" height="59.37" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-40" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="TSCiUmVzXHveZjrjVy07-27" source="TSCiUmVzXHveZjrjVy07-36" target="TSCiUmVzXHveZjrjVy07-39">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-36" value="Add RKNN or Rubik model to the list based on the family of this model" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-27">
-          <mxGeometry x="25" y="330.63" width="200" height="50.63" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-39" value="Sort list by name and log model UIDs grouped by backend" style="whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="TSCiUmVzXHveZjrjVy07-27">
-          <mxGeometry x="25" y="400" width="200" height="50.63" as="geometry" />
-        </mxCell>
-        <mxCell id="TSCiUmVzXHveZjrjVy07-38" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="TSCiUmVzXHveZjrjVy07-33" target="TSCiUmVzXHveZjrjVy07-3">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="1230" y="1561" />
-              <mxPoint x="1230" y="1440" />
-              <mxPoint x="1435" y="1440" />
-            </Array>
-          </mxGeometry>
+        <mxCell id="S9g8uFfFkQZEvXXLItgG-109" parent="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" value="&lt;b&gt;VisionRunner Thread&lt;/b&gt;" vertex="1">
+          <mxGeometry height="30" width="170" x="460" y="1157.5" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>


### PR DESCRIPTION
Still need to do most of the OD/NN section, but after that it should be mergeable.

Provides draw.io diagrams of the PhotonVision initialization, on-coproc dataflow, pipelines (AprilTag and Object Detection), and Object detection architecture. Intent is to be integrated into the contributor docs, though the diagrams should probably be split into their own files? 