### PR TITLE
refactor OD model UID to path

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
@@ -283,7 +283,7 @@ public class NeuralNetworkModelManager {
      * @param modelUID the unique identifier of the model to retrieve
      * @return an Optional containing the model if found, or an empty Optional if not found
      */
-    public Optional<Model> getModel(String modelUID) {
+    public Optional<Model> getModel(Path modelUID) {
         if (models == null) {
             return Optional.empty();
         }

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
@@ -292,7 +292,7 @@ public class NeuralNetworkModelManager {
         for (Family backend : supportedBackends) {
             if (models.containsKey(backend)) {
                 Optional<Model> model =
-                        models.get(backend).stream().filter(m -> m.getUID().equals(modelUID)).findFirst();
+                        models.get(backend).stream().filter(m -> m.getPath().equals(modelUID)).findFirst();
                 if (model.isPresent()) {
                     return model;
                 }
@@ -406,7 +406,8 @@ public class NeuralNetworkModelManager {
         // After loading all of the models, sort them by name to ensure a consistent
         // ordering
         models.forEach(
-                (backend, backendModels) -> backendModels.sort((a, b) -> a.getUID().compareTo(b.getUID())));
+                (backend, backendModels) ->
+                        backendModels.sort((a, b) -> a.getPath().compareTo(b.getPath())));
 
         // Log
         StringBuilder sb = new StringBuilder();
@@ -414,7 +415,7 @@ public class NeuralNetworkModelManager {
         models.forEach(
                 (backend, backendModels) -> {
                     sb.append(backend).append(" [");
-                    backendModels.forEach(model -> sb.append(model.getUID()).append(", "));
+                    backendModels.forEach(model -> sb.append(model.getPath()).append(", "));
                     sb.append("] ");
                 });
     }

--- a/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/NeuralNetworkModelManager.java
@@ -280,10 +280,10 @@ public class NeuralNetworkModelManager {
      *
      * <p>If this method returns `Optional.of(..)` then the model should be safe to load.
      *
-     * @param modelUID the unique identifier of the model to retrieve
+     * @param modelPath the unique identifier of the model to retrieve
      * @return an Optional containing the model if found, or an empty Optional if not found
      */
-    public Optional<Model> getModel(Path modelUID) {
+    public Optional<Model> getModel(Path modelPath) {
         if (models == null) {
             return Optional.empty();
         }
@@ -292,7 +292,7 @@ public class NeuralNetworkModelManager {
         for (Family backend : supportedBackends) {
             if (models.containsKey(backend)) {
                 Optional<Model> model =
-                        models.get(backend).stream().filter(m -> m.getPath().equals(modelUID)).findFirst();
+                        models.get(backend).stream().filter(m -> m.getPath().equals(modelPath)).findFirst();
                 if (model.isPresent()) {
                     return model;
                 }

--- a/photon-core/src/main/java/org/photonvision/vision/objects/Model.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/Model.java
@@ -17,13 +17,14 @@
 
 package org.photonvision.vision.objects;
 
+import java.nio.file.Path;
 import org.photonvision.common.configuration.NeuralNetworkModelManager.Family;
 import org.photonvision.common.configuration.NeuralNetworkModelsSettings.ModelProperties;
 
 public interface Model {
     public ObjectDetector load();
 
-    public String getUID();
+    public Path getUID();
 
     public String getNickname();
 

--- a/photon-core/src/main/java/org/photonvision/vision/objects/Model.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/Model.java
@@ -24,7 +24,12 @@ import org.photonvision.common.configuration.NeuralNetworkModelsSettings.ModelPr
 public interface Model {
     public ObjectDetector load();
 
-    public Path getUID();
+    /**
+     * Gets the path to the model file. This is being used as a UID.
+     *
+     * @return the path to the model file (for use as a UID)
+     */
+    public Path getPath();
 
     public String getNickname();
 

--- a/photon-core/src/main/java/org/photonvision/vision/objects/NullModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/NullModel.java
@@ -17,6 +17,7 @@
 
 package org.photonvision.vision.objects;
 
+import java.nio.file.Path;
 import java.util.List;
 import org.opencv.core.Mat;
 import org.photonvision.common.configuration.NeuralNetworkModelManager.Family;
@@ -43,8 +44,8 @@ public class NullModel implements Model, ObjectDetector {
     }
 
     @Override
-    public String getUID() {
-        return "NullModel";
+    public Path getUID() {
+        return Path.of("null");
     }
 
     @Override

--- a/photon-core/src/main/java/org/photonvision/vision/objects/NullModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/NullModel.java
@@ -44,7 +44,7 @@ public class NullModel implements Model, ObjectDetector {
     }
 
     @Override
-    public Path getUID() {
+    public Path getPath() {
         return Path.of("null");
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/objects/RknnModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/RknnModel.java
@@ -18,6 +18,7 @@
 package org.photonvision.vision.objects;
 
 import java.io.File;
+import java.nio.file.Path;
 import org.opencv.core.Size;
 import org.photonvision.common.configuration.NeuralNetworkModelManager.Family;
 import org.photonvision.common.configuration.NeuralNetworkModelManager.Version;
@@ -61,8 +62,8 @@ public class RknnModel implements Model {
     }
 
     /** Return the unique identifier for the model. In this case, it's the model's path. */
-    public String getUID() {
-        return properties.modelPath().toString();
+    public Path getUID() {
+        return properties.modelPath();
     }
 
     public String getNickname() {

--- a/photon-core/src/main/java/org/photonvision/vision/objects/RknnModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/RknnModel.java
@@ -62,7 +62,7 @@ public class RknnModel implements Model {
     }
 
     /** Return the unique identifier for the model. In this case, it's the model's path. */
-    public Path getUID() {
+    public Path getPath() {
         return properties.modelPath();
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/objects/RubikModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/RubikModel.java
@@ -60,7 +60,7 @@ public class RubikModel implements Model {
     }
 
     /** Return the unique identifier for the model. In this case, it's the model's path. */
-    public Path getUID() {
+    public Path getPath() {
         return properties.modelPath();
     }
 

--- a/photon-core/src/main/java/org/photonvision/vision/objects/RubikModel.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/RubikModel.java
@@ -18,6 +18,7 @@
 package org.photonvision.vision.objects;
 
 import java.io.File;
+import java.nio.file.Path;
 import org.opencv.core.Size;
 import org.photonvision.common.configuration.NeuralNetworkModelManager.Family;
 import org.photonvision.common.configuration.NeuralNetworkModelManager.Version;
@@ -59,8 +60,8 @@ public class RubikModel implements Model {
     }
 
     /** Return the unique identifier for the model. In this case, it's the model's path. */
-    public String getUID() {
-        return properties.modelPath().toString();
+    public Path getUID() {
+        return properties.modelPath();
     }
 
     public String getNickname() {

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/ObjectDetectionPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/ObjectDetectionPipeline.java
@@ -57,8 +57,7 @@ public class ObjectDetectionPipeline
     protected void setPipeParamsImpl() {
         Optional<Model> selectedModel =
                 settings.model != null
-                        ? NeuralNetworkModelManager.getInstance()
-                                .getModel(settings.model.modelPath().toString())
+                        ? NeuralNetworkModelManager.getInstance().getModel(settings.model.modelPath())
                         : Optional.empty();
 
         // If the desired model couldn't be found, log an error and try to use the default model


### PR DESCRIPTION
closes #2473

The current OD model UID is a string, but in the manager it's treated as a path. It makes sense to change the definition here too, so we're doing that to make it simpler and more consistent.
