### PR TITLE
Discourage use of NT APIs

### DIFF
--- a/photon-targeting/src/main/java/org/photonvision/common/networktables/NTTopicSet.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/networktables/NTTopicSet.java
@@ -40,7 +40,6 @@ import org.photonvision.targeting.PhotonPipelineResult;
  * <p>However, we do expect that the actual logic which fills out values in the entries will be
  * different for sim vs. real camera
  */
-@Deprecated(since = "2025", forRemoval = true)
 public class NTTopicSet {
     public NetworkTable subTable;
 

--- a/photon-targeting/src/main/native/include/photon/networktables/NTTopicSet.h
+++ b/photon-targeting/src/main/native/include/photon/networktables/NTTopicSet.h
@@ -28,7 +28,6 @@
 #include <networktables/NetworkTable.h>
 #include <networktables/RawTopic.h>
 #include <networktables/StructTopic.h>
-#include <wpi/deprecated.h>
 
 namespace photon {
 const std::string PhotonPipelineResult_TYPE_STRING =
@@ -102,12 +101,6 @@ class NTTopicSet {
         subTable->GetDoubleArrayTopic("cameraIntrinsics").Publish();
     cameraDistortionPublisher =
         subTable->GetDoubleArrayTopic("cameraDistortion").Publish();
-
-    fmt::println(
-        "NetworkTables is not a supported setup/viable option when using"
-        "PhotonVision as we only send one target at a time.   We strongly"
-        "recommend using PhotonLib instead, as the NetworkTables API will"
-        "most likely be removed in 2027.");
   }
 
  private:


### PR DESCRIPTION
## Description
<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->
As per the linked issue, raw NT APIs are old and mostly obsolete, this PR adds user-facing notifications of that.

Not sure if this "officially" counts as the raw APIs being deprecated, or if this is not meant to be a full on deprecation. Thoughts?
Closes #1828

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] This PR has been [linted](https://docs.photonvision.org/en/latest/docs/contributing/linting.html).
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2


