### PR TITLE
Approve dependencies in pnpm and pin pnpm version in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'org.wpilib.GradleJni' version '2027.0.0'
     id "org.ysb33r.doxygen" version "2.0.0" apply false
     id 'com.gradleup.shadow' version '9.0.0' apply false
-    id "com.github.node-gradle.node" version "7.0.1" apply false
+    id "com.github.node-gradle.node" version "7.1.0" apply false
 }
 
 allprojects {

--- a/photon-client/pnpm-workspace.yaml
+++ b/photon-client/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -43,6 +43,7 @@ shadowJar {
 
 node {
     nodeProjectDir = file("${projectDir}/../photon-client")
+    pnpmVersion = "11.0.9"
 }
 
 tasks.register('copyClientUIToResources', Copy) {


### PR DESCRIPTION
## Description

Fixes failure in #2481. The pnpm version was unpinned, so it quietly moved to pnpm 11, which introduced several breaking changes including [one with approved builds](https://pnpm.io/blog/releases/11.0#security--build-defaults) (specifically, [`strictDepBuilds`](https://pnpm.io/settings#strictdepbuilds)). Since we're on pnpm 11 anyways, use their new system for approving postinstalls for certain dependencies.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
