### PR TITLE
Use photon-image-runner to build images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,8 +449,7 @@ jobs:
   build-image:
     needs: [build-package]
 
-    # TODO: uncomment before merge
-    # if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' }}
 
     strategy:
       fail-fast: false
@@ -460,73 +459,61 @@ jobs:
             artifact-name: LinuxArm64
             image_suffix: RaspberryPi
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_raspi.img.xz
-            cpu: cortex-a7
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: limelight2
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight.img.xz
-            cpu: cortex-a7
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: limelight3
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight3.img.xz
-            cpu: cortex-a7
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: limelight3G
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight3g.img.xz
-            cpu: cortex-a7
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: limelight4
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight4.img.xz
-            cpu: cortex-a76
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: luma_p1
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_luma_p1.img.xz
-            cpu: cortex-a76
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: orangepi5
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5.img.xz
-            cpu: cortex-a8
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: orangepi5b
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5b.img.xz
-            cpu: cortex-a8
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: orangepi5plus
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5plus.img.xz
-            cpu: cortex-a8
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: orangepi5pro
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5pro.img.xz
-            cpu: cortex-a8
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: orangepi5max
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5max.img.xz
-            cpu: cortex-a8
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
             image_suffix: rock5c
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_rock5c.img.xz
-            cpu: cortex-a8
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64


### PR DESCRIPTION
## Description

This PR switches image building from `pguyot/arm-runner-action` to `PhotonVision/photon-image-runner`. The new runner uses native arm runners on GitHub and is much faster than the emulation used by the pguyot version.

Images from https://github.com/PhotonVision/photonvision/pull/2210/commits/a95914ca3612192f030b4b569840f17d87eb4380 tested and working on:

- [x] RaspberryPi4b
- [x] OrangePi5
- [x] OrangePi5pro
- [x] RubikPi3

Closes #2191

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2024.3.1
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
