### PR TITLE
Fixes to point conversion

### DIFF
--- a/photon-lib/src/main/native/cpp/photon/simulation/PhotonCameraSim.cpp
+++ b/photon-lib/src/main/native/cpp/photon/simulation/PhotonCameraSim.cpp
@@ -187,7 +187,7 @@ PhotonPipelineResult PhotonCameraSim::Process(
                      imagePoints[b].y - imagePoints[t].y},
           units::radian_t{-angles[r]}.convert<units::degrees>().to<float>()};
       std::vector<cv::Point2f> points{};
-      rect.points(points);
+      rect.points(points.data());
 
       // Can't find an easier way to convert from Point2f to Point2d
       imagePoints.clear();
@@ -203,7 +203,7 @@ PhotonPipelineResult PhotonCameraSim::Process(
         OpenCVHelp::GetMinAreaRect(noisyTargetCorners);
     std::vector<cv::Point2f> minAreaRectPts;
     minAreaRectPts.reserve(4);
-    minAreaRect.points(minAreaRectPts);
+    minAreaRect.points(minAreaRectPts.data());
     cv::Point2d centerPt = minAreaRect.center;
     frc::Rotation3d centerRot = prop.GetPixelRot(centerPt);
     double areaPercent = prop.GetContourAreaPercent(noisyTargetCorners);


### PR DESCRIPTION
## Description

While building this with GCC 13.3.0 using a process other than the normal gradle process (for a pet project) I received a new error that the api usage of these Point2d conversions were incorrect. Looking closer at it, it looks like it meant to use the raw data pointer of the vectors.

I'm uncertain exactly how one would test this, as I'm not super familiar with the internals - but this is what I think the source should be.
