### PR TITLE
Dynamically import echarts and three.js

### DIFF
--- a/photon-client/src/components/app/photon-3d-visualizer.vue
+++ b/photon-client/src/components/app/photon-3d-visualizer.vue
@@ -44,7 +44,7 @@ let renderer: WebGLRenderer | undefined;
 let controls: TrackballControls | undefined;
 
 let previousTargets: Object3D[] = [];
-const drawTargets = (targets: PhotonTarget[]) => {
+const drawTargets = async (targets: PhotonTarget[]) => {
   // Check here, since if we check in watchEffect this never gets called
   if (!scene || !camera || !renderer || !controls) {
     return;
@@ -89,7 +89,11 @@ const drawTargets = (targets: PhotonTarget[]) => {
 
   if (calibrationCoeffs) {
     // And show camera frustum
-    const calibCamera = createPerspectiveCamera(calibrationCoeffs.resolution, calibrationCoeffs.cameraIntrinsics, 10);
+    const calibCamera = await createPerspectiveCamera(
+      calibrationCoeffs.resolution,
+      calibrationCoeffs.cameraIntrinsics,
+      10
+    );
     const helper = new CameraHelper(calibCamera);
     const helperGroup = new Group();
     helperGroup.add(helper);

--- a/photon-client/src/components/app/photon-calibration-visualizer.vue
+++ b/photon-client/src/components/app/photon-calibration-visualizer.vue
@@ -65,7 +65,7 @@ const createChessboard = (obs: BoardObservation, cal: CameraCalibrationResult): 
 
 let previousTargets: Object3D[] = [];
 let baseAspect: number | undefined;
-const drawCalibration = (cal: CameraCalibrationResult | null) => {
+const drawCalibration = async (cal: CameraCalibrationResult | null) => {
   // Check here, since if we check in watchEffect this never gets called
   if (!cal || !scene || !camera || !renderer || !controls) {
     return;
@@ -95,7 +95,7 @@ const drawCalibration = (cal: CameraCalibrationResult | null) => {
   });
 
   // And show camera frustum
-  const calibCamera = createPerspectiveCamera(props.resolution, cal.cameraIntrinsics);
+  const calibCamera = await createPerspectiveCamera(props.resolution, cal.cameraIntrinsics);
   const helper = new CameraHelper(calibCamera);
 
   // Flip to +Z forward

--- a/photon-client/src/components/settings/DeviceCard.vue
+++ b/photon-client/src/components/settings/DeviceCard.vue
@@ -376,21 +376,33 @@ watch(metricsHistorySnapshot, () => {
             <span>CPU Usage</span>
             <span>{{ Math.round(cpuUsageData.at(-1)?.value ?? 0) }}%</span>
           </div>
-          <MetricsChart id="chart" :data="cpuUsageData" type="percentage" :min="0" :max="100" color="blue" />
+          <Suspense>
+            <!-- Allows us to import echarts when it's actually needed  -->
+            <MetricsChart id="chart" :data="cpuUsageData" type="percentage" :min="0" :max="100" color="blue" />
+            <template #fallback> Loading... </template>
+          </Suspense>
         </v-card-text>
         <v-card-text class="pt-0 flex-0-0 pb-2">
           <div class="d-flex justify-space-between pb-3 pt-3">
             <span>CPU Memory Usage</span>
             <span>{{ Math.round(cpuMemoryUsageData.at(-1)?.value ?? 0) }}%</span>
           </div>
-          <MetricsChart id="chart" :data="cpuMemoryUsageData" type="percentage" :min="0" :max="100" color="purple" />
+          <Suspense>
+            <!-- Allows us to import echarts when it's actually needed  -->
+            <MetricsChart id="chart" :data="cpuMemoryUsageData" type="percentage" :min="0" :max="100" color="purple" />
+            <template #fallback> Loading... </template>
+          </Suspense>
         </v-card-text>
         <v-card-text class="pt-0 flex-0-0 pb-2">
           <div class="d-flex justify-space-between pb-3 pt-3">
             <span>CPU Temperature</span>
             <span>{{ cpuTempData.at(-1)?.value == -1 ? "--- " : Math.round(cpuTempData.at(-1)?.value ?? 0) }}°C</span>
           </div>
-          <MetricsChart id="chart" :data="cpuTempData" type="temperature" color="red" />
+          <Suspense>
+            <!-- Allows us to import echarts when it's actually needed  -->
+            <MetricsChart id="chart" :data="cpuTempData" type="temperature" color="red" />
+            <template #fallback> Loading... </template>
+          </Suspense>
         </v-card-text>
         <v-card-text class="pt-0 flex-0-0">
           <div class="d-flex justify-space-between pb-3 pt-3">
@@ -404,7 +416,11 @@ watch(metricsHistorySnapshot, () => {
               >{{ networkUsageData.at(-1)?.value == -1 ? "---" : networkUsageData.at(-1)?.value.toFixed(3) }} Mb/s</span
             >
           </div>
-          <MetricsChart id="chart" :data="networkUsageData" type="mb" :min="0" :max="10" color="green" />
+          <Suspense>
+            <!-- Allows us to import echarts when it's actually needed  -->
+            <MetricsChart id="chart" :data="networkUsageData" type="mb" :min="0" :max="10" color="green" />
+            <template #fallback> Loading... </template>
+          </Suspense>
         </v-card-text>
       </v-card>
     </v-col>

--- a/photon-client/src/components/settings/MetricsChart.vue
+++ b/photon-client/src/components/settings/MetricsChart.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import * as echarts from "echarts";
 import { onMounted, ref, onBeforeUnmount, watch } from "vue";
 import { useTheme } from "vuetify";
 
@@ -198,7 +197,8 @@ const props = defineProps<{
   color?: string;
 }>();
 
-onMounted(() => {
+onMounted(async () => {
+  const echarts = await import("echarts");
   chart = echarts.init(chartRef.value);
   chart.setOption(getOptions(props.data));
 

--- a/photon-client/src/lib/ThreeUtils.ts
+++ b/photon-client/src/lib/ThreeUtils.ts
@@ -1,5 +1,5 @@
 import type { JsonMatOfDouble, Resolution } from "@/types/SettingTypes";
-const { PerspectiveCamera } = await import("three");
+const three = import("three");
 
 /**
  * Convert a camera intrinsics matrix and image resolution to a Three.js PerspectiveCamera. This assumes no skew and square pixels (same focal length in x and y), which is a sane assumption for most FRC cameras
@@ -8,11 +8,12 @@ const { PerspectiveCamera } = await import("three");
  * @param intrinsicsCore camera intrinsics from the backend, row-major
  * @returns a Three.js PerspectiveCamera matching the provided intrinsics
  */
-export const createPerspectiveCamera = (
+export const createPerspectiveCamera = async (
   resolution: Resolution,
   intrinsicsCore: JsonMatOfDouble,
   frustumMax: number = 1
 ) => {
+  const { PerspectiveCamera } = await three;
   const imageWidth = resolution.width;
   const imageHeight = resolution.height;
   const focalLengthY = intrinsicsCore.data[4];


### PR DESCRIPTION
## Description

This splits echarts into its own bundle to speed up the initial page load, and dynamically imports it so it's only loaded when a user navigates to the settings page. This also fixes an issue with the three.js dynamic import where the import was immediately awaited, so the page load was blocked on loading three.js.

https://github.com/user-attachments/assets/ac7cfc91-d11e-42d1-940d-d1dbe65693dc

Note the UI isn't displayed until after three.js is fully downloaded.

https://github.com/user-attachments/assets/63ead48e-f351-472a-8ca1-1ed8dff259e8

Note that the initial JS bundle is much smaller and three.js is loaded after the UI loads.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
