### PR TITLE
Fix windows build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'org.wpilib.GradleJni' version '2027.0.0'
     id "org.ysb33r.doxygen" version "2.0.0" apply false
     id 'com.gradleup.shadow' version '9.0.0' apply false
-    id "com.github.node-gradle.node" version "7.0.1" apply false
+    id "com.github.node-gradle.node" version "7.1.0" apply false
 }
 
 allprojects {

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -42,6 +42,8 @@ shadowJar {
 }
 
 node {
+    version = '24'
+    pnpmVersion = '11'
     nodeProjectDir = file("${projectDir}/../photon-client")
 }
 


### PR DESCRIPTION
We're seeing CI failures in #2479, ~~trying to figure out where that's coming from~~

looks like pnpm updated out from under us, and we didn't have it pinned. We're now pinning it to 11, and we've updated the relevant build-scripts that need to be approved.