### PR TITLE
Fix pipeline type when creating a new pipeline being off by one

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/DataSocketHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/DataSocketHandler.java
@@ -155,7 +155,7 @@ public class DataSocketHandler {
                             // var name = (String) data.get("pipelineName");
                             var arr = (ArrayList<Object>) entryValue;
                             var name = (String) arr.get(0);
-                            var type = PipelineType.values()[(Integer) arr.get(1) + 2];
+                            var type = PipelineType.values()[(Integer) arr.get(1) + 3];
 
                             dcService.publishEvent(
                                     new IncomingWebSocketEvent<>(


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

This cherry-picks the bug fix from #2225, but not the tests as we're having issues with those. #2225 will remain open for the tests.

https://github.com/PhotonVision/photonvision/pull/2204 fixed the off-by-one error on the frontend, but again, because enums are serialized with ordinal(), DataSocketHandler needed to be updated to account for the indices shifting by one.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] ~If this PR addresses a bug, a regression test for it is added~ Deferred 
