### PR TITLE
switched to shared cleaners in object detectors

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/objects/RknnObjectDetector.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/RknnObjectDetector.java
@@ -33,7 +33,6 @@ import org.photonvision.vision.pipe.impl.NeuralNetworkPipeResult;
 public class RknnObjectDetector implements ObjectDetector {
     private static final Logger logger = new Logger(RknnObjectDetector.class, LogGroup.General);
 
-    /** Cleaner instance to release the detector when it goes out of scope */
     private static final Cleaner cleaner = Cleaner.create();
 
     private final Cleanable cleanable;

--- a/photon-core/src/main/java/org/photonvision/vision/objects/RknnObjectDetector.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/RknnObjectDetector.java
@@ -34,7 +34,7 @@ public class RknnObjectDetector implements ObjectDetector {
     private static final Logger logger = new Logger(RknnObjectDetector.class, LogGroup.General);
 
     /** Cleaner instance to release the detector when it goes out of scope */
-    private final Cleaner cleaner = Cleaner.create();
+    private static final Cleaner cleaner = Cleaner.create();
 
     private final Cleanable cleanable;
 

--- a/photon-core/src/main/java/org/photonvision/vision/objects/RubikObjectDetector.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/RubikObjectDetector.java
@@ -33,8 +33,7 @@ import org.photonvision.vision.pipe.impl.NeuralNetworkPipeResult;
 public class RubikObjectDetector implements ObjectDetector {
     private static final Logger logger = new Logger(RubikObjectDetector.class, LogGroup.General);
 
-    /** Cleaner instance to release the detector when it goes out of scope */
-    private final Cleaner cleaner = Cleaner.create();
+    private static final Cleaner cleaner = Cleaner.create();
 
     private final Cleanable cleanable;
 


### PR DESCRIPTION
## Description

The Object detector classes now share a static cleaner instance across all instances, rather than instantiating a new cleaner instance with every object. JVM documentation recommends using shared cleaner instances https://docs.oracle.com/en/java/javase/21/gctuning/other-considerations.html

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
