### PR TITLE
Consistently serialize neural network data

### DIFF
--- a/photon-client/src/components/settings/ObjectDetectionCard.vue
+++ b/photon-client/src/components/settings/ObjectDetectionCard.vue
@@ -86,7 +86,7 @@ const renameModel = async (model: ObjectDetectionModelProperties, newName: strin
   });
 
   axiosPost("/objectdetection/rename", "rename an object detection model", {
-    modelPath: model.modelPath.replace("file:", ""),
+    modelPath: model.modelPath,
     newName: newName
   });
   showRenameDialog.value.show = false;
@@ -418,7 +418,7 @@ const handleBulkImport = () => {
                 <a
                   ref="exportIndividualModel"
                   style="color: black; text-decoration: none; display: none"
-                  :href="`http://${address}/api/objectdetection/exportIndividual?modelPath=${showInfo.model.modelPath.replace('file:', '')}`"
+                  :href="`http://${address}/api/objectdetection/exportIndividual?modelPath=${showInfo.model.modelPath}`"
                   :download="`${showInfo.model.nickname}_${showInfo.model.family}_${showInfo.model.version}_${showInfo.model.resolutionWidth}x${showInfo.model.resolutionHeight}_${showInfo.model.labels.join('_')}.${showInfo.model.family.toLowerCase()}`"
                   target="_blank"
                 />

--- a/photon-core/src/main/java/org/photonvision/common/util/file/JacksonUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/util/file/JacksonUtils.java
@@ -17,15 +17,9 @@
 
 package org.photonvision.common.util.file;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
-import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -37,7 +31,6 @@ import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.jetty.io.EofException;
@@ -45,89 +38,41 @@ import org.eclipse.jetty.io.EofException;
 public class JacksonUtils {
     public static class UIMap extends HashMap<String, Object> {}
 
-    // Custom Path serializer that outputs just the path string without file:/ prefix
-    public static class PathSerializer extends JsonSerializer<Path> {
-        @Override
-        public void serialize(Path value, JsonGenerator gen, SerializerProvider serializers)
-                throws IOException {
-            if (value == null) {
-                gen.writeNull();
-            } else {
-                gen.writeString(value.toString());
-            }
-        }
-    }
-
-    // Custom Path deserializer that reads path strings
-    public static class PathDeserializer extends JsonDeserializer<Path> {
-        @Override
-        public Path deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            String pathString = p.getValueAsString();
-            if (pathString == null || pathString.isEmpty()) {
-                return null;
-            }
-
-            // Handle case where old serialized data might still have file:/ prefix
-            if (pathString.startsWith("file:/")) {
-                pathString = pathString.substring(6); // Remove "file:/" prefix
-            }
-
-            return Paths.get(pathString);
-        }
-    }
-
-    // Custom Path key deserializer for Maps with Path keys
-    public static class PathKeyDeserializer extends com.fasterxml.jackson.databind.KeyDeserializer {
-        @Override
-        public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
-            if (key == null || key.isEmpty()) {
-                return null;
-            }
-
-            // Handle case where old serialized data might still have file:/ prefix
-            if (key.startsWith("file:/")) {
-                key = key.substring(6); // Remove "file:/" prefix
-            }
-
-            return Paths.get(key);
-        }
-    }
-
-    // Helper method to create ObjectMapper with Path serialization support
-    private static ObjectMapper createObjectMapperWithPathSupport(Class<?> baseType) {
-        PolymorphicTypeValidator ptv =
-                BasicPolymorphicTypeValidator.builder().allowIfBaseType(baseType).build();
-
-        SimpleModule pathModule = new SimpleModule();
-        pathModule.addSerializer(Path.class, new PathSerializer());
-        pathModule.addDeserializer(Path.class, new PathDeserializer());
-        pathModule.addKeyDeserializer(Path.class, new PathKeyDeserializer());
-
-        return JsonMapper.builder()
-                .configure(JsonReadFeature.ALLOW_JAVA_COMMENTS, true)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT)
-                .addModule(pathModule)
-                .build();
-    }
-
     public static <T> void serialize(Path path, T object) throws IOException {
         serialize(path, object, true);
     }
 
     public static <T> String serializeToString(T object) throws IOException {
-        ObjectMapper objectMapper = createObjectMapperWithPathSupport(object.getClass());
+        PolymorphicTypeValidator ptv =
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(object.getClass()).build();
+        ObjectMapper objectMapper =
+                JsonMapper.builder()
+                        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT)
+                        .build();
         return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
     }
 
     public static <T> void serialize(Path path, T object, boolean forceSync) throws IOException {
-        ObjectMapper objectMapper = createObjectMapperWithPathSupport(object.getClass());
+        PolymorphicTypeValidator ptv =
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(object.getClass()).build();
+        ObjectMapper objectMapper =
+                JsonMapper.builder()
+                        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT)
+                        .build();
         String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
         saveJsonString(json, path, forceSync);
     }
 
     public static <T> T deserialize(Map<?, ?> s, Class<T> ref) throws IOException {
-        ObjectMapper objectMapper = createObjectMapperWithPathSupport(ref);
+        PolymorphicTypeValidator ptv =
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(ref).build();
+        ObjectMapper objectMapper =
+                JsonMapper.builder()
+                        .configure(JsonReadFeature.ALLOW_JAVA_COMMENTS, true)
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT)
+                        .build();
+
         return objectMapper.convertValue(s, ref);
     }
 
@@ -136,14 +81,28 @@ public class JacksonUtils {
             throw new EofException("Provided empty string for class " + ref.getName());
         }
 
-        ObjectMapper objectMapper = createObjectMapperWithPathSupport(ref);
-        objectMapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+        PolymorphicTypeValidator ptv =
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(ref).build();
+        ObjectMapper objectMapper =
+                JsonMapper.builder()
+                        .configure(JsonReadFeature.ALLOW_JAVA_COMMENTS, true)
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+                        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT)
+                        .build();
 
         return objectMapper.readValue(s, ref);
     }
 
     public static <T> T deserialize(Path path, Class<T> ref) throws IOException {
-        ObjectMapper objectMapper = createObjectMapperWithPathSupport(ref);
+        PolymorphicTypeValidator ptv =
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(ref).build();
+        ObjectMapper objectMapper =
+                JsonMapper.builder()
+                        .configure(JsonReadFeature.ALLOW_JAVA_COMMENTS, true)
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.JAVA_LANG_OBJECT)
+                        .build();
         File jsonFile = new File(path.toString());
         if (jsonFile.exists() && jsonFile.length() > 0) {
             return objectMapper.readValue(jsonFile, ref);
@@ -156,12 +115,6 @@ public class JacksonUtils {
         ObjectMapper objectMapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
         module.addDeserializer(ref, deserializer);
-
-        // Add Path support to custom deserializer case as well
-        module.addSerializer(Path.class, new PathSerializer());
-        module.addDeserializer(Path.class, new PathDeserializer());
-        module.addKeyDeserializer(Path.class, new PathKeyDeserializer());
-
         objectMapper.registerModule(module);
 
         File jsonFile = new File(path.toString());
@@ -182,12 +135,6 @@ public class JacksonUtils {
         ObjectMapper objectMapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
         module.addSerializer(ref, serializer);
-
-        // Add Path support to custom serializer case as well
-        module.addSerializer(Path.class, new PathSerializer());
-        module.addDeserializer(Path.class, new PathDeserializer());
-        module.addKeyDeserializer(Path.class, new PathKeyDeserializer());
-
         objectMapper.registerModule(module);
         String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
         saveJsonString(json, path, forceSync);

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -850,33 +850,30 @@ public class RequestHandler {
         }
     }
 
-    private record DeleteObjectDetectionModelRequest(String modelPath) {}
+    private record DeleteObjectDetectionModelRequest(Path modelPath) {}
 
     public static void onDeleteObjectDetectionModelRequest(Context ctx) {
         logger.info("Deleting object detection model");
-        Path modelPath;
 
         try {
             DeleteObjectDetectionModelRequest request =
                     JacksonUtils.deserialize(ctx.body(), DeleteObjectDetectionModelRequest.class);
 
-            modelPath = Path.of(request.modelPath.substring(7));
-
-            if (modelPath == null) {
+            if (request.modelPath == null) {
                 ctx.status(400);
                 ctx.result("The provided model path was malformed");
                 logger.error("The provided model path was malformed");
                 return;
             }
 
-            if (!modelPath.toFile().exists()) {
+            if (!request.modelPath.toFile().exists()) {
                 ctx.status(400);
                 ctx.result("The provided model path does not exist");
                 logger.error("The provided model path does not exist");
                 return;
             }
 
-            if (!modelPath.toFile().delete()) {
+            if (!request.modelPath.toFile().delete()) {
                 ctx.status(500);
                 ctx.result("Unable to delete the model file");
                 logger.error("Unable to delete the model file");
@@ -886,7 +883,7 @@ public class RequestHandler {
             if (!ConfigManager.getInstance()
                     .getConfig()
                     .neuralNetworkPropertyManager()
-                    .removeModel(modelPath)) {
+                    .removeModel(request.modelPath)) {
                 ctx.status(400);
                 ctx.result("The model's information was not found in the config");
                 logger.error("The model's information was not found in the config");
@@ -910,26 +907,24 @@ public class RequestHandler {
                                 UIPhotonConfiguration.programStateToUi(ConfigManager.getInstance().getConfig())));
     }
 
-    private record RenameObjectDetectionModelRequest(String modelPath, String newName) {}
+    private record RenameObjectDetectionModelRequest(Path modelPath, String newName) {}
 
     public static void onRenameObjectDetectionModelRequest(Context ctx) {
         try {
             RenameObjectDetectionModelRequest request =
                     JacksonUtils.deserialize(ctx.body(), RenameObjectDetectionModelRequest.class);
 
-            Path modelPath = Path.of(request.modelPath);
-
-            if (modelPath == null) {
+            if (request.modelPath == null) {
                 ctx.status(400);
                 ctx.result("The provided model path was malformed");
                 logger.error("The provided model path was malformed");
                 return;
             }
 
-            if (!modelPath.toFile().exists()) {
+            if (!request.modelPath.toFile().exists()) {
                 ctx.status(400);
                 ctx.result("The provided model path does not exist");
-                logger.error("The model path: " + modelPath + " does not exist");
+                logger.error("The model path: " + request.modelPath + " does not exist");
                 return;
             }
 
@@ -943,7 +938,7 @@ public class RequestHandler {
             if (!ConfigManager.getInstance()
                     .getConfig()
                     .neuralNetworkPropertyManager()
-                    .renameModel(modelPath, request.newName)) {
+                    .renameModel(request.modelPath, request.newName)) {
                 ctx.status(400);
                 ctx.result("The model's information was not found in the config");
                 logger.error("The model's information was not found in the config");


### PR DESCRIPTION
## Description

#1894 implemented custom serialization for Path handling that's used to serialize NN settings into the SQLite database, which just saved the raw Path and avoiding `file:` URIs. However, this causes a rift between what's sent to the client, and what's actually stored in the config because the custom serialization is only used for saving into the config. This wasn't an issue before, since at worst, there were some extra slashes, since the URI typically looked like `file:///etc/...`, but only `file:` was dropped on the client end and the extra slashes are just dropped when constructing a new Path object, but with the advent of Playwright testing, model paths can involve Windows paths, leaving paths like `//C:/path/...` which `Path.of` cannot decode. We _could_ just drop `file://` and that would likely work, but having this kind of inconsistent serde is concerning. So we're just going to use Jackson's standard path serialization for consistency, because it will handle it all seamlessly (and we don't have to convert Strings to Paths ourselves). This undoes the changes made to JacksonUtils in #1894.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
