### PR TITLE
Made steam overlay buttons primary color

### DIFF
--- a/photon-client/src/components/app/photon-camera-stream.vue
+++ b/photon-client/src/components/app/photon-camera-stream.vue
@@ -105,18 +105,21 @@ onBeforeUnmount(() => {
     />
     <div class="stream-overlay" :style="overlayStyle">
       <pv-icon
+        color="primary"
         icon-name="mdi-camera-image"
         tooltip="Capture and save a frame of this stream"
         class="ma-1 mr-2"
         @click="handleCaptureClick"
       />
       <pv-icon
+        color="primary"
         icon-name="mdi-fullscreen"
         tooltip="Open this stream in fullscreen"
         class="ma-1 mr-2"
         @click="handleFullscreenRequest"
       />
       <pv-icon
+        color="primary"
         icon-name="mdi-open-in-new"
         tooltip="Open this stream in a new window"
         class="ma-1 mr-2"


### PR DESCRIPTION
## Description

Fixed issue where stream overlay buttons were not visible on a white background.

<img width="518" height="305" alt="image" src="https://github.com/user-attachments/assets/919cc64d-6d65-422f-a3c7-94f99862a956" />

Closes #1820

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
