### PR TITLE
[ci] Pin upload-artifact action to specific SHA hash instead of HEAD

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,7 +50,7 @@ jobs:
             mypy --show-column-numbers --config-file photon-lib/py/pyproject.toml photon-lib
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: dist
           path: ./photon-lib/py/dist/


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->
Pins the `upload-artifact` action to a specific SHA1 hash instead of pulling the latest commit off of `master`. This addresses [some](https://nesbitt.io/2025/12/06/github-actions-package-manager.html) but [not all](https://www.paloaltonetworks.com/blog/cloud-security/unpinnable-actions-github-security/) issues with blindly pulling an action from a branch and assuming it's safe.
<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
