### PR TITLE
Enable NM 1.52 link-local fallback resolution

### DIFF
--- a/docs/source/docs/quick-start/networking.md
+++ b/docs/source/docs/quick-start/networking.md
@@ -2,10 +2,6 @@
 
 ## Physical Networking
 
-:::{warning}
-When using PhotonVision off robot, you _MUST_ plug the coprocessor into a physical router/radio. You can then connect your laptop/device used to view the webdashboard to the same network. Any other networking setup will not work and will not be supported in any capacity.
-:::
-
 ::::{tab-set}
 
 :::{tab-item} New Radio (2025 - present)
@@ -38,6 +34,29 @@ Rename each device from the default "photonvision" to a unique hostname (e.g., "
 ```{image} images/editHostname.png
 :alt: The hostname can be edited in the settings page under the network section.
 ```
+
+## Test Networking
+
+By default, PhotonVision will attempt to obtain an IP address from a router through DHCP, and fall back to a self-assigned link-local address if that fails. With either of these methods, it is best to access the PhotonVision web dashboard through its hostname and port (`photonvision.local:5800` by default) since its IP address is not known ahead of time. (An mDNS resolver is required to use `.local` hostnames, often installed by default.)
+
+::::{tab-set}
+
+:::{tab-item} DHCP (Router)
+
+If PhotonVision is connected to a DHCP server such as a router, it will obtain a dynamic IP address assignment (like “192.168.0.101” or “10.TE.AM.200”). If a DHCP server (router) is not found on the network, it falls back to a link-local address. Nearly all host computers will support a DHCP network without extra thought, as long as an incompatible static IP address was not configured on the host computer.
+
+:::
+
+:::{tab-item} Link-Local (Direct)
+
+If PhotonVision is directly wired to the host computer, a randomly-generated link-local IP address (like “169.254.36.176”) will be self-assigned. This requires the host computer to also self-assign a link-local address for communication to be established. Many host computers do this by default, although sometimes additional configuration or installations are required to enable the link-local service.
+
+:::
+::::
+
+:::{warning}
+Both DHCP and link-local address assignment are disabled if PhotonVision is configured with a static IP address, which may make your camera inaccessible on a test network.
+:::
 
 ## Robot Networking
 

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkingCommands.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkingCommands.java
@@ -41,6 +41,7 @@ public class NetworkingCommands {
         autoconnect yes
         ipv4.method auto
         ipv6.method disabled
+        ipv4.link-local fallback
         """.replaceAll("[\\n]", " ");
 }
 //spotless:on

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkingCommands.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkingCommands.java
@@ -40,7 +40,7 @@ public class NetworkingCommands {
         nmcli connection modify "${connection}"
         autoconnect yes
         ipv4.method auto
-        ipv6.method disabled
+        ipv6.method link-local
         ipv4.link-local fallback
         """.replaceAll("[\\n]", " ");
 }

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkingCommands.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkingCommands.java
@@ -40,8 +40,9 @@ public class NetworkingCommands {
         nmcli connection modify "${connection}"
         autoconnect yes
         ipv4.method auto
-        ipv6.method link-local
         ipv4.link-local fallback
+        ipv4.dhcp-timeout infinity
+        ipv6.method disabled
         """.replaceAll("[\\n]", " ");
 }
 //spotless:on


### PR DESCRIPTION
## Description

This enables link-local as a fallback to DHCP address resolution, using the new features of NetworkManager 1.52. Debian 13 (Trixie) and Ubuntu 26.04 (Resolute) introduce the required updates to NetworkManager for this to work. Unlike #1550, this continues to timeout and retry DHCP while holding a link-local address, which should avoid breaking compatibility with DHCP servers that don't respond immediately.

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

Closes #1813, blocked on updating the images to have NM 1.52 or later.

## Meta

Merge checklist:
- [X] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [X] The description documents the _what_ and _why_
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
