### PR TITLE
Remove old camera quirk aliases

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/CameraQuirk.java
@@ -17,8 +17,6 @@
 
 package org.photonvision.vision.camera;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
-
 public enum CameraQuirk {
     /** Camera settable for controllable image gain */
     Gain,
@@ -29,7 +27,6 @@ public enum CameraQuirk {
     /** Cap at 100FPS for high-bandwidth cameras */
     FPSCap100,
     /** Separate red/blue gain controls available */
-    @JsonAlias("AWBGain") // remove after https://github.com/PhotonVision/photonvision/issues/1488
     AwbRedBlueGain,
     /** Will not work with photonvision - Logitech C270 at least */
     CompletelyBroken,
@@ -43,11 +40,8 @@ public enum CameraQuirk {
      * Camera is an arducam USB ov9281 which has a funky exposure issue where it is defined in v4l as
      * 1-5000 instead of 1-75
      */
-    @JsonAlias("ArduOV9281") // remove after https://github.com/PhotonVision/photonvision/issues/1488
     ArduOV9281Controls,
     /** Dummy quirk to tell OV2311 from OV9281 */
-    // from 2024.3.1
-    @JsonAlias("ArduOV2311") // remove after https://github.com/PhotonVision/photonvision/issues/1488
     ArduOV2311Controls,
     ArduOV9782Controls,
     /**


### PR DESCRIPTION
## Description

Pursuant to #1488, remove some old aliases that are no longer needed for backwards compatability.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [x] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
