### PR TITLE
Restart avahi every time network is (re)iniitlaized

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -154,7 +154,7 @@ public class NetworkManager {
         try {
             var shell = new ShellExec(true, false);
             shell.executeBashCommand("systemctl restart avahi-daemon.service");
-            logger.debug("Restarted avahi.");
+            logger.debug("Restarted avahi");
         } catch (IOException e) {
             logger.error("Failed to restart avahi daemon");
         }


### PR DESCRIPTION
## Description
The avahi daemon should be restarted whenever the network configuration (hostname or IP address) is changed to be sure that mDNS has the updated information about the coprocessor. The restart was only happening when the hostname changed, which missed the case where the IP address changes, for example when setting a static IP address. 

This PR restarts the avahi daemon every time that `NetworkManager.initialize()` and `NetworkManager.reinitialize()` are called.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
