### PR TITLE
Scaffold a secondary apriltag detector using SIMD optimized umich detector

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/apriltag/AprilTagDetectorAdapter.java
+++ b/photon-core/src/main/java/org/photonvision/vision/apriltag/AprilTagDetectorAdapter.java
@@ -1,0 +1,15 @@
+package org.photonvision.vision.apriltag;
+
+import java.util.List;
+import org.photonvision.vision.opencv.CVMat;
+import org.photonvision.vision.pipe.impl.AprilTagDetectionPipe;
+import org.photonvision.vision.opencv.Releasable;
+import edu.wpi.first.apriltag.AprilTagDetection;
+
+public interface AprilTagDetectorAdapter extends Releasable {
+    AprilTagDetectorBackend getBackendType();
+
+    void setParams(AprilTagDetectionPipe.AprilTagDetectionPipeParams params);
+
+    List<AprilTagDetection> detect(CVMat in);
+}

--- a/photon-core/src/main/java/org/photonvision/vision/apriltag/AprilTagDetectorBackend.java
+++ b/photon-core/src/main/java/org/photonvision/vision/apriltag/AprilTagDetectorBackend.java
@@ -1,0 +1,6 @@
+package org.photonvision.vision.apriltag;
+
+public enum AprilTagDetectorBackend {
+    WPILIB,
+    OPTIMIZED_UMICH
+}

--- a/photon-core/src/main/java/org/photonvision/vision/apriltag/OptimizedAprilTagDetectorAdapter.java
+++ b/photon-core/src/main/java/org/photonvision/vision/apriltag/OptimizedAprilTagDetectorAdapter.java
@@ -1,0 +1,44 @@
+package org.photonvision.vision.apriltag;
+
+import edu.wpi.first.apriltag.AprilTagDetection;
+import java.util.List;
+import org.photonvision.common.logging.LogGroup;
+import org.photonvision.common.logging.Logger;
+import org.photonvision.vision.opencv.CVMat;
+import org.photonvision.vision.pipe.impl.AprilTagDetectionPipe;
+
+/**
+ * Placeholder for the optimized UMich-backed detector. Currently falls back to the WPILib detector
+ * while providing a drop-in slot for wiring the optimized JNI.
+ */
+public class OptimizedAprilTagDetectorAdapter implements AprilTagDetectorAdapter {
+    private static final Logger logger = new Logger(OptimizedAprilTagDetectorAdapter.class, LogGroup.VisionModule);
+
+    private final WpilibAprilTagDetectorAdapter fallback = new WpilibAprilTagDetectorAdapter();
+    private boolean warnedAboutFallback = false;
+
+    @Override
+    public AprilTagDetectorBackend getBackendType() {
+        return AprilTagDetectorBackend.OPTIMIZED_UMICH;
+    }
+
+    @Override
+    public void setParams(AprilTagDetectionPipe.AprilTagDetectionPipeParams newParams) {
+        // TODO: replace fallback with optimized detector configuration once JNI is available.
+        fallback.setParams(newParams);
+    }
+
+    @Override
+    public List<AprilTagDetection> detect(CVMat in) {
+        if (!warnedAboutFallback) {
+            logger.warn("Optimized AprilTag backend not yet wired to JNI; using WPILib fallback");
+            warnedAboutFallback = true;
+        }
+        return fallback.detect(in);
+    }
+
+    @Override
+    public void release() {
+        fallback.release();
+    }
+}

--- a/photon-core/src/main/java/org/photonvision/vision/apriltag/WpilibAprilTagDetectorAdapter.java
+++ b/photon-core/src/main/java/org/photonvision/vision/apriltag/WpilibAprilTagDetectorAdapter.java
@@ -1,0 +1,40 @@
+package org.photonvision.vision.apriltag;
+
+import edu.wpi.first.apriltag.AprilTagDetection;
+import edu.wpi.first.apriltag.AprilTagDetector;
+import java.util.List;
+import org.photonvision.vision.opencv.CVMat;
+import org.photonvision.vision.pipe.impl.AprilTagDetectionPipe;
+
+public class WpilibAprilTagDetectorAdapter implements AprilTagDetectorAdapter {
+    private AprilTagDetector detector = new AprilTagDetector();
+
+    @Override
+    public AprilTagDetectorBackend getBackendType() {
+        return AprilTagDetectorBackend.WPILIB;
+    }
+
+    @Override
+    public void setParams(AprilTagDetectionPipe.AprilTagDetectionPipeParams newParams) {
+        detector.setConfig(newParams.detectorParams());
+        detector.setQuadThresholdParameters(newParams.quadParams());
+
+        detector.clearFamilies();
+        detector.addFamily(newParams.family().getNativeName());
+    }
+
+    @Override
+    public List<AprilTagDetection> detect(CVMat in) {
+        var ret = detector.detect(in.getMat());
+        if (ret == null) {
+            return List.of();
+        }
+        return List.of(ret);
+    }
+
+    @Override
+    public void release() {
+        detector.close();
+        detector = null;
+    }
+}

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipeline.java
@@ -101,7 +101,7 @@ public class AprilTagPipeline extends CVPipeline<CVPipelineResult, AprilTagPipel
         quadParams.deglitch = false;
 
         aprilTagDetectionPipe.setParams(
-                new AprilTagDetectionPipeParams(settings.tagFamily, config, quadParams));
+                new AprilTagDetectionPipeParams(settings.tagFamily, config, quadParams, settings.detectorBackend));
 
         if (frameStaticProperties.cameraCalibration != null) {
             var cameraMatrix = frameStaticProperties.cameraCalibration.getCameraIntrinsicsMat();

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipelineSettings.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/AprilTagPipelineSettings.java
@@ -18,12 +18,14 @@
 package org.photonvision.vision.pipeline;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.photonvision.vision.apriltag.AprilTagDetectorBackend;
 import org.photonvision.vision.apriltag.AprilTagFamily;
 import org.photonvision.vision.target.TargetModel;
 
 @JsonTypeName("AprilTagPipelineSettings")
 public class AprilTagPipelineSettings extends AdvancedPipelineSettings {
     public AprilTagFamily tagFamily = AprilTagFamily.kTag36h11;
+    public AprilTagDetectorBackend detectorBackend = AprilTagDetectorBackend.WPILIB;
     public int decimate = 1;
     public double blur = 0;
     public int threads = 4; // Multiple threads seems to be better performance on most platforms
@@ -52,6 +54,7 @@ public class AprilTagPipelineSettings extends AdvancedPipelineSettings {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ((tagFamily == null) ? 0 : tagFamily.hashCode());
+        result = prime * result + ((detectorBackend == null) ? 0 : detectorBackend.hashCode());
         result = prime * result + decimate;
         long temp;
         temp = Double.doubleToLongBits(blur);
@@ -74,6 +77,7 @@ public class AprilTagPipelineSettings extends AdvancedPipelineSettings {
         if (getClass() != obj.getClass()) return false;
         AprilTagPipelineSettings other = (AprilTagPipelineSettings) obj;
         if (tagFamily != other.tagFamily) return false;
+        if (detectorBackend != other.detectorBackend) return false;
         if (decimate != other.decimate) return false;
         if (Double.doubleToLongBits(blur) != Double.doubleToLongBits(other.blur)) return false;
         if (threads != other.threads) return false;


### PR DESCRIPTION
## Description

Adds a selectable apriltag pipeline with a hook for an alternate SIMD accelerated apriltag detector (to be upstreamed to wpilib). Currently the backend falls back to the wpilib backend, since the SIMD specific detector needs to be built on a platform specific basis. 

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
