### PR TITLE
Remove snapshot from vendordep

### DIFF
--- a/photon-lib/src/generate/photonlib.json.in
+++ b/photon-lib/src/generate/photonlib.json.in
@@ -5,8 +5,7 @@
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
   "frcYear": "${frc_year}",
   "mavenUrls": [
-    "https://maven.photonvision.org/repository/internal",
-    "https://maven.photonvision.org/repository/snapshots"
+    "https://maven.photonvision.org/repository/internal"
   ],
   "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/photonlib-json/1.0/photonlib-json-1.0.json",
   "jniDependencies": [


### PR DESCRIPTION
## Description

Pursuant to https://github.com/wpilibsuite/vendor-json-repo/pull/193#issuecomment-3647261870, I'm removing the snapshot repo from the vendordep. photonlib doesn't seem to pull from anything in there, so I believe this shouldn't be an issue.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
