### PR TITLE
Add JNI libraries to smoketests

### DIFF
--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -209,8 +209,10 @@ public class Main {
             System.exit(1);
         }
 
+        // We load these in the case of a smoketest to ensure that the libraries exist, and can be
+        // loaded properly.
         try {
-            if (Platform.isRaspberryPi()) {
+            if (Platform.isRaspberryPi() || isSmoketest) {
                 LoadJNI.forceLoad(LoadJNI.JNITypes.LIBCAMERA);
                 logger.info("Loaded libcamera-JNI");
             }
@@ -218,7 +220,7 @@ public class Main {
             logger.error("Failed to load libcamera-JNI!", e);
         }
         try {
-            if (Platform.isRK3588()) {
+            if (Platform.isRK3588() || isSmoketest) {
                 LoadJNI.forceLoad(LoadJNI.JNITypes.RKNN_DETECTOR);
                 logger.info("Loaded RKNN-JNI");
             } else {
@@ -228,7 +230,7 @@ public class Main {
             logger.error("Failed to load RKNN-JNI!", e);
         }
         try {
-            if (Platform.isQCS6490()) {
+            if (Platform.isQCS6490() || isSmoketest) {
                 LoadJNI.forceLoad(LoadJNI.JNITypes.RUBIK_DETECTOR);
                 logger.info("Loaded Rubik-JNI");
             } else {


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

Our previous smoketests would not load any of our JNI libraries, as they are locked behind platform specific checks. This PR tries to load JNI libraries if the jar is being run with the `--smoketest` argument.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
