### PR TITLE
fix: simplify version regex and fix rc tag handling

### DIFF
--- a/photon-lib/py/setup.py
+++ b/photon-lib/py/setup.py
@@ -4,15 +4,13 @@ import subprocess
 from setuptools import find_packages, setup
 
 gitDescribeResult = (
-    subprocess.check_output(
-        ["git", "describe", "--tags", "--match=v*", "--exclude=*rc*", "--always"]
-    )
+    subprocess.check_output(["git", "describe", "--tags", "--match=v*", "--always"])
     .decode("utf-8")
     .strip()
 )
 
 m = re.search(
-    r"(v[0-9]{4}\.[0-9]{1}\.[0-9]{1})-?((?:beta)?(?:alpha)?)-?([0-9\.]*)",
+    r"v([0-9]{4}\.[0-9]{1}\.[0-9]{1})-?((?:beta|alpha|rc)?)-?([0-9\.]*)",
     gitDescribeResult,
 )
 
@@ -26,7 +24,7 @@ if m:
         prefix = m.group(1)
         maturity = m.group(2)
         suffix = m.group(3).replace(".", "")
-        versionString = f"{prefix}.{maturity}.{suffix}"
+        versionString = f"{prefix}{maturity}{suffix}"
     else:
         split = gitDescribeResult.split("-")
         if len(split) == 3:
@@ -35,8 +33,7 @@ if m:
             versionString = f"{year[1:]}post{commits}"
             print("using dev release " + versionString)
         else:
-            year = gitDescribeResult
-            versionString = year[1:]
+            versionString = gitDescribeResult[1:]
             print("using full release " + versionString)
 
 


### PR DESCRIPTION
## Description

The hand-rolled version generation was ignoring RC tags. When removing the RC tag filter, it broke:

```pytb
$ python setup.py sdist
using dev release 2026.1.1postrc
Building version 2026.1.1postrc
Traceback (most recent call last):
  [snip]
  File "/usr/lib/python3.13/site-packages/setuptools/dist.py", line 294, in __init__
    self.metadata.version = self._normalize_version(self.metadata.version)
                            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/setuptools/dist.py", line 330, in _normalize_version
    normalized = str(Version(version))
                     ~~~~~~~^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/packaging/version.py", line 202, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
packaging.version.InvalidVersion: Invalid version: '2026.1.1postrc'
```

This fixes that, and simplifies the regex slightly so it's clearer what on earth is happening. Some surrounding code to handle PEP 440 versioning is also cleaned up to squash a warning we get otherwise for RCs:

```
/usr/lib/python3.13/site-packages/setuptools/dist.py:294: InformationOnly: Normalizing '2026.1.1.rc.2' to '2026.1.1rc2'
```

Amp-Thread-ID: https://ampcode.com/threads/T-019bb77f-d3b6-7618-b511-4109f328102f

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
