### PR TITLE
Fix Arducam OV9782 Exposure Changing After Reboot

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
@@ -169,10 +169,11 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
 
     @Override
     public void setAutoExposure(boolean cameraAutoExposure) {
-        if (configuration.cameraQuirks.hasQuirk(CameraQuirk.ArduOV9281Controls)
+        if ((configuration.cameraQuirks.hasQuirk(CameraQuirk.ArduOV9281Controls)
+                        || configuration.cameraQuirks.hasQuirk(CameraQuirk.ArduOV9782Controls))
                 && !cameraAutoExposure) {
-            // OV9281 on Linux seems to sometimes ignore our exposure requests on first boot if we're in
-            // manual mode. Poking the camera into and out of auto exposure seems to fix it.
+            // OV9281 and OV9782 on Linux seems to sometimes ignore our exposure requests on first boot if
+            // we're in manual mode. Poking the camera into and out of auto exposure seems to fix it.
             try {
                 setAutoExposureImpl(false);
                 Thread.sleep(2000);
@@ -180,7 +181,7 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
                 Thread.sleep(2000);
                 setAutoExposureImpl(false);
             } catch (InterruptedException e) {
-                logger.error("Thread interrupted while setting OV9281 exposure!", e);
+                logger.error("Thread interrupted while setting OV9281 or OV9782 exposure!", e);
             }
         } else {
             setAutoExposureImpl(cameraAutoExposure);


### PR DESCRIPTION
The Arducam OV9782's exposure value is changed after a power cycle just like the OV9281. Toggling auto exposure on and off fixes it.

## Description

Adds a check for the OV9782 quirk and uses the same auto exposure toggle that fixed the OV9281's problems.

Closes #2353 

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
