### PR TITLE
Update Dashboard to reflect Calibration Rotation Changes

### DIFF
--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -171,7 +171,7 @@ const interactiveCols = computed(() =>
     <pv-select
       v-model="useCameraSettingsStore().currentPipelineSettings.inputImageRotationMode"
       label="Orientation"
-      tooltip="Rotates the camera stream. Rotation not available when camera has been calibrated."
+      tooltip="Rotates the camera stream"
       :items="cameraRotations"
       :select-cols="interactiveCols"
       @update:modelValue="


### PR DESCRIPTION
## Description

Hi PV team,

Around 2 years ago, this PR #1277 added checks to make sure that users weren't enabling camera rotation when they calibrated their cameras as a stop gap to Issue #1084 

However PR #1464 has resolved this issue (see https://github.com/PhotonVision/photonvision/issues/1084#issuecomment-2477580204) and I wanted to update the orientation tooltip in the dashboard to reflect this.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
