### PR TITLE
Rknn numpy fix

### DIFF
--- a/scripts/rknn_conversion.ipynb
+++ b/scripts/rknn_conversion.ipynb
@@ -50,7 +50,7 @@
    "execution_count": null,
    "source": [
     "%pip uninstall numpy -y\n",
-    "%pip install \"numpy>=1.23.0,<2.0.0\""
+    "%pip install \"numpy==1.26.4\""
    ],
    "id": "7156e69495f48f49"
   },


### PR DESCRIPTION
## Description

Due to Rockchip dependencies not being locked to a specific version, it installs the incorrect version of Numpy, causing the conversion to fail. This PR locks the version of Numpy to 1.26.4 as this is the highest known working version

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
