### PR TITLE
Don't interact with Libcamera cameras until connected

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/frame/FrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/FrameProvider.java
@@ -35,15 +35,12 @@ public abstract class FrameProvider implements Supplier<Frame>, Releasable {
         cameraPropertiesCached = true;
     }
 
-    /**
-     * Returns if the camera is currently connected. Use checkCameraConnected instead to properly
-     * handle camera connection.
-     */
-    public abstract boolean isConnected();
+    /** Internal provider for if the camera is currently connected. */
+    protected abstract boolean checkCameraConnected();
 
     /** Checks if the camera is currently connected. Also handles connection events. */
-    public boolean checkCameraConnected() {
-        boolean connected = this.isConnected();
+    public boolean isConnected() {
+        boolean connected = this.checkCameraConnected();
 
         if (!cameraPropertiesCached && connected) {
             onCameraConnected();

--- a/photon-core/src/main/java/org/photonvision/vision/frame/FrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/FrameProvider.java
@@ -35,9 +35,22 @@ public abstract class FrameProvider implements Supplier<Frame>, Releasable {
         cameraPropertiesCached = true;
     }
 
+    /**
+     * Returns if the camera is currently connected. Use checkCameraConnected instead to properly
+     * handle camera connection.
+     */
     public abstract boolean isConnected();
 
-    public abstract boolean checkCameraConnected();
+    /** Checks if the camera is currently connected. Also handles connection events. */
+    public boolean checkCameraConnected() {
+        boolean connected = this.isConnected();
+
+        if (!cameraPropertiesCached && connected) {
+            onCameraConnected();
+        }
+
+        return connected;
+    }
 
     /**
      * Returns if the camera has connected at some point. This is not if it is currently connected.

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
@@ -37,11 +37,6 @@ public class LibcameraGpuFrameProvider extends FrameProvider {
 
     public LibcameraGpuFrameProvider(LibcameraGpuSettables visionSettables) {
         this.settables = visionSettables;
-
-        var vidMode = settables.getCurrentVideoMode();
-        settables.setVideoMode(vidMode);
-        this.cameraPropertiesCached =
-                true; // Camera properties are not able to be changed so they are always cached
     }
 
     @Override
@@ -150,7 +145,7 @@ public class LibcameraGpuFrameProvider extends FrameProvider {
     }
 
     @Override
-    public boolean checkCameraConnected() {
+    public boolean isConnected() {
         String[] cameraNames = LibCameraJNI.getCameraNames();
         for (String name : cameraNames) {
             if (name.equals(settables.getConfiguration().getDevicePath())) {
@@ -160,9 +155,13 @@ public class LibcameraGpuFrameProvider extends FrameProvider {
         return false;
     }
 
-    // To our knowledge the camera is always connected (after boot) with csi cameras
     @Override
-    public boolean isConnected() {
-        return checkCameraConnected();
+    protected void onCameraConnected() {
+        logger.info("Camera connected! running callback");
+
+        super.onCameraConnected();
+
+        var vidMode = settables.getCurrentVideoMode();
+        settables.setVideoMode(vidMode);
     }
 }

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
@@ -145,7 +145,7 @@ public class LibcameraGpuFrameProvider extends FrameProvider {
     }
 
     @Override
-    public boolean isConnected() {
+    public boolean checkCameraConnected() {
         String[] cameraNames = LibCameraJNI.getCameraNames();
         for (String name : cameraNames) {
             if (name.equals(settables.getConfiguration().getDevicePath())) {

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/USBFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/USBFrameProvider.java
@@ -57,18 +57,6 @@ public class USBFrameProvider extends CpuImageProcessor {
         this.connectedCallback = connectedCallback;
     }
 
-    @Override
-    public boolean checkCameraConnected() {
-        boolean connected = camera.isConnected();
-
-        if (!cameraPropertiesCached && connected) {
-            logger.info("Camera connected! running callback");
-            onCameraConnected();
-        }
-
-        return connected;
-    }
-
     final double CSCORE_DEFAULT_FRAME_TIMEOUT = 1.0 / 4.0;
 
     @Override
@@ -145,6 +133,8 @@ public class USBFrameProvider extends CpuImageProcessor {
 
     @Override
     public void onCameraConnected() {
+        logger.info("Camera connected! running callback");
+
         super.onCameraConnected();
 
         this.connectedCallback.run();

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/USBFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/USBFrameProvider.java
@@ -141,7 +141,7 @@ public class USBFrameProvider extends CpuImageProcessor {
     }
 
     @Override
-    public boolean isConnected() {
+    public boolean checkCameraConnected() {
         return camera.isConnected();
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionRunner.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionRunner.java
@@ -132,7 +132,7 @@ public class VisionRunner {
 
     private void update() {
         // wait for the camera to connect
-        while (!frameSupplier.checkCameraConnected() && !Thread.interrupted()) {
+        while (!frameSupplier.isConnected() && !Thread.interrupted()) {
             // yield
             pipelineResultConsumer.accept(new CVPipelineResult(0l, 0, 0, null, new Frame()));
             try {


### PR DESCRIPTION
## Description

<!-- What changed? Why? (the code + comments should speak for itself on the "how") -->

The Libcamera frame provider was trying to reset the video mode to the saved value regardless of whether the camera is currently attached or not. This waits until the camera is connected first to prevent crashing PhotonVision.

<!-- Fun screenshots or a cool video or something are super helpful as well. If this touches platform-specific behavior, this is where test evidence should be collected. -->

<!-- Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`. -->

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with settings back to v2025.3.2
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
