### PR TITLE
Downgrade and pin numpy to 2.3.5

### DIFF
--- a/photon-lib/py/setup.py
+++ b/photon-lib/py/setup.py
@@ -57,7 +57,7 @@ setup(
     package_data={"photonlibpy": ["py.typed"]},
     version=versionString,
     install_requires=[
-        "numpy~=2.4",
+        "numpy==2.3.5",
         "wpilib==2026.1.1",
         "robotpy-wpimath==2026.1.1",
         "robotpy-apriltag==2026.1.1",


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

Pursuant to #2300

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
