### PR TITLE
Disallow low-resolution calibration

### DIFF
--- a/docs/source/docs/calibration/calibration.md
+++ b/docs/source/docs/calibration/calibration.md
@@ -7,7 +7,7 @@ In order to detect AprilTags and use 3D mode, your camera must be calibrated at 
 To calibrate a camera, images of a ChArUco board (or chessboard) are taken. By comparing where the grid corners should be in object space (for example, a corner once every inch in an 8x6 grid) with where they appear in the camera image, we can find a least-squares estimate for intrinsic camera properties like focal lengths, center point, and distortion coefficients. For more on camera calibration, please review the [OpenCV documentation](https://docs.opencv.org/4.x/dc/dbb/tutorial_py_calibration.html).
 
 :::{warning}
-PhotonVision supports many resolution configuration options, with only a minimum of 480x640 required. However, higher resolutions may be too performance-intensive for some coprocessors to handle. Therefore, we recommend experimenting to see what works best for your coprocessor.
+PhotonVision supports many resolution configuration options, with only a minimum of 640x480 required. However, higher resolutions may be too performance-intensive for some coprocessors to handle. Therefore, we recommend experimenting to see what works best for your coprocessor.
 :::
 
 :::{note}

--- a/docs/source/docs/calibration/calibration.md
+++ b/docs/source/docs/calibration/calibration.md
@@ -7,7 +7,7 @@ In order to detect AprilTags and use 3D mode, your camera must be calibrated at 
 To calibrate a camera, images of a ChArUco board (or chessboard) are taken. By comparing where the grid corners should be in object space (for example, a corner once every inch in an 8x6 grid) with where they appear in the camera image, we can find a least-squares estimate for intrinsic camera properties like focal lengths, center point, and distortion coefficients. For more on camera calibration, please review the [OpenCV documentation](https://docs.opencv.org/4.x/dc/dbb/tutorial_py_calibration.html).
 
 :::{warning}
-While any resolution can be calibrated, higher resolutions may be too performance-intensive for some coprocessors to handle. Therefore, we recommend experimenting to see what works best for your coprocessor.
+PhotonVision supports many resolution configuration options, with only a minimum of 480x640 required. However, higher resolutions may be too performance-intensive for some coprocessors to handle. Therefore, we recommend experimenting to see what works best for your coprocessor.
 :::
 
 :::{note}

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -38,22 +38,16 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
 
     if (!skip) {
       const calib = useCameraSettingsStore().getCalibrationCoeffs(format.resolution);
+
+      // minPixelCount is the multiplied area of a 640x480 (the minimum for proper calibration) resolution
+      const minPixelCount = 640 * 480;
+      const resArea = format.resolution.width * format.resolution.height;
       if (calib !== undefined) {
         // Mean overall reprojection error
         // Calculated as average of each observation's mean error
         if (calib.meanErrors.length)
           format.mean = calib.meanErrors.reduce((a, b) => a + b, 0) / calib.meanErrors.length;
         else format.mean = NaN;
-
-        // minPixelCount is the multiplied area of a 640x480 (the minimum for proper calibration) resolution
-        const minPixelCount = 640 * 480;
-        const resArea = format.resolution.width * format.resolution.height;
-
-        if (resArea < minPixelCount) {
-          format.resolution.width = 640;
-          format.resolution.height = 480;
-          uniqueResolutions.push(format);
-        }
 
         format.horizontalFOV =
           2 * Math.atan2(format.resolution.width / 2, calib.cameraIntrinsics.data[0]) * (180 / Math.PI);
@@ -70,7 +64,9 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
           ) *
           (180 / Math.PI);
       }
-      uniqueResolutions.push(format);
+      if (resArea > minPixelCount) {
+        uniqueResolutions.push(format);
+      }
     }
   });
   uniqueResolutions.sort(

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -66,7 +66,7 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
           (180 / Math.PI);
       }
 
-      if (resArea > minPixelCount) {
+      if (resArea >= minPixelCount) {
         uniqueResolutions.push(format);
       }
     }

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -99,7 +99,8 @@ watchEffect(() => {
   const names = useCameraSettingsStore().currentCameraSettings.validVideoFormats.map((f) =>
     getResolutionString(f.resolution)
   );
-  uniqueVideoResolutionString.value = names[currentIndex] ?? names[0] ?? "";
+  const lastIndex = names.lastIndexOf("");
+  uniqueVideoResolutionString.value = names[currentIndex] ?? names[lastIndex] ?? "";
 });
 const squareSizeIn = ref(1);
 const markerSizeIn = ref(0.75);

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -99,7 +99,12 @@ watchEffect(() => {
   );
   const currentFormatIndex = useCameraSettingsStore().currentVideoFormat.index ?? 0;
   // Checks if the current resolution is present in the list of valid formats, if not defaults to the last index (which is usually the highest resolution)
-  const currentIndex = getUniqueVideoResolutionStrings().map(x => x.name).find((n) => n === names[currentFormatIndex]) !== undefined ? currentFormatIndex : names.length - 1;
+  const currentIndex =
+    getUniqueVideoResolutionStrings()
+      .map((x) => x.name)
+      .find((n) => n === names[currentFormatIndex]) !== undefined
+      ? currentFormatIndex
+      : names.length - 1;
   useStateStore().calibrationData.videoFormatIndex = currentIndex;
   uniqueVideoResolutionString.value = names[currentIndex] ?? "";
 });

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -45,6 +45,16 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
           format.mean = calib.meanErrors.reduce((a, b) => a + b, 0) / calib.meanErrors.length;
         else format.mean = NaN;
 
+        // minPixelCount is the total area, in pixels, of the 640x480 (the minimum for proper calibration) resolution
+        const minPixelCount = 307200;
+        const resArea = format.resolution.width * format.resolution.height;
+
+        if (resArea > minPixelCount) {
+          format.resolution.width = 640;
+          format.resolution.height = 480;
+          uniqueResolutions.push(format);
+        }
+
         format.horizontalFOV =
           2 * Math.atan2(format.resolution.width / 2, calib.cameraIntrinsics.data[0]) * (180 / Math.PI);
         format.verticalFOV =

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -99,8 +99,7 @@ watchEffect(() => {
   const names = useCameraSettingsStore().currentCameraSettings.validVideoFormats.map((f) =>
     getResolutionString(f.resolution)
   );
-  const lastIndex = names.lastIndexOf("");
-  uniqueVideoResolutionString.value = names[currentIndex] ?? names[lastIndex] ?? "";
+  uniqueVideoResolutionString.value = names[currentIndex] ?? names[names.length - 1] ?? "";
 });
 const squareSizeIn = ref(1);
 const markerSizeIn = ref(0.75);

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -45,11 +45,11 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
           format.mean = calib.meanErrors.reduce((a, b) => a + b, 0) / calib.meanErrors.length;
         else format.mean = NaN;
 
-        // minPixelCount is the total area, in pixels, of the 640x480 (the minimum for proper calibration) resolution
-        const minPixelCount = 307200;
+        // minPixelCount is the multiplied area of a 640x480 (the minimum for proper calibration) resolution
+        const minPixelCount = 640 * 480;
         const resArea = format.resolution.width * format.resolution.height;
 
-        if (resArea > minPixelCount) {
+        if (resArea < minPixelCount) {
           format.resolution.width = 640;
           format.resolution.height = 480;
           uniqueResolutions.push(format);

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -94,12 +94,14 @@ const uniqueVideoResolutionString = ref("");
 // Use a watchEffect so the value is populated/reacts when the stores become available or update.
 // This avoids trying to index into an array that may be empty during page reload.
 watchEffect(() => {
-  const currentIndex = useCameraSettingsStore().currentVideoFormat.index ?? 0;
-  useStateStore().calibrationData.videoFormatIndex = currentIndex;
   const names = useCameraSettingsStore().currentCameraSettings.validVideoFormats.map((f) =>
     getResolutionString(f.resolution)
   );
-  uniqueVideoResolutionString.value = names[currentIndex] ?? names[names.length - 1] ?? "";
+  const currentFormatIndex = useCameraSettingsStore().currentVideoFormat.index ?? 0;
+  // Checks if the current resolution is present in the list of valid formats, if not defaults to the last index (which is usually the highest resolution)
+  const currentIndex = getUniqueVideoResolutionStrings().map(x => x.name).find((n) => n === names[currentFormatIndex]) !== undefined ? currentFormatIndex : names.length - 1;
+  useStateStore().calibrationData.videoFormatIndex = currentIndex;
+  uniqueVideoResolutionString.value = names[currentIndex] ?? "";
 });
 const squareSizeIn = ref(1);
 const markerSizeIn = ref(0.75);

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -39,9 +39,8 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
     if (!skip) {
       const calib = useCameraSettingsStore().getCalibrationCoeffs(format.resolution);
 
-      // minPixelCount is the multiplied area of a 640x480 (the minimum for proper calibration) resolution
-      const minPixelCount = 640 * 480;
-      const resArea = format.resolution.width * format.resolution.height;
+      const resWidth = format.resolution.width;
+      const resHeight = format.resolution.height;
       if (calib !== undefined) {
         // Mean overall reprojection error
         // Calculated as average of each observation's mean error
@@ -64,7 +63,8 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
           ) *
           (180 / Math.PI);
       }
-      if (resArea > minPixelCount) {
+
+      if (resWidth < 640 || resHeight < 480) {
         uniqueResolutions.push(format);
       }
     }

--- a/photon-client/src/components/cameras/CameraCalibrationCard.vue
+++ b/photon-client/src/components/cameras/CameraCalibrationCard.vue
@@ -39,8 +39,10 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
     if (!skip) {
       const calib = useCameraSettingsStore().getCalibrationCoeffs(format.resolution);
 
-      const resWidth = format.resolution.width;
-      const resHeight = format.resolution.height;
+      // minPixelCount is the multiplied area of a 640x480 (the minimum for proper calibration) resolution
+      const minPixelCount = 640 * 480;
+      const resArea = format.resolution.width * format.resolution.height;
+
       if (calib !== undefined) {
         // Mean overall reprojection error
         // Calculated as average of each observation's mean error
@@ -64,7 +66,7 @@ const getUniqueVideoFormatsByResolution = (): VideoFormat[] => {
           (180 / Math.PI);
       }
 
-      if (resWidth < 640 || resHeight < 480) {
+      if (resArea > minPixelCount) {
         uniqueResolutions.push(format);
       }
     }


### PR DESCRIPTION
Description

Filter calibration resolution options plus preview table to only resolutions with at least 640*480 pixels^2 of area. We can tune this later if it's too aggressive.

If lower resolutions are calibrated, users will no longer be able to see them on the table. This is fine. They shouldn't have been using them anyways 

Closes #1719
Successor to #2390

Meta

Merge checklist:

    Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
    The description documents the what and why, including events that led to this PR
    If this PR changes behavior or adds a feature, user documentation is updated