### PR TITLE
Require cross compiler toolchain when cross compiling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,10 +268,10 @@ jobs:
           - container: wpilib/roborio-cross-ubuntu:2025-24.04
             artifact-name: Athena
             build-options: "-Ponlylinuxathena"
-          - container: wpilib/raspbian-cross-ubuntu:bullseye-22.04
+          - container: wpilib/raspbian-cross-ubuntu:bookworm-22.04
             artifact-name: Raspbian
             build-options: "-Ponlylinuxarm32"
-          - container: wpilib/aarch64-cross-ubuntu:bullseye-22.04
+          - container: wpilib/aarch64-cross-ubuntu:bookworm-22.04
             artifact-name: Aarch64
             build-options: "-Ponlylinuxarm64"
 

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -13,6 +13,11 @@ nativeUtils.wpi.configureDependencies {
     niLibVersion = "2026.1.0"
 }
 
+// Force cross compiles to fail without the toolchain
+if (wpilibTools.platformMapper.wpilibClassifier.contains('linux') && !wpilibTools.platformMapper.wpilibClassifier.contains('linux86-64')) {
+    nativeUtils.crossCompilers.getByName(wpilibTools.platformMapper.wpilibClassifier).optional = false
+}
+
 // Configure warnings and errors
 nativeUtils.wpi.addWarnings()
 nativeUtils.wpi.addWarningsAsErrors()


### PR DESCRIPTION
## Description

Because native-utils marks toolchains as optional by default, it's possible to request a cross compilation and then... just have it not cross compile. This marks Linux cross compilers as non-optional if they are requested.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
