### PR TITLE
Allow configuring maximum target count

### DIFF
--- a/photon-client/src/components/dashboard/tabs/OutputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/OutputTab.vue
@@ -3,6 +3,7 @@ import PvSelect from "@/components/common/pv-select.vue";
 import { useCameraSettingsStore } from "@/stores/settings/CameraSettingsStore";
 import { type ActivePipelineSettings, PipelineType, RobotOffsetPointMode } from "@/types/PipelineTypes";
 import PvSwitch from "@/components/common/pv-switch.vue";
+import PvSlider from "@/components/common/pv-slider.vue";
 import { computed } from "vue";
 import { RobotOffsetType } from "@/types/SettingTypes";
 import { useStateStore } from "@/stores/StateStore";
@@ -61,11 +62,24 @@ const interactiveCols = computed(() =>
     <pv-switch
       v-model="useCameraSettingsStore().currentPipelineSettings.outputShowMultipleTargets"
       label="Show Multiple Targets"
-      tooltip="If enabled, up to five targets will be displayed and sent via PhotonLib, instead of just one"
+      tooltip="If enabled, a configurable number of targets will be displayed and sent via PhotonLib, instead of just one"
       :disabled="isTagPipeline"
       :switch-cols="interactiveCols"
       @update:modelValue="
         (value) => useCameraSettingsStore().changeCurrentPipelineSetting({ outputShowMultipleTargets: value }, false)
+      "
+    />
+    <pv-slider
+      v-model="useCameraSettingsStore().currentPipelineSettings.outputMaximumTargets"
+      label="Maximum Targets"
+      tooltip="The maximum number of targets to display and send. Set to 0 for no limit."
+      :disabled="isTagPipeline || !currentPipelineSettings.outputShowMultipleTargets"
+      :min="0"
+      :max="200"
+      :step="1"
+      :switch-cols="interactiveCols"
+      @update:modelValue="
+        (value) => useCameraSettingsStore().changeCurrentPipelineSetting({ outputMaximumTargets: value }, false)
       "
     />
     <pv-switch

--- a/photon-client/src/types/PipelineTypes.ts
+++ b/photon-client/src/types/PipelineTypes.ts
@@ -67,6 +67,7 @@ export interface PipelineSettings {
   ledMode: boolean;
   hueInverted: boolean;
   outputShowMultipleTargets: boolean;
+  outputMaximumTargets: number;
   contourSortMode: number;
   cameraExposureRaw: number;
   cameraMinExposureRaw: number;
@@ -137,6 +138,7 @@ export const DefaultPipelineSettings: Omit<
   offsetDualPointB: { x: 0, y: 0 },
   hsvHue: { first: 50, second: 180 },
   hueInverted: false,
+  outputMaximumTargets: 10,
   contourSortMode: 0,
   offsetSinglePoint: { x: 0, y: 0 },
   cameraBrightness: 50,

--- a/photon-core/src/main/java/org/photonvision/vision/pipe/impl/SortContoursPipe.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipe/impl/SortContoursPipe.java
@@ -47,6 +47,11 @@ public class SortContoursPipe
             }
         }
 
+        // If max targets is set to 0, return all contours
+        if (params.maxTargets() == 0) {
+            return m_sortedContours;
+        }
+
         return new ArrayList<>(m_sortedContours.subList(0, Math.min(in.size(), params.maxTargets())));
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/AdvancedPipelineSettings.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/AdvancedPipelineSettings.java
@@ -42,6 +42,7 @@ public class AdvancedPipelineSettings extends CVPipelineSettings {
 
     public boolean outputShouldDraw = true;
     public boolean outputShowMultipleTargets = false;
+    public int outputMaximumTargets = 10;
 
     public DoubleCouple contourArea = new DoubleCouple(0.0, 100.0);
     public DoubleCouple contourRatio = new DoubleCouple(0.0, 20.0);
@@ -98,6 +99,7 @@ public class AdvancedPipelineSettings extends CVPipelineSettings {
         AdvancedPipelineSettings that = (AdvancedPipelineSettings) o;
         return outputShouldDraw == that.outputShouldDraw
                 && outputShowMultipleTargets == that.outputShowMultipleTargets
+                && outputMaximumTargets == that.outputMaximumTargets
                 && contourSpecklePercentage == that.contourSpecklePercentage
                 && Double.compare(that.offsetDualPointAArea, offsetDualPointAArea) == 0
                 && Double.compare(that.offsetDualPointBArea, offsetDualPointBArea) == 0
@@ -137,6 +139,7 @@ public class AdvancedPipelineSettings extends CVPipelineSettings {
                 hueInverted,
                 outputShouldDraw,
                 outputShowMultipleTargets,
+                outputMaximumTargets,
                 contourArea,
                 contourRatio,
                 contourFullness,

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/CVPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/CVPipeline.java
@@ -26,8 +26,6 @@ import org.photonvision.vision.pipeline.result.CVPipelineResult;
 
 public abstract class CVPipeline<R extends CVPipelineResult, S extends CVPipelineSettings>
         implements Releasable {
-    static final int MAX_MULTI_TARGET_RESULTS = 10;
-
     protected S settings;
     protected FrameStaticProperties frameStaticProperties;
     protected QuirkyCamera cameraQuirks;

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/ColoredShapePipeline.java
@@ -103,7 +103,7 @@ public class ColoredShapePipeline
                 new SortContoursPipe.SortContoursParams(
                         settings.contourSortMode,
                         settings.outputShowMultipleTargets
-                                ? MAX_MULTI_TARGET_RESULTS // TODO don't hardcode?
+                                ? settings.outputMaximumTargets
                                 : 1,
                         frameStaticProperties));
 

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/ObjectDetectionPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/ObjectDetectionPipeline.java
@@ -83,7 +83,7 @@ public class ObjectDetectionPipeline
         sortContoursPipe.setParams(
                 new SortContoursPipe.SortContoursParams(
                         settings.contourSortMode,
-                        settings.outputShowMultipleTargets ? MAX_MULTI_TARGET_RESULTS : 1,
+                settings.outputShowMultipleTargets ? settings.outputMaximumTargets : 1,
                         frameStaticProperties));
 
         filterContoursPipe.setParams(

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/ReflectivePipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/ReflectivePipeline.java
@@ -86,7 +86,7 @@ public class ReflectivePipeline extends CVPipeline<CVPipelineResult, ReflectiveP
         sortContoursPipe.setParams(
                 new SortContoursPipe.SortContoursParams(
                         settings.contourSortMode,
-                        settings.outputShowMultipleTargets ? MAX_MULTI_TARGET_RESULTS : 1,
+                        settings.outputShowMultipleTargets ? settings.outputMaximumTargets : 1,
                         frameStaticProperties));
 
         collect2dTargetsPipe.setParams(


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

We wanted to track more than 10 objects in an Object Detection pipeline, so we added a "Maximum Targets" setting for when "Show Multiple Targets" is enabled. The default value is 10, so no existing configuration should change, though a "Show multiple targets" setting is redundant in theory.

None of the documentation mentioned this 10-object limit, so nothing there changed for now.

<img width="1223" height="282" alt="image" src="https://github.com/user-attachments/assets/48ef12f3-a2e1-4a6b-b6da-1a4d1bff1be2" />

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [x] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [x] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [x] If this PR addresses a bug, a regression test for it is added
