### PR TITLE
Take calib snapshots in a loop

### DIFF
--- a/docs/source/docs/calibration/calibration.md
+++ b/docs/source/docs/calibration/calibration.md
@@ -59,7 +59,11 @@ We'll next select a resolution to calibrate and populate our pattern spacing, ma
 If you have a [calib.io](https://calib.io/) ChArUco Target you will have to enter the paramaters of your target. For example if your target says "9x12 | Checker Size: 30 mm | Marker Size: 22 mm | Dictionary: ArUco DICT 5x5", you would have to set the board type to Dict_5x5_1000, the pattern spacing to 1.1811 in (30 mm converted to inches), the marker size 0.866142 in (22 mm converted to inches), the board width to 12 and the board height to 9. If you chose the wrong tag family the board wont be detected during calibration. If you swap the width and height your calibration will have a very high error.
 :::
 
-### 4. Take at calibration images from various angles.
+::{note}
+Using the `Snapshot Loop` feature can help speed up the image capture process. This feature will continuously take snapshots at a set interval until the user stops it. This is useful for capturing images from different angles quickly without having to manually click the snapshot button each time.
+:::
+
+### 4. Take calibration images from various angles.
 
 Now, we'll capture images of our board from various angles. It's important to check that the board overlay matches the board in your image. The further the overdrawn points are from the true position of the chessboard corners, the less accurate the final calibration will be. We'll want to capture enough images to cover the whole camera's FOV (with a minimum of 12). Once we've got our images, we'll click "Finish calibration" and wait for the calibration process to complete. If all goes well, the mean error and FOVs will be shown in the table on the right. The FOV should be close to the camera's specified FOV (usually found in a datasheet) usually within + or - 10 degrees. The mean error should also be low, usually less than 1 pixel.
 

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -591,7 +591,6 @@ const setSelectedVideoFormat = (format: VideoFormat) => {
               size="small"
               block
               :variant="theme.global.current.value.dark ? 'outlined' : 'elevated'"
-              v-if="isCalibrating"
               :color="useStateStore().calibrationData.hasEnoughImages ? 'buttonActive' : 'error'"
               :disabled="!isCalibrating || !settingsValid"
               @click="endCalibration"

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -239,6 +239,7 @@ const calibCanceled = ref(false);
 const calibSuccess = ref<boolean | undefined>(undefined);
 const calibEndpointFail = ref(false);
 const endCalibration = () => {
+  useCameraSettingsStore().stopCalibrationSnapshotLoop();
   calibSuccess.value = undefined;
   calibEndpointFail.value = false;
 
@@ -589,6 +590,7 @@ const setSelectedVideoFormat = (format: VideoFormat) => {
               size="small"
               block
               :variant="theme.global.current.value.dark ? 'outlined' : 'elevated'"
+              v-if="isCalibrating"
               :color="useStateStore().calibrationData.hasEnoughImages ? 'buttonActive' : 'error'"
               :disabled="!isCalibrating || !settingsValid"
               @click="endCalibration"
@@ -599,6 +601,22 @@ const setSelectedVideoFormat = (format: VideoFormat) => {
               <span class="calib-btn-label">{{
                 useStateStore().calibrationData.hasEnoughImages ? "Finish Calibration" : "Cancel Calibration"
               }}</span>
+            </v-btn>
+            <v-btn
+              size="small"
+              block
+              v-if="!isCalibrating"
+              color="buttonActive"
+              :variant="theme.global.name.value === 'LightTheme' ? 'elevated' : 'outlined'"
+              :disabled="!settingsValid"
+              tooltip="Automatically take calibration snapshots in a loop until calibration is ended"
+              @click="
+                startCalibration();
+                useCameraSettingsStore().startCalibrationSnapshotLoop();
+              "
+            >
+              <v-icon start class="calib-btn-icon" size="large"> mdi-autorenew </v-icon>
+              <span class="calib-btn-label"> Start Snapshot Loop </span>
             </v-btn>
           </v-col>
         </div>

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -587,6 +587,7 @@ const setSelectedVideoFormat = (format: VideoFormat) => {
           </v-col>
           <v-col cols="6" class="pa-0 pl-2">
             <v-btn
+              v-if="isCalibrating"
               size="small"
               block
               :variant="theme.global.current.value.dark ? 'outlined' : 'elevated'"
@@ -603,9 +604,9 @@ const setSelectedVideoFormat = (format: VideoFormat) => {
               }}</span>
             </v-btn>
             <v-btn
+              v-if="!isCalibrating"
               size="small"
               block
-              v-if="!isCalibrating"
               color="buttonActive"
               :variant="theme.global.name.value === 'LightTheme' ? 'elevated' : 'outlined'"
               :disabled="!settingsValid"

--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -432,7 +432,7 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
      */
     startCalibrationSnapshotLoop(intervalMs = 500, cameraUniqueName: string = useStateStore().currentCameraUniqueName) {
       // store the interval id on the store instance (avoid changing state shape)
-      if ((this as any)._calibrationSnapshotInterval != null) return;
+      if ((this as any)._calibrationSnapshotInterval !== null) return;
       // take one immediately then schedule
       this.takeCalibrationSnapshot(cameraUniqueName);
       (this as any)._calibrationSnapshotInterval = window.setInterval(() => {
@@ -444,7 +444,7 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
      * Stop a running calibration snapshot loop started with startCalibrationSnapshotLoop().
      */
     stopCalibrationSnapshotLoop() {
-      if ((this as any)._calibrationSnapshotInterval == null) return;
+      if ((this as any)._calibrationSnapshotInterval === null) return;
       clearInterval((this as any)._calibrationSnapshotInterval);
       (this as any)._calibrationSnapshotInterval = null;
     },

--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -422,6 +422,32 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
       };
       useStateStore().websocket?.send(payload);
     },
+
+    /**
+     * Start repeatedly calling takeCalibrationSnapshot every intervalMs milliseconds.
+     * No-op if already running. Call stopCalibrationSnapshotLoop() to stop.
+     *
+     * @param intervalMs interval in milliseconds between snapshots (default 1000)
+     * @param cameraUniqueName camera to snapshot (captured when the loop starts)
+     */
+    startCalibrationSnapshotLoop(intervalMs = 500, cameraUniqueName: string = useStateStore().currentCameraUniqueName) {
+      // store the interval id on the store instance (avoid changing state shape)
+      if ((this as any)._calibrationSnapshotInterval != null) return;
+      // take one immediately then schedule
+      this.takeCalibrationSnapshot(cameraUniqueName);
+      (this as any)._calibrationSnapshotInterval = window.setInterval(() => {
+        this.takeCalibrationSnapshot(cameraUniqueName);
+      }, intervalMs);
+    },
+
+    /**
+     * Stop a running calibration snapshot loop started with startCalibrationSnapshotLoop().
+     */
+    stopCalibrationSnapshotLoop() {
+      if ((this as any)._calibrationSnapshotInterval == null) return;
+      clearInterval((this as any)._calibrationSnapshotInterval);
+      (this as any)._calibrationSnapshotInterval = null;
+    },
     /**
      * Save a snapshot of the input frame of the camera.
      *


### PR DESCRIPTION
## Description

Instead of requiring users to click the snapshot button each time they want to grab an image, we now take snapshots whenever we have a target in the image. All of this is done in the frontend, so no backend changes are needed.

See [here](https://drive.google.com/file/d/13OCmBB96rPm0EDJHWlw8Uq8DyAM0er49/view?usp=sharing) for an example.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
