### PR TITLE
Bump image version to 2026.1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -552,6 +552,12 @@ jobs:
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             artifact-name: LinuxArm64
+            image_suffix: orangepi6plus
+            plat_override: LINUX_AARCH64
+            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi6plus.img.xz
+            minimum_free_mb: 1024
+          - os: ubuntu-24.04-arm
+            artifact-name: LinuxArm64
             image_suffix: rubikpi3
             plat_override: LINUX_QCS6490
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_rubikpi3.tar.xz


### PR DESCRIPTION
[Release notes for 2026.1.3](https://github.com/PhotonVision/photon-image-modifier/releases/tag/v2026.1.3)
- Provisional orange pi 6 plus image builder by @guineawheek in https://github.com/PhotonVision/photon-image-modifier/pull/126
- Install usbtop to images by @samfreund in https://github.com/PhotonVision/photon-image-modifier/pull/129
- Shrunk our Rubik Pi 3 image by @crschardt in https://github.com/PhotonVision/photon-image-modifier/pull/128

This PR includes a downsized Rubik Pi image and usbtop shipped with the image for debugging. It also adds the opi6 image (note no OD support yet; platform is detected as a generic arm64 target).
