### PR TITLE
Add missing buildAndCopyUI instructions

### DIFF
--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -47,6 +47,30 @@ In the photon-client directory:
 pnpm install
 ```
 
+### Building the UI
+
+In order to properly builf UI changes before running the project, run the following `gradlew` command in the project's root directory:
+
+```{eval-rst}
+.. tab-set::
+
+   .. tab-item:: Linux
+      :sync: linux
+
+      ``./gradlew buildAndCopyUI``
+
+   .. tab-item:: macOS
+      :sync: macos
+
+      ``./gradlew buildAndCopyUI``
+
+   .. tab-item:: Windows (cmd)
+      :sync: windows
+
+      ``gradlew buildAndCopyUI``
+```
+
+
 ### Using hot reload on the UI
 
 In the photon-client directory:

--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -49,7 +49,7 @@ pnpm install
 
 ### Building the UI
 
-In order to properly builf UI changes before running the project, run the following `gradlew` command in the project's root directory:
+In order to properly build UI changes before running the project, run the following `gradlew` command in the project's root directory:
 
 ```{eval-rst}
 .. tab-set::


### PR DESCRIPTION
## Description

What changed? Why? (the code + comments should speak for itself on the "how")
Adds `./gradlew buildAndCopyUI` instruction to the documentation on building Photonvision, to clarify that this step must be ran to properly build the UI

Closes #2452

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
