### PR TITLE
Bump IMAGE_VERSION to v2026.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_VERSION: v2026.1.0
+  IMAGE_VERSION: v2026.1.1
 
 jobs:
 


### PR DESCRIPTION
Pulls in the diff from https://github.com/PhotonVision/photon-image-modifier/releases/tag/v2026.1.1 :

- Stop mounting partition 1 as /boot by @crschardt in https://github.com/PhotonVision/photon-image-modifier/pull/120
- Fix incorrect video mode on Luma P1 by @crschardt in https://github.com/PhotonVision/photon-image-modifier/pull/122