### PR TITLE
Add Luma P1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_VERSION: v2026.0.3
+  IMAGE_VERSION: v2026.0.4
 
 jobs:
 
@@ -447,8 +447,8 @@ jobs:
             image_additional_mb: 0
           - os: ubuntu-24.04
             artifact-name: LinuxArm64
-            image_suffix: lumap1
-            image_url: https://github.com/PhotonVision/photon-image-modifier/actions/runs/18581709087/artifacts/4295810004
+            image_suffix: luma_p1
+            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_luma_p1.img.xz
             cpu: cortex-a76
             image_additional_mb: 0
           - os: ubuntu-24.04


### PR DESCRIPTION
## Description

Adds support for building images for the Luma P1. This bumps the image modifier pin to v2025.0.4. This pulls in:

[Move compression outside of mount script (](https://github.com/PhotonVision/photon-image-modifier/commit/224a35cd3f714801402b73c389f5b00c5fd6e3c5)https://github.com/PhotonVision/photon-image-modifier/pull/84[)](https://github.com/PhotonVision/photon-image-modifier/commit/224a35cd3f714801402b73c389f5b00c5fd6e3c5)
[Add Luma P1 support (](https://github.com/PhotonVision/photon-image-modifier/commit/cd928224b86600f5eb6fd2ff92ca88474c647815)https://github.com/PhotonVision/photon-image-modifier/pull/85[)](https://github.com/PhotonVision/photon-image-modifier/commit/cd928224b86600f5eb6fd2ff92ca88474c647815)
[Fix tarball directory structure (](https://github.com/PhotonVision/photon-image-modifier/commit/970f1b585696d672a3f09d20d2c021fd924e577f)https://github.com/PhotonVision/photon-image-modifier/pull/86[)](https://github.com/PhotonVision/photon-image-modifier/commit/970f1b585696d672a3f09d20d2c021fd924e577f)

**Full Changelog**: https://github.com/PhotonVision/photon-image-modifier/compare/v2026.0.3...v2026.0.4


## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
