### PR TITLE
Properly handle non-managed networking

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -327,7 +327,6 @@ public class NetworkUtils {
 
     private static NetworkInterface getInterfaceForRemoteAddress(
             InetAddress remoteAddress, int remotePort) {
-
         // Paranoia -- validate remote address
         if (remoteAddress == null
                 || remoteAddress.isLoopbackAddress()

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -17,15 +17,18 @@
 
 package org.photonvision.common.networking;
 
-import edu.wpi.first.networktables.NetworkTableInstance;
 import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.photonvision.common.configuration.ConfigManager;
+import org.photonvision.common.dataflow.networktables.NetworkTablesManager;
 import org.photonvision.common.hardware.Platform;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
@@ -262,17 +265,34 @@ public class NetworkUtils {
             // Not managed? See if we're connected to a network. General assumption is one interface in
             // use at a time
             if (config.networkManagerIface == null || config.networkManagerIface.isBlank()) {
-                // Use NT client IP address to find the interface in use
+                // Use NT client IP address to find the interface in use, if a client
                 if (!config.runNTServer) {
-                    var conn = NetworkTableInstance.getDefault().getConnections();
-                    if (conn.length > 0 && !conn[0].remote_ip.equals("127.0.0.1")) {
-                        var addr = InetAddress.getByName(conn[0].remote_ip);
-                        return formatMacAddress(NetworkInterface.getByInetAddress(addr).getHardwareAddress());
+                    // All active connections. Client, so either empty or the active connection
+                    logger.debug("Trying MAC address via NT inst server route");
+                    var conn = NetworkTablesManager.getInstance().getNTInst().getConnections();
+                    if (conn.length > 0) {
+                        // We have a connection to server. Check it looks valid (paranoia)
+                        var remoteIp = conn[0].remote_ip;
+                        var remotePort = conn[0].remote_port;
+                        if (remoteIp != null && !remoteIp.isBlank()) {
+                            var remoteAddr = InetAddress.getByName(remoteIp);
+                            if (!remoteAddr.isLoopbackAddress()) {
+                                var iface = getInterfaceForRemoteAddress(remoteAddr, remotePort);
+                                if (iface != null) {
+                                    byte[] mac = iface.getHardwareAddress();
+                                    if (mac != null) {
+                                        return formatMacAddress(mac);
+                                    }
+                                } else {
+                                    logger.debug(
+                                            "Unable to resolve local interface for NT remote address " + remoteIp);
+                                }
+                            }
+                        }
                     }
                 }
-                // Connected to a localhost server or we are the server? Try resolving ourselves. Only
-                // returns a localhost address when there's no other interface available on Windows, but
-                // like to return a localhost address on Linux
+                // We are the server? Try resolving ourselves. Only returns a localhost address when there's
+                // no other interface available on Windows, but like to return a localhost address on Linux
                 var localIface = NetworkInterface.getByInetAddress(InetAddress.getLocalHost());
                 if (localIface != null) {
                     byte[] mac = localIface.getHardwareAddress();
@@ -280,7 +300,7 @@ public class NetworkUtils {
                         return formatMacAddress(mac);
                     }
                 }
-                // Fine. Just find something with a MAC address
+                // Fallback: Just find something with a MAC address
                 for (var iface : NetworkInterface.networkInterfaces().toList()) {
                     if (iface.isUp() && iface.getHardwareAddress() != null) {
                         return formatMacAddress(iface.getHardwareAddress());
@@ -300,7 +320,81 @@ public class NetworkUtils {
         } catch (Exception e) {
             logger.error("Error getting MAC address", e);
         }
+
+        logger.debug("Fallback to null");
         return "";
+    }
+
+    private static NetworkInterface getInterfaceForRemoteAddress(
+            InetAddress remoteAddress, int remotePort) {
+
+        // Paranoia -- validate remote address
+        if (remoteAddress == null
+                || remoteAddress.isLoopbackAddress()
+                || remoteAddress.isAnyLocalAddress()) {
+            return null;
+        }
+
+        // IPv6 link-local addresses require a scope to be routable
+        if (remoteAddress instanceof Inet6Address v6
+                && v6.isLinkLocalAddress()
+                && v6.getScopeId() == 0) {
+            logger.debug("Cannot route to unscoped IPv6 link-local address: " + remoteAddress);
+            return null;
+        }
+
+        // Trigger routing-table lookup with a connected, non-transmitting UDP socket
+        int port = remotePort > 0 ? remotePort : 9; // discard protocol
+        try (var socket = new DatagramSocket()) {
+            socket.connect(remoteAddress, port);
+
+            InetAddress localAddress = socket.getLocalAddress();
+
+            if (localAddress == null
+                    || localAddress.isAnyLocalAddress()
+                    || localAddress.isLoopbackAddress()) {
+                logger.debug(
+                        "Routing lookup yielded unusable local address "
+                                + localAddress
+                                + " for "
+                                + remoteAddress
+                                + ":"
+                                + remotePort);
+                return null;
+            }
+
+            NetworkInterface iface = NetworkInterface.getByInetAddress(localAddress);
+            if (iface == null) {
+                logger.debug(
+                        "No interface found for local address "
+                                + localAddress
+                                + " (interface may have changed)");
+                return null;
+            }
+
+            // Skip interfaces that have no MAC
+            byte[] mac = iface.getHardwareAddress();
+            if (mac == null || mac.length == 0) {
+                logger.debug(
+                        "Interface "
+                                + iface.getName()
+                                + " has no hardware address (tunnel/virtual?); skipping");
+                return null;
+            }
+
+            return iface;
+
+        } catch (SocketException e) {
+            logger.debug(
+                    "Error resolving local interface for remote address "
+                            + remoteAddress
+                            + ":"
+                            + remotePort
+                            + " ("
+                            + e.toString()
+                            + ")");
+            return null;
+        }
     }
 
     private static String formatMacAddress(byte[] mac) {


### PR DESCRIPTION
## Description

The previous code did not handle various null cases, but more importantly, the non-managed device codepath was totally bjork if the server was not at localhost. This code path is only taken if networking is disabled, and I wasnt able to find any testing outside of localhost:

```
[19:34:04] [2026-04-24 19:34:05] [General - NetworkUtils] [ERROR] java.lang.NullPointerException: Cannot invoke "java.net.NetworkInterface.getHardwareAddress()" because the return value of "java.net.NetworkInterface.getByInetAddress(java.net.InetAddress)" is null
    at org.photonvision.common.networking.NetworkUtils.getMacAddress(NetworkUtils.java:270)
    at org.photonvision.common.dataflow.networktables.NetworkTablesManager.checkHostnameAndCameraNames(NetworkTablesManager.java:249)
    at org.photonvision.common.util.TimedTaskManager$CaughtScheduledThreadPoolExecutor.lambda$wrap$0(TimedTaskManager.java:56)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
    at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:369)
    at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:310)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
    at java.base/java.lang.Thread.run(Thread.java:1474)
```

## Changes

- Open/connect a UDP socket to query local address
- Handle more error cases, weird network interfaces more cleanly

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
