### PR TITLE
Copy old configs before testing

### DIFF
--- a/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/configuration/SQLConfigTest.java
@@ -23,13 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.wpi.first.cscore.UsbCameraInfo;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -47,20 +45,11 @@ import org.photonvision.vision.pipeline.PipelineType;
 import org.photonvision.vision.pipeline.ReflectivePipelineSettings;
 
 public class SQLConfigTest {
-    @TempDir private static Path tmpDir;
+    @TempDir private Path tmpDir;
 
     @BeforeAll
     public static void init() {
         LoadJNI.loadLibraries();
-    }
-
-    @BeforeEach
-    public void setup() throws IOException {
-        // Ensure temp dir is empty
-        Files.walk(tmpDir)
-                .filter(path -> !path.equals(tmpDir))
-                .map(Path::toFile)
-                .forEach(file -> file.delete());
     }
 
     @Test


### PR DESCRIPTION
## Description

Presently, any tests using our old configs happen in place. This is problematic, as it changes the files themselves. This means that anyone running the tests will cause unintentional modifications, which stand a chance of being committed and merged into main. We want these old database files to remain untouched, thus we copy them to a temp directory prior to running our tests.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
