### PR TITLE
Add downgrade fix for ONNX error during RKNN conversion

### DIFF
--- a/scripts/rknn-convert-tool/create_onnx.py
+++ b/scripts/rknn-convert-tool/create_onnx.py
@@ -82,7 +82,8 @@ def run_onnx_conversion_yolov5(model_path):
             "-r",
             os.path.join(ultralytics_folder_name_yolov5, "requirements.txt"),
             "torch<2.6.0",
-            "onnx",
+            "onnx==1.18.0",
+            "onnxscript",
         ]
     )
 
@@ -121,7 +122,9 @@ def run_onnx_conversion_yolov5(model_path):
 
 def run_onnx_conversion_no_anchor(model_path):
     check_or_clone_rockchip_repo(yolo_non_anchor_repo)
-    run_pip_install_or_else_exit(["-e", ultralytics_default_folder_name, "onnx"])
+    run_pip_install_or_else_exit(
+        ["-e", ultralytics_default_folder_name, "onnx==1.18.0", "onnxscript"]
+    )
 
     sys.path.insert(0, os.path.abspath(ultralytics_default_folder_name))
     model_abs_path = os.path.abspath(model_path)

--- a/scripts/rknn-convert-tool/rknn_conversion.ipynb
+++ b/scripts/rknn-convert-tool/rknn_conversion.ipynb
@@ -109,7 +109,7 @@
     "\n",
     "#### Automatic installation\n",
     "\n",
-    "Please run `pip` below. If it does not work, refer to the instructions for manual installation.\n"
+    "Please run `pip` below. If it does not work, refer to the instructions for manual installation. You may need to restart your session after running the command below.\n"
    ]
   },
   {


### PR DESCRIPTION
## Description

Due to a version mismatch for the version of ONNX needed for the `rknn-toolkit2` to work, the `create_rknn.py` script would give an attribute not found error. This PR fixes it by locking the version of the ONNX library to `1.18.0`

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
