### PR TITLE
Catch other boards in isRK3588 check

### DIFF
--- a/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
@@ -128,7 +128,10 @@ public enum Platform {
     }
 
     public static boolean isRK3588() {
-        return Platform.isOrangePi() || Platform.isCoolPi4b() || Platform.isRock5C();
+        return Platform.isOrangePi()
+                || Platform.isCoolPi4b()
+                || Platform.isRock5C()
+                || fileHasText("/proc/device-tree/compatible", "rk3588");
     }
 
     public static boolean isQCS6490() {


### PR DESCRIPTION
## Description

The current `isRK3588` check only catches certain boards. Specifically, Orange Pi 5, Cool Pi 4, and Rock 5C. So, RKNN object detection is not available on boards such as the Radxa CM5, which has an RK3588S chip.

This PR adds an additional check to catch other boards with the RK3588(S) chip by checking for `rk3588` in `/proc/device-tree/compatible`.

## Meta

Merge checklist:
- [X] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [X] The description documents the _what_ and _why_
- [X] This PR has been [linted](https://docs.photonvision.org/en/latest/docs/contributing/linting.html).
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
