### PR TITLE
Remove obsolete latency api reference

### DIFF
--- a/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
+++ b/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
@@ -48,19 +48,19 @@ You can use the `setPipelineIndex()`/`SetPipelineIndex()` (Java and C++ respecti
 
 ## Getting the Pipeline Image Capture Time
 
-You can also get the pipeline's image capture time from a pipeline result using the `getTimestampSeconds()`/`GetTimestamp()` (Java and C++ respectively) methods on a `PhotonPipelineResult`.
+You can also get the pipeline's image capture time from a pipeline result using the `getTimestampSeconds()`/`GetTimestamp()` (Java and C++ respectively) methods on a `PhotonPipelineResult`. This is useful when adding vision pose estimates to a pose estimator or Kalman Filter, to help express the idea that camera image for the estimates was taken some time in the past.
 
 ```{eval-rst}
 .. tab-set-code::
    .. code-block:: java
 
-      // Get the pipeline latency.
-      double latencySeconds = result.getTimestampSeconds() / 1000.0;
+      // Get the pipeline image capture timestamp.
+      double resultTime = result.getTimestampSeconds() / 1000.0;
 
    .. code-block:: c++
 
-      // Get the pipeline latency.
-      units::second_t latency = result.GetTimestamp();
+      // Get the pipeline image capture timestamp.
+      units::second_t resultTime = result.GetTimestamp();
 
    .. code-block:: python
 
@@ -68,5 +68,5 @@ You can also get the pipeline's image capture time from a pipeline result using 
 ```
 
 :::{note}
-The C++ version of PhotonLib returns the latency in a unit container. For more information on the Units library, see [here](https://docs.wpilib.org/en/stable/docs/software/basic-programming/cpp-units.html).
+The C++ version of PhotonLib returns the image capture time in a unit container. For more information on the Units library, see [here](https://docs.wpilib.org/en/stable/docs/software/basic-programming/cpp-units.html).
 :::

--- a/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
+++ b/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
@@ -46,9 +46,9 @@ You can use the `setPipelineIndex()`/`SetPipelineIndex()` (Java and C++ respecti
         # Coming Soon!
 ```
 
-## Getting the Pipeline Latency
+## Getting the Pipeline Image Capture Time
 
-You can also get the pipeline latency from a pipeline result using the `getLatencyMillis()`/`GetLatency()` (Java and C++ respectively) methods on a `PhotonPipelineResult`.
+You can also get the pipeline's image capture time from a pipeline result using the `getTimestampSeconds()`/`GetTimestamp()` (Java and C++ respectively) methods on a `PhotonPipelineResult`.
 
 ```{eval-rst}
 .. tab-set-code::
@@ -60,7 +60,7 @@ You can also get the pipeline latency from a pipeline result using the `getLaten
    .. code-block:: c++
 
       // Get the pipeline latency.
-      units::second_t latency = result.GetTimestampSeconds();
+      units::second_t latency = result.GetTimestamp();
 
    .. code-block:: python
 

--- a/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
+++ b/docs/source/docs/programming/photonlib/driver-mode-pipeline-index.md
@@ -55,12 +55,12 @@ You can also get the pipeline latency from a pipeline result using the `getLaten
    .. code-block:: java
 
       // Get the pipeline latency.
-      double latencySeconds = result.getLatencyMillis() / 1000.0;
+      double latencySeconds = result.getTimestampSeconds() / 1000.0;
 
    .. code-block:: c++
 
       // Get the pipeline latency.
-      units::second_t latency = result.GetLatency();
+      units::second_t latency = result.GetTimestampSeconds();
 
    .. code-block:: python
 


### PR DESCRIPTION
## Description

Docs had a lingering reference to an old/ non-existant api

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
