### PR TITLE
Fix default gateway in static IP config to match VH-109 DHCP config

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkManager.java
@@ -223,9 +223,10 @@ public class NetworkManager {
             return;
         }
 
-        // guess at the gateway from the staticIp
+        // Default gateway handed out by the VH-109 DHCP server is 10.TE.AM.4
+        // https://docs.wpilib.org/en/stable/docs/networking/networking-introduction/ip-configurations.html#on-the-field-dhcp-configuration
         String[] parts = config.staticIp.split("\\.");
-        parts[parts.length - 1] = "1";
+        parts[parts.length - 1] = "4";
         String gateway = String.join(".", parts);
 
         var shell = new ShellExec();


### PR DESCRIPTION
## Description
Closes #2362 
The default gateway handed out by the vh-109 dhcp server is .4, not .1.
prompted by https://www.chiefdelphi.com/t/photonvision-not-accessible-over-vh109-running-ap-firmware/514418/29

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [x] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [x] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added (does this change need a regression test...?)
