### PR TITLE
Use WPILib Artifactory mirror instead of Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
 allprojects {
     repositories {
         maven { url = "https://frcmaven.wpi.edu/artifactory/ex-mvn/" }
+        mavenCentral()
         mavenLocal()
         maven { url = "https://maven.photonvision.org/releases" }
         maven { url = "https://maven.photonvision.org/snapshots" }

--- a/photonlib-cpp-examples/build.gradle
+++ b/photonlib-cpp-examples/build.gradle
@@ -5,6 +5,7 @@ plugins {
 allprojects {
     repositories {
         maven { url = "https://frcmaven.wpi.edu/artifactory/ex-mvn/" }
+        mavenCentral()
         mavenLocal()
         maven { url = "https://maven.photonvision.org/releases" }
     }

--- a/photonlib-java-examples/build.gradle
+++ b/photonlib-java-examples/build.gradle
@@ -5,6 +5,7 @@ plugins {
 allprojects {
     repositories {
         maven { url = "https://frcmaven.wpi.edu/artifactory/ex-mvn/" }
+        mavenCentral()
         mavenLocal()
         maven { url = "https://maven.photonvision.org/releases" }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         maven { url = "https://frcmaven.wpi.edu/artifactory/ex-mvn/" }
+        mavenCentral()
         gradlePluginPortal()
         maven {
             url = uri('https://maven.photonvision.org/releases')


### PR DESCRIPTION
## Description

By hitting WPIlib's Artifactory Maven Central mirror instead of Maven Central, we should reduce the number of 403 flakes we see during workflow runs. This also removes jogamp from the repository list, as jogamp dependencies were removed in #1926.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
