### PR TITLE
Fix bug with import nickname

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -655,15 +655,11 @@ public class RequestHandler {
                 Files.copy(modelFileStream, modelPath, StandardCopyOption.REPLACE_EXISTING);
             }
 
+            int idx = modelFile.filename().lastIndexOf('.');
+            String nickname = modelFile.filename().substring(0, idx);
+
             ModelProperties modelProperties =
-                    new ModelProperties(
-                            modelPath,
-                            modelFile.filename().replaceAll("." + family.extension(), ""),
-                            labels,
-                            width,
-                            height,
-                            family,
-                            version);
+                    new ModelProperties(modelPath, nickname, labels, width, height, family, version);
 
             ObjectDetector objDetector = null;
 


### PR DESCRIPTION
## Description

`.` is a special regex character, which means we weren't actually matching the `.` in the string, but rather the character before it. This resulted in the last letter in a model nickname getting cut off on import. This fix resolves that issue.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] This PR has been [linted](https://docs.photonvision.org/en/latest/docs/contributing/linting.html).
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
