### PR TITLE
Fix PipelineType index mismatch

### DIFF
--- a/photon-client/src/stores/settings/CameraSettingsStore.ts
+++ b/photon-client/src/stores/settings/CameraSettingsStore.ts
@@ -45,7 +45,7 @@ export const useCameraSettingsStore = defineStore("cameraSettings", {
     },
     // This method only exists due to just how lazy I am and my dislike of consolidating the pipeline type enums (which mind you, suck as is)
     currentWebsocketPipelineType(): WebsocketPipelineType {
-      return this.currentPipelineType - 2;
+      return this.currentPipelineType - 3;
     },
     currentVideoFormat(): VideoFormat {
       return this.currentCameraSettings.validVideoFormats[this.currentPipelineSettings.cameraVideoModeIndex];

--- a/photon-client/src/types/PipelineTypes.ts
+++ b/photon-client/src/types/PipelineTypes.ts
@@ -1,13 +1,16 @@
 import type { WebsocketNumberPair } from "@/types/WebsocketDataTypes";
 import type { ObjectDetectionModelProperties } from "@/types/SettingTypes";
 
+/**
+ * The on-wire form of PipelineType.java (the enum is serialized with `ordinal()`)
+ */
 export enum PipelineType {
-  DriverMode = 1,
-  Reflective = 2,
-  ColoredShape = 3,
-  AprilTag = 4,
-  Aruco = 5,
-  ObjectDetection = 6
+  DriverMode = 2,
+  Reflective = 3,
+  ColoredShape = 4,
+  AprilTag = 5,
+  Aruco = 6,
+  ObjectDetection = 7
 }
 
 export enum AprilTagFamily {


### PR DESCRIPTION
## Description

#2180 added an additional value to PipelineType.java. Enums are serialized with `ordinal()`, and the frontend wasn't updated to account for this, causing an off-by-one error where the UI thought the pipeline was actually the next pipeline over. This resyncs the enum on the frontend to the backend and adjusts the mapping from PipelineType to WebsocketPipelineType to make everything match.

Fixes #2201.

closes #2202 

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] This PR has been [linted](https://docs.photonvision.org/en/latest/docs/contributing/linting.html).
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [x] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
