### PR TITLE
Refactor frontend pipeline typing

### DIFF
--- a/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
+++ b/photon-client/src/components/dashboard/CameraAndPipelineSelectCard.vue
@@ -124,7 +124,7 @@ const cancelPipelineNameEdit = () => {
 // Pipeline Creation
 const showPipelineCreationDialog = ref(false);
 const newPipelineName = ref("");
-const newPipelineType = ref<WebsocketPipelineType>(useCameraSettingsStore().currentWebsocketPipelineType);
+const newPipelineType = ref<WebsocketPipelineType>(useCameraSettingsStore().currentPipelineType);
 const validNewPipelineTypes = computed(() => {
   const pipelineTypes = [
     { name: "Reflective", value: WebsocketPipelineType.Reflective },
@@ -139,7 +139,7 @@ const validNewPipelineTypes = computed(() => {
 });
 const showCreatePipelineDialog = () => {
   newPipelineName.value = "";
-  newPipelineType.value = useCameraSettingsStore().currentWebsocketPipelineType;
+  newPipelineType.value = useCameraSettingsStore().currentPipelineType;
   showPipelineCreationDialog.value = true;
 };
 const createNewPipeline = () => {
@@ -151,7 +151,7 @@ const createNewPipeline = () => {
 const cancelPipelineCreation = () => {
   showPipelineCreationDialog.value = false;
   newPipelineName.value = "";
-  newPipelineType.value = useCameraSettingsStore().currentWebsocketPipelineType;
+  newPipelineType.value = useCameraSettingsStore().currentPipelineType;
 };
 
 // Pipeline Deletion
@@ -183,7 +183,7 @@ const pipelineTypesWrapper = computed<{ name: string; value: number }[]>(() => {
 
   return pipelineTypes;
 });
-const pipelineType = ref<WebsocketPipelineType>(useCameraSettingsStore().currentWebsocketPipelineType);
+const pipelineType = ref<WebsocketPipelineType>(useCameraSettingsStore().currentPipelineType);
 const currentPipelineType = computed<WebsocketPipelineType>({
   get: () => {
     if (useCameraSettingsStore().isDriverMode) return WebsocketPipelineType.DriverMode;
@@ -201,7 +201,7 @@ const confirmChangePipelineType = () => {
   showPipelineTypeChangeDialog.value = false;
 };
 const cancelChangePipelineType = () => {
-  pipelineType.value = useCameraSettingsStore().currentWebsocketPipelineType;
+  pipelineType.value = useCameraSettingsStore().currentPipelineType;
   showPipelineTypeChangeDialog.value = false;
 };
 

--- a/photon-client/src/components/dashboard/ConfigOptions.vue
+++ b/photon-client/src/components/dashboard/ConfigOptions.vue
@@ -85,10 +85,10 @@ const tabGroups = computed<ConfigOption[][]>(() => {
   if (useCameraSettingsStore().isDriverMode) return [[allTabs.inputTab]];
 
   const allow3d = useCameraSettingsStore().currentPipelineSettings.solvePNPEnabled;
-  const isAprilTag = useCameraSettingsStore().currentWebsocketPipelineType === WebsocketPipelineType.AprilTag;
-  const isAruco = useCameraSettingsStore().currentWebsocketPipelineType === WebsocketPipelineType.Aruco;
+  const isAprilTag = useCameraSettingsStore().currentPipelineType === WebsocketPipelineType.AprilTag;
+  const isAruco = useCameraSettingsStore().currentPipelineType === WebsocketPipelineType.Aruco;
   const isObjectDetection =
-    useCameraSettingsStore().currentWebsocketPipelineType === WebsocketPipelineType.ObjectDetection;
+    useCameraSettingsStore().currentPipelineType === WebsocketPipelineType.ObjectDetection;
 
   return getTabGroups()
     .map((tabGroup) =>

--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -12,8 +12,8 @@ import type {
 import { PlaceholderCameraSettings } from "@/types/SettingTypes";
 import { useStateStore } from "@/stores/StateStore";
 import type { WebsocketCameraSettingsUpdate } from "@/types/WebsocketDataTypes";
-import { WebsocketPipelineType } from "@/types/WebsocketDataTypes";
-import type { ActiveConfigurablePipelineSettings, ActivePipelineSettings, PipelineType } from "@/types/PipelineTypes";
+import { PipelineType } from "@/types/WebsocketDataTypes";
+import type { ActiveConfigurablePipelineSettings, ActivePipelineSettings } from "@/types/PipelineTypes";
 import axios from "axios";
 import { resolutionsAreEqual } from "@/lib/PhotonUtils";
 
@@ -43,10 +43,6 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
     currentPipelineType(): PipelineType {
       return this.currentPipelineSettings.pipelineType;
     },
-    // This method only exists due to just how lazy I am and my dislike of consolidating the pipeline type enums (which mind you, suck as is)
-    currentWebsocketPipelineType(): WebsocketPipelineType {
-      return this.currentPipelineType - 2;
-    },
     currentVideoFormat(): VideoFormat {
       return this.currentCameraSettings.validVideoFormats[this.currentPipelineSettings.cameraVideoModeIndex];
     },
@@ -71,10 +67,10 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
       return this.pipelineNames[useStateStore().currentCameraUniqueName];
     },
     isDriverMode(): boolean {
-      return this.currentCameraSettings.currentPipelineIndex === WebsocketPipelineType.DriverMode;
+      return this.currentCameraSettings.currentPipelineIndex === PipelineType.DriverMode;
     },
     isCalibrationMode(): boolean {
-      return this.currentCameraSettings.currentPipelineIndex == WebsocketPipelineType.Calib3d;
+      return this.currentCameraSettings.currentPipelineIndex == PipelineType.Calib3d;
     },
     isCSICamera(): boolean {
       return this.currentCameraSettings.isCSICamera;
@@ -180,12 +176,12 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
      * Create a new Pipeline for the provided camera.
      *
      * @param newPipelineName the name of the new pipeline.
-     * @param pipelineType the type of the new pipeline. Cannot be {@link WebsocketPipelineType.Calib3d} or {@link WebsocketPipelineType.DriverMode}.
+     * @param pipelineType the type of the new pipeline. Cannot be {@link PipelineType.Calib3d} or {@link PipelineType.DriverMode}.
      * @param cameraUniqueName the unique name of the camera.
      */
     createNewPipeline(
       newPipelineName: string,
-      pipelineType: Exclude<WebsocketPipelineType, WebsocketPipelineType.Calib3d | WebsocketPipelineType.DriverMode>,
+      pipelineType: Exclude<PipelineType, PipelineType.Calib3d | PipelineType.DriverMode>,
       cameraUniqueName: string = useStateStore().currentCameraUniqueName
     ) {
       const payload = {
@@ -250,11 +246,11 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
     /**
      * Modify the Pipeline type of the currently selected pipeline of the provided camera. This overwrites the current pipeline's settings when the backend resets the current pipeline settings.
      *
-     * @param type the pipeline type to set.  Cannot be {@link WebsocketPipelineType.Calib3d} or {@link WebsocketPipelineType.DriverMode}.
+     * @param type the pipeline type to set.  Cannot be {@link PipelineType.Calib3d} or {@link PipelineType.DriverMode}.
      * @param cameraUniqueName the unique name of the camera.
      */
     changeCurrentPipelineType(
-      type: Exclude<WebsocketPipelineType, WebsocketPipelineType.Calib3d | WebsocketPipelineType.DriverMode>,
+      type: Exclude<PipelineType, PipelineType.Calib3d | PipelineType.DriverMode>,
       cameraUniqueName: string = useStateStore().currentCameraUniqueName
     ) {
       const payload = {

--- a/photon-client/src/types/PipelineTypes.ts
+++ b/photon-client/src/types/PipelineTypes.ts
@@ -2,12 +2,13 @@ import type { WebsocketNumberPair } from "@/types/WebsocketDataTypes";
 import type { ObjectDetectionModelProperties } from "@/types/SettingTypes";
 
 export enum PipelineType {
-  DriverMode = 1,
-  Reflective = 2,
-  ColoredShape = 3,
-  AprilTag = 4,
-  Aruco = 5,
-  ObjectDetection = 6
+  Calib3d = -2,
+  DriverMode = -1,
+  Reflective = 0,
+  ColoredShape = 1,
+  AprilTag = 2,
+  Aruco = 3,
+  ObjectDetection = 4
 }
 
 export enum AprilTagFamily {
@@ -325,7 +326,7 @@ export type ConfigurableCalibration3dPipelineSettings = Partial<Omit<Calibration
   ConfigurablePipelineSettings;
 export const DefaultCalibration3dPipelineSettings: Calibration3dPipelineSettings = {
   ...DefaultPipelineSettings,
-  pipelineType: PipelineType.ObjectDetection,
+  pipelineType: PipelineType.Calib3d,
   cameraGain: 20,
   targetModel: TargetModel.InfiniteRechargeHighGoalOuter,
   ledMode: true,


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

We currently duplicate the pipeline type enum in the frontend. This PR changes all instances that used the enum from PipelineTypes to use the Websocket enum. It additionally sets the calib3d pipeline type to calib3d instead of OD.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] This PR has been [linted](https://docs.photonvision.org/en/latest/docs/contributing/linting.html).
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
