### PR TITLE
Increase resolution of camera lost frame

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/frame/StaticFrames.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/StaticFrames.java
@@ -26,87 +26,68 @@ import org.opencv.imgproc.Imgproc;
 import org.photonvision.common.util.ColorHelper;
 
 public class StaticFrames {
-    public static final Mat LOST_MAT = new Mat(60, 15 * 7, CvType.CV_8UC3);
-    public static final Mat EMPTY_MAT = new Mat(60, 15 * 7, CvType.CV_8UC3);
+    public static final Mat LOST_MAT = new Mat(120, 30 * 7, CvType.CV_8UC3);
 
     static {
-        EMPTY_MAT.setTo(ColorHelper.colorToScalar(Color.BLACK));
+        LOST_MAT.setTo(ColorHelper.colorToScalar(Color.BLACK));
         var col = 0;
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(col, 0, 15, EMPTY_MAT.height()),
+                LOST_MAT,
+                new Rect(col, 0, 30, LOST_MAT.height()),
                 ColorHelper.colorToScalar(new Color(0xa2a2a2)),
                 -1);
-        col += 15;
+        col += 30;
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(col, 0, 15, EMPTY_MAT.height()),
+                LOST_MAT,
+                new Rect(col, 0, 30, LOST_MAT.height()),
                 ColorHelper.colorToScalar(new Color(0xa2a300)),
                 -1);
-        col += 15;
+        col += 30;
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(col, 0, 15, EMPTY_MAT.height()),
+                LOST_MAT,
+                new Rect(col, 0, 30, LOST_MAT.height()),
                 ColorHelper.colorToScalar(new Color(0x00a3a2)),
                 -1);
-        col += 15;
+        col += 30;
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(col, 0, 15, EMPTY_MAT.height()),
+                LOST_MAT,
+                new Rect(col, 0, 30, LOST_MAT.height()),
                 ColorHelper.colorToScalar(new Color(0x00a200)),
                 -1);
-        col += 15;
+        col += 30;
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(col, 0, 15, EMPTY_MAT.height()),
-                ColorHelper.colorToScalar(new Color(0x440045)),
+                LOST_MAT,
+                new Rect(col, 0, 30, LOST_MAT.height()),
+                ColorHelper.colorToScalar(new Color(0x440090)),
                 -1);
-        col += 15;
+        col += 30;
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(col, 0, 15, EMPTY_MAT.height()),
+                LOST_MAT,
+                new Rect(col, 0, 30, LOST_MAT.height()),
                 ColorHelper.colorToScalar(new Color(0x0000a2)),
                 -1);
-        col += 15;
+        col += 30;
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(col, 0, 15, EMPTY_MAT.height()),
+                LOST_MAT,
+                new Rect(col, 0, 30, LOST_MAT.height()),
                 ColorHelper.colorToScalar(new Color(0)),
                 -1);
         Imgproc.rectangle(
-                EMPTY_MAT,
-                new Rect(0, 50, EMPTY_MAT.width(), 10),
+                LOST_MAT,
+                new Rect(0, 100, LOST_MAT.width(), 20),
                 ColorHelper.colorToScalar(new Color(0)),
                 -1);
         Imgproc.rectangle(
-                EMPTY_MAT, new Rect(15, 50, 30, 10), ColorHelper.colorToScalar(Color.WHITE), -1);
-
-        EMPTY_MAT.copyTo(LOST_MAT);
+                LOST_MAT, new Rect(30, 100, 60, 20), ColorHelper.colorToScalar(Color.WHITE), -1);
 
         Imgproc.putText(
-                EMPTY_MAT, "Stream", new Point(14, 20), 0, 0.6, ColorHelper.colorToScalar(Color.white), 2);
+                LOST_MAT, "Camera", new Point(28, 40), 0, 1.2, ColorHelper.colorToScalar(Color.white), 6);
         Imgproc.putText(
-                EMPTY_MAT,
-                "Disabled",
-                new Point(14, 45),
-                0,
-                0.6,
-                ColorHelper.colorToScalar(Color.white),
-                2);
-
+                LOST_MAT, "Lost", new Point(28, 90), 0, 1.2, ColorHelper.colorToScalar(Color.white), 6);
         Imgproc.putText(
-                EMPTY_MAT, "Stream", new Point(14, 20), 0, 0.6, ColorHelper.colorToScalar(Color.RED), 1);
+                LOST_MAT, "Camera", new Point(28, 40), 0, 1.2, ColorHelper.colorToScalar(Color.RED), 2);
         Imgproc.putText(
-                EMPTY_MAT, "Disabled", new Point(14, 45), 0, 0.6, ColorHelper.colorToScalar(Color.RED), 1);
-
-        Imgproc.putText(
-                LOST_MAT, "Camera", new Point(14, 20), 0, 0.6, ColorHelper.colorToScalar(Color.white), 2);
-        Imgproc.putText(
-                LOST_MAT, "Lost", new Point(14, 45), 0, 0.6, ColorHelper.colorToScalar(Color.white), 2);
-        Imgproc.putText(
-                LOST_MAT, "Camera", new Point(14, 20), 0, 0.6, ColorHelper.colorToScalar(Color.RED), 1);
-        Imgproc.putText(
-                LOST_MAT, "Lost", new Point(14, 45), 0, 0.6, ColorHelper.colorToScalar(Color.RED), 1);
+                LOST_MAT, "Lost", new Point(28, 90), 0, 1.2, ColorHelper.colorToScalar(Color.RED), 2);
     }
 
     public StaticFrames() {}


### PR DESCRIPTION
## Description

The current Camera Lost image is rather low resolution and pixelated, corrupting the shape of the text, and JPEG compression also smudges all the text, making it somewhat hard to read (and not very appealing to look at either). Doubling the resolution removes most of the smudging from JPEG artifacts, and gives enough pixels for the text to be shaped correctly, with the end result being much easier to read and nicer to look at. Bandwidth increases from ~0.08 Mbit/s to ~0.18 Mbit/s, which is likely acceptable for this use case.

<img width="698" height="864" alt="image" src="https://github.com/user-attachments/assets/8f2ca78a-9501-4c2c-80c1-d4acf4a1a541" />

<img width="700" height="871" alt="image" src="https://github.com/user-attachments/assets/c7de1766-60b4-4e1a-81e9-b4af144d882b" />


## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
