### PR TITLE
Set raw exposure before setting auto exposure

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -465,13 +465,13 @@ public class VisionModule {
                             pipelineSettings.cameraExposureRaw = 10; // reasonable default
                     }
 
+                    settables.setExposureRaw(pipelineSettings.cameraExposureRaw);
                     try {
                         settables.setAutoExposure(pipelineSettings.cameraAutoExposure);
                     } catch (VideoException e) {
                         logger.error("Unable to set camera auto exposure!");
                         logger.error(e.toString());
                     }
-                    settables.setExposureRaw(pipelineSettings.cameraExposureRaw);
                     if (cameraQuirks.hasQuirk(CameraQuirk.Gain)) {
                         // If the gain is disabled for some reason, re-enable it
                         if (pipelineSettings.cameraGain == -1) pipelineSettings.cameraGain = 75;


### PR DESCRIPTION
## Description

On Luma P1 and other devices, autoexposure on boot was getting overridden with the manual exposure setting. This was traced back to #1814, where the order of setting auto exposure and raw exposure was flipped. This flips it back.

## Meta

Merge checklist:
- [X] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [X] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
