### PR TITLE
Check POST request status before displaying success

### DIFF
--- a/photon-client/src/components/settings/DeviceCard.vue
+++ b/photon-client/src/components/settings/DeviceCard.vue
@@ -13,13 +13,15 @@ import { metricsHistorySnapshot } from "@/stores/settings/GeneralSettingsStore";
 
 const theme = useTheme();
 
-const restartProgram = () => {
-  axiosPost("/utils/restartProgram", "restart PhotonVision");
-  forceReloadPage();
+const restartProgram = async () => {
+  if (await axiosPost("/utils/restartProgram", "restart PhotonVision")) {
+    forceReloadPage();
+  }
 };
-const restartDevice = () => {
-  axiosPost("/utils/restartDevice", "restart the device");
-  forceReloadPage();
+const restartDevice = async () => {
+  if (await axiosPost("/utils/restartDevice", "restart the device")) {
+    forceReloadPage();
+  }
 };
 
 const address = inject<string>("backendHost");
@@ -38,28 +40,30 @@ const handleOfflineUpdate = async () => {
     color: "secondary",
     timeout: -1
   });
-  await axiosPost("/utils/offlineUpdate", "upload new software", formData, {
-    headers: { "Content-Type": "multipart/form-data" },
-    onUploadProgress: ({ progress }) => {
-      const uploadPercentage = (progress || 0) * 100.0;
-      if (uploadPercentage < 99.5) {
-        useStateStore().showSnackbarMessage({
-          message: "New Software Upload in Progress",
-          color: "secondary",
-          timeout: -1,
-          progressBar: uploadPercentage,
-          progressBarColor: "primary"
-        });
-      } else {
-        useStateStore().showSnackbarMessage({
-          message: "Installing uploaded software...",
-          color: "secondary",
-          timeout: -1
-        });
+  if (
+    await axiosPost("/utils/offlineUpdate", "upload new software", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+      onUploadProgress: ({ progress }) => {
+        const uploadPercentage = (progress || 0) * 100.0;
+        if (uploadPercentage < 99.5) {
+          useStateStore().showSnackbarMessage({
+            message: "New Software Upload in Progress",
+            color: "secondary",
+            timeout: -1,
+            progressBar: uploadPercentage,
+            progressBarColor: "primary"
+          });
+        }
       }
-    }
-  });
-  forceReloadPage();
+    })
+  ) {
+    useStateStore().showSnackbarMessage({
+      message: "Installing uploaded software...",
+      color: "secondary",
+      timeout: -1
+    });
+    forceReloadPage();
+  }
 };
 
 const exportLogFile = ref();
@@ -116,9 +120,10 @@ const handleSettingsImport = () => {
 };
 
 const showFactoryReset = ref(false);
-const nukePhotonConfigDirectory = () => {
-  axiosPost("/utils/nukeConfigDirectory", "delete the config directory");
-  forceReloadPage();
+const nukePhotonConfigDirectory = async () => {
+  if (await axiosPost("/utils/nukeConfigDirectory", "delete the config directory")) {
+    forceReloadPage();
+  }
 };
 
 interface MetricItem {

--- a/photon-client/src/components/settings/ObjectDetectionCard.vue
+++ b/photon-client/src/components/settings/ObjectDetectionCard.vue
@@ -26,7 +26,7 @@ const importWidth = ref<number | null>(null);
 const importVersion = ref<string | null>(null);
 
 // TODO gray out the button when model is uploading
-const handleImport = () => {
+const handleImport = async () => {
   if (importModelFile.value === null) return;
 
   const formData = new FormData();
@@ -43,25 +43,27 @@ const handleImport = () => {
     timeout: -1
   });
 
-  axiosPost("/objectdetection/import", "import an object detection model", formData, {
-    headers: { "Content-Type": "multipart/form-data" },
-    onUploadProgress: ({ progress }) => {
-      const uploadPercentage = (progress || 0) * 100.0;
-      if (uploadPercentage < 99.5) {
-        useStateStore().showSnackbarMessage({
-          message: "Object Detection Model Upload in Process, " + uploadPercentage.toFixed(2) + "% complete",
-          color: "secondary",
-          timeout: -1
-        });
-      } else {
-        useStateStore().showSnackbarMessage({
-          message: "Processing uploaded Object Detection Model...",
-          color: "secondary",
-          timeout: -1
-        });
+  if (
+    await axiosPost("/objectdetection/import", "import an object detection model", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+      onUploadProgress: ({ progress }) => {
+        const uploadPercentage = (progress || 0) * 100.0;
+        if (uploadPercentage < 99.5) {
+          useStateStore().showSnackbarMessage({
+            message: "Object Detection Model Upload in Process, " + uploadPercentage.toFixed(2) + "% complete",
+            color: "secondary",
+            timeout: -1
+          });
+        }
       }
-    }
-  });
+    })
+  ) {
+    useStateStore().showSnackbarMessage({
+      message: "Processing uploaded Object Detection Model...",
+      color: "secondary",
+      timeout: -1
+    });
+  }
 
   showImportDialog.value = false;
 
@@ -121,33 +123,35 @@ const nukeModels = () => {
 
 const showBulkImportDialog = ref(false);
 const importFile = ref<File | null>(null);
-const handleBulkImport = () => {
+const handleBulkImport = async () => {
   if (importFile.value === null) return;
 
   const formData = new FormData();
   formData.append("data", importFile.value);
 
-  axiosPost("/objectdetection/bulkimport", "import object detection models", formData, {
-    headers: { "Content-Type": "multipart/form-data" },
-    onUploadProgress: ({ progress }) => {
-      const uploadPercentage = (progress || 0) * 100.0;
-      if (uploadPercentage < 99.5) {
-        useStateStore().showSnackbarMessage({
-          message: "Object Detection Models Upload in Progress",
-          color: "secondary",
-          timeout: -1,
-          progressBar: uploadPercentage,
-          progressBarColor: "primary"
-        });
-      } else {
-        useStateStore().showSnackbarMessage({
-          message: "Importing New Object Detection Models...",
-          color: "secondary",
-          timeout: -1
-        });
+  if (
+    await axiosPost("/objectdetection/bulkimport", "import object detection models", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+      onUploadProgress: ({ progress }) => {
+        const uploadPercentage = (progress || 0) * 100.0;
+        if (uploadPercentage < 99.5) {
+          useStateStore().showSnackbarMessage({
+            message: "Object Detection Models Upload in Progress",
+            color: "secondary",
+            timeout: -1,
+            progressBar: uploadPercentage,
+            progressBarColor: "primary"
+          });
+        }
       }
-    }
-  });
+    })
+  ) {
+    useStateStore().showSnackbarMessage({
+      message: "Importing New Object Detection Models...",
+      color: "secondary",
+      timeout: -1
+    });
+  }
   showImportDialog.value = false;
   importFile.value = null;
 };

--- a/photon-client/src/lib/PhotonUtils.ts
+++ b/photon-client/src/lib/PhotonUtils.ts
@@ -71,33 +71,33 @@ export const parseJsonFile = async <T extends Record<string, any>>(file: File): 
  * @param description A brief description of the request for users, e.g., "import object detection models".
  * @param data Payload to be sent in the POST request
  * @param config Optional axios request configuration
- * @returns A promise that resolves when the POST request is complete
+ * @returns A promise that resolves to true if the POST request is successful, or false if an error occurs.
  */
-export const axiosPost = (url: string, description: string, data?: any, config?: any): Promise<void> => {
-  return axios
-    .post(url, data, config)
-    .then(() => {
-      useStateStore().showSnackbarMessage({
-        message: "Successfully dispatched the request to " + description + ". Waiting for backend to respond",
-        color: "success"
-      });
-    })
-    .catch((error) => {
-      if (error.response) {
-        useStateStore().showSnackbarMessage({
-          message: "The backend is unable to fulfill the request to " + description + ".",
-          color: "error"
-        });
-      } else if (error.request) {
-        useStateStore().showSnackbarMessage({
-          message: "Error while trying to process the request to " + description + "! The backend didn't respond.",
-          color: "error"
-        });
-      } else {
-        useStateStore().showSnackbarMessage({
-          message: "An error occurred while trying to process the request to " + description + ".",
-          color: "error"
-        });
-      }
+export const axiosPost = async (url: string, description: string, data?: any, config?: any): Promise<boolean> => {
+  try {
+    await axios.post(url, data, config);
+    useStateStore().showSnackbarMessage({
+      message: "Successfully dispatched the request to " + description + ". Waiting for backend to respond",
+      color: "success"
     });
+    return true;
+  } catch (error: any) {
+    if (error.response) {
+      useStateStore().showSnackbarMessage({
+        message: "The backend is unable to fulfill the request to " + description + ".",
+        color: "error"
+      });
+    } else if (error.request) {
+      useStateStore().showSnackbarMessage({
+        message: "Error while trying to process the request to " + description + "! The backend didn't respond.",
+        color: "error"
+      });
+    } else {
+      useStateStore().showSnackbarMessage({
+        message: "An error occurred while trying to process the request to " + description + ".",
+        color: "error"
+      });
+    }
+    return false;
+  }
 };


### PR DESCRIPTION
## Description

We currently don't check if the POST request succeeded before immediately sprinting off to reload the page. This often means users see a green "reloading" notification, which I think is masking issues in https://www.chiefdelphi.com/t/photonvision-offline-updating-to-2026-1-1-not-working/512677. Confirmed that a disconnected UI (the demo page) will always show that green reloading notification. Fix this by making `axiosPost` return whether or not the POST request succeeded, and only refresh if it succeeded. This also similarly pulls out the snackbar message displayed on upload completion out of the upload progress callback and into an if statement because it's cleaner and avoids potential rounding errors causing it to not display.

https://github.com/user-attachments/assets/6f389b16-3176-4937-b7f2-b6660ffd8faf

https://github.com/user-attachments/assets/90ab7404-8fb3-4058-b83e-91d6332553aa

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
