### PR TITLE
Throw errors for doxygen warnings

### DIFF
--- a/photon-docs/build.gradle
+++ b/photon-docs/build.gradle
@@ -48,7 +48,7 @@ doxygen.sourceSets.main {
         }
     }
     option 'case_sense_names', false
-    option 'extension_mapping', 'inc=C++ no_extension=C++'
+    option 'extension_mapping', ['inc=C++', 'no_extension=C++']
     option 'extract_all', true
     option 'extract_static', true
     option 'file_patterns', '*'

--- a/photon-docs/build.gradle
+++ b/photon-docs/build.gradle
@@ -81,9 +81,7 @@ doxygen.sourceSets.main {
             "\"__cplusplus\"\\\n" +
             "\"HAL_ENUM(name)=enum name : int32_t"
 
-    if (project.hasProperty('docWarningsAsErrors')) {
-        warn_as_error 'FAIL_ON_WARNINGS'
-    }
+    option 'warn_as_error', 'FAIL_ON_WARNINGS'
 }
 
 tasks.register("zipCppDocs", Zip) {

--- a/photon-lib/src/main/native/include/photon/PhotonCamera.h
+++ b/photon-lib/src/main/native/include/photon/PhotonCamera.h
@@ -60,7 +60,7 @@ class PhotonCamera {
    *
    * @param instance The NetworkTableInstance to pull data from. This can be a
    * custom instance in simulation, but should *usually* be the default
-   * NTInstance from {@link NetworkTableInstance::getDefault}
+   * NTInstance from @ref NetworkTableInstance::getDefault
    * @param cameraName The name of the camera, as seen in the UI.
    * over.
    */

--- a/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
@@ -234,7 +234,7 @@ class PhotonPoseEstimator {
    * due to the RIO's weak computing power.
    *
    * @param cameraResult A pipeline result from the camera.
-  * @param camMat Camera intrinsics from camera calibration data.
+   * @param camMat Camera intrinsics from camera calibration data.
    * @param distCoeffs Distortion coefficients from camera calibration data.
    * @return An EstimatedRobotPose with an estimated pose, timestamp, and
    * targets used to create the estimate, or std::nullopt if there's less than 2

--- a/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
+++ b/photon-lib/src/main/native/include/photon/PhotonPoseEstimator.h
@@ -234,7 +234,7 @@ class PhotonPoseEstimator {
    * due to the RIO's weak computing power.
    *
    * @param cameraResult A pipeline result from the camera.
-   * @param cameraMatrix Camera intrinsics from camera calibration data.
+  * @param camMat Camera intrinsics from camera calibration data.
    * @param distCoeffs Distortion coefficients from camera calibration data.
    * @return An EstimatedRobotPose with an estimated pose, timestamp, and
    * targets used to create the estimate, or std::nullopt if there's less than 2

--- a/photon-lib/src/main/native/include/photon/PhotonUtils.h
+++ b/photon-lib/src/main/native/include/photon/PhotonUtils.h
@@ -73,16 +73,16 @@ class PhotonUtils {
   /**
    * Estimate the position of the robot in the field.
    *
-   * @param cameraHeightMeters The physical height of the camera off the floor
-   * in meters.
-   * @param targetHeightMeters The physical height of the target off the floor
-   * in meters. This should be the height of whatever is being targeted (i.e. if
+  * @param cameraHeight The physical height of the camera off the floor in
+  * meters.
+  * @param targetHeight The physical height of the target off the floor in
+  * meters. This should be the height of whatever is being targeted (i.e. if
    * the targeting region is set to top, this should be the height of the top of
    * the target).
-   * @param cameraPitchRadians The pitch of the camera from the horizontal plane
-   *                           in radians. Positive values up.
-   * @param targetPitchRadians The pitch of the target in the camera's lens in
-   *                           radians. Positive values up.
+  * @param cameraPitch The pitch of the camera from the horizontal plane in
+  * radians. Positive values up.
+  * @param targetPitch The pitch of the target in the camera's lens in radians.
+  * Positive values up.
    * @param targetYaw          The observed yaw of the target. Note that this
    *                           *must* be CCW-positive, and Photon returns
    *                           CW-positive.

--- a/photon-lib/src/main/native/include/photon/PhotonUtils.h
+++ b/photon-lib/src/main/native/include/photon/PhotonUtils.h
@@ -115,7 +115,7 @@ class PhotonUtils {
   }
 
   /**
-   * Estimates a {@link wpi::math::Transform2d} that maps the camera position to
+   * Estimates a @ref wpi::math::Transform2d that maps the camera position to
    * the target position, using the robot's gyro. Note that the gyro angle
    * provided *must* line up with the field coordinate system -- that is, it
    * should read zero degrees when pointed towards the opposing alliance

--- a/photon-lib/src/main/native/include/photon/PhotonUtils.h
+++ b/photon-lib/src/main/native/include/photon/PhotonUtils.h
@@ -73,16 +73,16 @@ class PhotonUtils {
   /**
    * Estimate the position of the robot in the field.
    *
-  * @param cameraHeight The physical height of the camera off the floor in
-  * meters.
-  * @param targetHeight The physical height of the target off the floor in
-  * meters. This should be the height of whatever is being targeted (i.e. if
+   * @param cameraHeight The physical height of the camera off the floor in
+   * meters.
+   * @param targetHeight The physical height of the target off the floor in
+   * meters. This should be the height of whatever is being targeted (i.e. if
    * the targeting region is set to top, this should be the height of the top of
    * the target).
-  * @param cameraPitch The pitch of the camera from the horizontal plane in
-  * radians. Positive values up.
-  * @param targetPitch The pitch of the target in the camera's lens in radians.
-  * Positive values up.
+   * @param cameraPitch The pitch of the camera from the horizontal plane in
+   * radians. Positive values up.
+   * @param targetPitch The pitch of the target in the camera's lens in radians.
+   * Positive values up.
    * @param targetYaw          The observed yaw of the target. Note that this
    *                           *must* be CCW-positive, and Photon returns
    *                           CW-positive.

--- a/photon-lib/src/main/native/include/photon/simulation/PhotonCameraSim.h
+++ b/photon-lib/src/main/native/include/photon/simulation/PhotonCameraSim.h
@@ -64,7 +64,7 @@ class PhotonCameraSim {
    * maximum sight range.
    *
    * @param camera The camera to be simulated
-   * @param prop Properties of this camera such as FOV and FPS
+  * @param props Properties of this camera such as FOV and FPS
    * @param tagLayout The AprilTagFieldLayout used to solve for tag
    * positions.
    */
@@ -79,7 +79,7 @@ class PhotonCameraSim {
    * PhotonCamera's results.
    *
    * @param camera The camera to be simulated
-   * @param prop Properties of this camera such as FOV and FPS
+  * @param props Properties of this camera such as FOV and FPS
    * @param minTargetAreaPercent The minimum percentage (0 - 100) a detected
    * target must take up of the camera's image to be processed. Match this with
    * your contour filtering settings in the PhotonVision GUI.
@@ -182,7 +182,7 @@ class PhotonCameraSim {
    * Sets the maximum distance at which the target is illuminated to your
    * camera. Note that minimum target area of the image is separate from this.
    *
-   * @param rangeMeters The distance
+  * @param range The distance
    */
   inline void SetMaxSightRange(wpi::units::meter_t range) {
     maxSightRange = range;

--- a/photon-lib/src/main/native/include/photon/simulation/PhotonCameraSim.h
+++ b/photon-lib/src/main/native/include/photon/simulation/PhotonCameraSim.h
@@ -64,7 +64,7 @@ class PhotonCameraSim {
    * maximum sight range.
    *
    * @param camera The camera to be simulated
-  * @param props Properties of this camera such as FOV and FPS
+   * @param props Properties of this camera such as FOV and FPS
    * @param tagLayout The AprilTagFieldLayout used to solve for tag
    * positions.
    */
@@ -79,7 +79,7 @@ class PhotonCameraSim {
    * PhotonCamera's results.
    *
    * @param camera The camera to be simulated
-  * @param props Properties of this camera such as FOV and FPS
+   * @param props Properties of this camera such as FOV and FPS
    * @param minTargetAreaPercent The minimum percentage (0 - 100) a detected
    * target must take up of the camera's image to be processed. Match this with
    * your contour filtering settings in the PhotonVision GUI.
@@ -182,7 +182,7 @@ class PhotonCameraSim {
    * Sets the maximum distance at which the target is illuminated to your
    * camera. Note that minimum target area of the image is separate from this.
    *
-  * @param range The distance
+   * @param range The distance
    */
   inline void SetMaxSightRange(wpi::units::meter_t range) {
     maxSightRange = range;

--- a/photon-lib/src/main/native/include/photon/simulation/SimCameraProperties.h
+++ b/photon-lib/src/main/native/include/photon/simulation/SimCameraProperties.h
@@ -216,8 +216,8 @@ class SimCameraProperties {
    * The pitch from the principal point of this camera to the pixel y value.
    * Pitch is positive down.
    *
-   * Note that this angle is naively computed and may be incorrect. See
-   * #getCorrectedPixelRot(const cv::Point2d).
+  * Note that this angle is naively computed and may be incorrect. See
+  * \ref GetCorrectedPixelRot "GetCorrectedPixelRot()".
    */
   wpi::math::Rotation2d GetPixelPitch(double pixelY) const {
     double fy = camIntrinsics(1, 1);
@@ -229,8 +229,8 @@ class SimCameraProperties {
    * Finds the yaw and pitch to the given image point. Yaw is positive left, and
    * pitch is positive down.
    *
-   * Note that pitch is naively computed and may be incorrect. See
-   * #getCorrectedPixelRot(const cv::Point2d).
+  * Note that pitch is naively computed and may be incorrect. See
+  * \ref GetCorrectedPixelRot "GetCorrectedPixelRot()".
    */
   wpi::math::Rotation3d GetPixelRot(const cv::Point2d& point) const {
     return wpi::math::Rotation3d{0_rad, GetPixelPitch(point.y).Radians(),

--- a/photon-lib/src/main/native/include/photon/simulation/SimCameraProperties.h
+++ b/photon-lib/src/main/native/include/photon/simulation/SimCameraProperties.h
@@ -247,7 +247,7 @@ class SimCameraProperties {
    * to be confused with lens distortion)-- for example, the pitch angle is
    * naively calculated as:
    *
-   * <pre>pitch = arctan(pixel y offset / focal length y)<pre>
+  * <pre>pitch = arctan(pixel y offset / focal length y)</pre>
    *
    * However, using focal length as a side of the associated right triangle is
    * not correct when the pixel x value is not 0, because the distance from this

--- a/photon-lib/src/main/native/include/photon/simulation/SimCameraProperties.h
+++ b/photon-lib/src/main/native/include/photon/simulation/SimCameraProperties.h
@@ -216,8 +216,8 @@ class SimCameraProperties {
    * The pitch from the principal point of this camera to the pixel y value.
    * Pitch is positive down.
    *
-  * Note that this angle is naively computed and may be incorrect. See
-  * \ref GetCorrectedPixelRot "GetCorrectedPixelRot()".
+   * Note that this angle is naively computed and may be incorrect. See
+   * \ref GetCorrectedPixelRot "GetCorrectedPixelRot()".
    */
   wpi::math::Rotation2d GetPixelPitch(double pixelY) const {
     double fy = camIntrinsics(1, 1);
@@ -229,8 +229,8 @@ class SimCameraProperties {
    * Finds the yaw and pitch to the given image point. Yaw is positive left, and
    * pitch is positive down.
    *
-  * Note that pitch is naively computed and may be incorrect. See
-  * \ref GetCorrectedPixelRot "GetCorrectedPixelRot()".
+   * Note that pitch is naively computed and may be incorrect. See
+   * \ref GetCorrectedPixelRot "GetCorrectedPixelRot()".
    */
   wpi::math::Rotation3d GetPixelRot(const cv::Point2d& point) const {
     return wpi::math::Rotation3d{0_rad, GetPixelPitch(point.y).Radians(),
@@ -247,7 +247,7 @@ class SimCameraProperties {
    * to be confused with lens distortion)-- for example, the pitch angle is
    * naively calculated as:
    *
-  * <pre>pitch = arctan(pixel y offset / focal length y)</pre>
+   * <pre>pitch = arctan(pixel y offset / focal length y)</pre>
    *
    * However, using focal length as a side of the associated right triangle is
    * not correct when the pixel x value is not 0, because the distance from this

--- a/photon-lib/src/main/native/include/photon/simulation/VideoSimUtil.h
+++ b/photon-lib/src/main/native/include/photon/simulation/VideoSimUtil.h
@@ -513,7 +513,8 @@ static std::vector<std::vector<cv::Point2f>> PolyFrom3dLines(
  * @param floorSubdivisions A NxN "grid" is created from the floor where this
  * parameter is N, which defines the floor lines.
  * @param floorThickness Thickness of the lines used for drawing the field floor
- * grid in pixels. This is scaled by \ref GetScaledThickness "GetScaledThickness()".
+ * grid in pixels. This is scaled by \ref GetScaledThickness
+ * "GetScaledThickness()".
  * @param floorColor Color of the lines used for drawing the field floor grid.
  * @param destination The destination image to draw to.
  */

--- a/photon-lib/src/main/native/include/photon/simulation/VideoSimUtil.h
+++ b/photon-lib/src/main/native/include/photon/simulation/VideoSimUtil.h
@@ -508,12 +508,12 @@ static std::vector<std::vector<cv::Point2f>> PolyFrom3dLines(
  * diagonal length in pixels. Line segments will be subdivided if they exceed
  * this resolution.
  * @param wallThickness Thickness of the lines used for drawing the field walls
- * in pixels. This is scaled by #getScaledThickness(double, cv::Mat).
+ * in pixels. This is scaled by \ref GetScaledThickness "GetScaledThickness()".
  * @param wallColor Color of the lines used for drawing the field walls.
  * @param floorSubdivisions A NxN "grid" is created from the floor where this
  * parameter is N, which defines the floor lines.
  * @param floorThickness Thickness of the lines used for drawing the field floor
- * grid in pixels. This is scaled by #getScaledThickness(double, cv::Mat).
+ * grid in pixels. This is scaled by \ref GetScaledThickness "GetScaledThickness()".
  * @param floorColor Color of the lines used for drawing the field floor grid.
  * @param destination The destination image to draw to.
  */

--- a/photon-lib/src/main/native/include/photon/simulation/VisionSystemSim.h
+++ b/photon-lib/src/main/native/include/photon/simulation/VisionSystemSim.h
@@ -331,9 +331,10 @@ class VisionSystemSim {
   /**
    * Removes every VisionTargetSim of the specified type from the simulated
    * field.
-  *
-  * @param type Type of target (e.g. "cargo"). Same as the type passed into
-  *  \ref AddVisionTargets "AddVisionTargets(std::string, const std::vector<VisionTargetSim>&)"
+   *
+   * @param type Type of target (e.g. "cargo"). Same as the type passed into
+   *  \ref AddVisionTargets "AddVisionTargets(std::string, const
+   * std::vector<VisionTargetSim>&)"
    */
   void RemoveVisionTargets(std::string type) { targetSets.erase(type); }
 
@@ -404,7 +405,7 @@ class VisionSystemSim {
    * Periodic update. Ensure this is called repeatedly-- camera performance is
    * used to automatically determine if a new frame should be submitted.
    *
-  * @param robotPose The simulated robot pose in meters
+   * @param robotPose The simulated robot pose in meters
    */
   void Update(const wpi::math::Pose2d& robotPose) {
     Update(wpi::math::Pose3d{robotPose});
@@ -414,7 +415,7 @@ class VisionSystemSim {
    * Periodic update. Ensure this is called repeatedly-- camera performance is
    * used to automatically determine if a new frame should be submitted.
    *
-  * @param robotPose The simulated robot pose in meters
+   * @param robotPose The simulated robot pose in meters
    */
   void Update(const wpi::math::Pose3d& robotPose) {
     for (auto& set : targetSets) {

--- a/photon-lib/src/main/native/include/photon/simulation/VisionSystemSim.h
+++ b/photon-lib/src/main/native/include/photon/simulation/VisionSystemSim.h
@@ -331,9 +331,9 @@ class VisionSystemSim {
   /**
    * Removes every VisionTargetSim of the specified type from the simulated
    * field.
-   *
-   * @param type Type of target (e.g. "cargo"). Same as the type passed into
-   *  #addVisionTargets(String, VisionTargetSim...)
+  *
+  * @param type Type of target (e.g. "cargo"). Same as the type passed into
+  *  \ref AddVisionTargets "AddVisionTargets(std::string, const std::vector<VisionTargetSim>&)"
    */
   void RemoveVisionTargets(std::string type) { targetSets.erase(type); }
 

--- a/photon-lib/src/main/native/include/photon/simulation/VisionSystemSim.h
+++ b/photon-lib/src/main/native/include/photon/simulation/VisionSystemSim.h
@@ -334,8 +334,6 @@ class VisionSystemSim {
    *
    * @param type Type of target (e.g. "cargo"). Same as the type passed into
    *  #addVisionTargets(String, VisionTargetSim...)
-   * @return The removed targets, or null if no targets of the specified type
-   * exist
    */
   void RemoveVisionTargets(std::string type) { targetSets.erase(type); }
 
@@ -406,7 +404,7 @@ class VisionSystemSim {
    * Periodic update. Ensure this is called repeatedly-- camera performance is
    * used to automatically determine if a new frame should be submitted.
    *
-   * @param robotPoseMeters The simulated robot pose in meters
+  * @param robotPose The simulated robot pose in meters
    */
   void Update(const wpi::math::Pose2d& robotPose) {
     Update(wpi::math::Pose3d{robotPose});
@@ -416,7 +414,7 @@ class VisionSystemSim {
    * Periodic update. Ensure this is called repeatedly-- camera performance is
    * used to automatically determine if a new frame should be submitted.
    *
-   * @param robotPoseMeters The simulated robot pose in meters
+  * @param robotPose The simulated robot pose in meters
    */
   void Update(const wpi::math::Pose3d& robotPose) {
     for (auto& set : targetSets) {


### PR DESCRIPTION
Throw errors for any warnings we find generating the C++ docs for photonlib. Also fixes some out of date docs