### PR TITLE
Check if returned NetworkInterface is null before attempting to get MAC address

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -260,11 +260,14 @@ public class NetworkUtils {
                     }
                 }
             } else { // Managed? We should have a working interface available
-                byte[] mac = NetworkInterface.getByName(config.networkManagerIface).getHardwareAddress();
-                if (mac != null) {
-                    return formatMacAddress(mac);
-                } else {
-                    logger.error("No MAC address found for " + config.networkManagerIface);
+                var iface = NetworkInterface.getByName(config.networkManagerIface);
+                if (iface != null) {
+                    byte[] mac = iface.getHardwareAddress();
+                    if (mac != null) {
+                        return formatMacAddress(mac);
+                    } else {
+                        logger.error("No MAC address found for " + config.networkManagerIface);
+                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Description

On boot, the interface might not be fully configured yet, and the returned NetworkInterface will be null. This would cause an NPE to be thrown when attempting to get the MAC address from the interface. This checks if the interface is null and silently returns an empty string if it is, which is okay if the networking is being managed because if that interface is broken, there's bigger problems. Fixes #2244.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
