### PR TITLE
Remove redundant photon-targeting JNI library load

### DIFF
--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -38,7 +38,6 @@ import org.photonvision.common.logging.Logger;
 import org.photonvision.common.logging.PvCSCoreLogger;
 import org.photonvision.common.networking.NetworkManager;
 import org.photonvision.common.util.TestUtils;
-import org.photonvision.jni.LibraryLoader;
 import org.photonvision.jni.RknnDetectorJNI;
 import org.photonvision.jni.RubikDetectorJNI;
 import org.photonvision.raspi.LibCameraJNILoader;
@@ -205,20 +204,7 @@ public class Main {
             logger.error("Failed to load native libraries!", e);
             System.exit(1);
         }
-        logger.info("WPI JNI libraries loaded.");
-
-        try {
-            boolean success = LibraryLoader.loadTargeting();
-
-            if (!success) {
-                logger.error("Failed to load native libraries! Giving up :(");
-                System.exit(1);
-            }
-        } catch (Exception e) {
-            logger.error("Failed to load photon-targeting JNI!", e);
-            System.exit(1);
-        }
-        logger.info("photon-targeting JNI libraries loaded.");
+        logger.info("WPILib and photon-targeting JNI libraries loaded.");
 
         if (!HAL.initialize(500, 0)) {
             logger.error("Failed to initialize the HAL! Giving up :(");


### PR DESCRIPTION
## Description

#2137 made it so `TestUtils.loadLibraries()` loads both WPILib and photon-targeting, which is used in Main.java to load libraries, but it left the separate photon-targeting load in Main. This removes the extra library load, since it's covered by `TestUtils.loadLibraries()`.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
