### PR TITLE
Fix versioning helper

### DIFF
--- a/versioningHelper.gradle
+++ b/versioningHelper.gradle
@@ -8,7 +8,7 @@ gradle.allprojects {
         def stdout = new ByteArrayOutputStream()
         String tagIsh
         try {
-            Project.getProviders().exec {
+            project.exec {
                 commandLine 'git', 'describe', '--tags', "--match=v*"
                 standardOutput = stdout
             }


### PR DESCRIPTION
## Description

When we tagged `v2026.0.0-alpha-1`, we broke the versioning-helper logic. It doesn't expect `alpha` in the version string. This PR adds matching for lowercase alphanumeric to the versioning helper, which resolves that issue.

Also turns out `getProviders()` is now broken as a gradle method. Sad.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
