### PR TITLE
fix(libcamera): publish mid-exposure timestamp

### DIFF
--- a/docs/source/docs/contributing/design-descriptions/e2e-latency.md
+++ b/docs/source/docs/contributing/design-descriptions/e2e-latency.md
@@ -37,6 +37,8 @@ I'm sure that we'll find a camera that doesn't play nice, because we can't have 
 
 Other things to note: This gets us an estimate at when the camera *started* collecting photons. The camera's sensor will remain collecting light for up to the total integration time, plus readout time for rolling shutter cameras.
 
+For the libcamera capture path, PhotonVision now applies a mid-exposure correction using the per-frame `ExposureTime` metadata from libcamera. The published timestamp is the midpoint of the integration window for global-shutter sensors. Rolling-shutter sensors have a residual row-dependent bias not yet corrected. If libcamera does not populate `ExposureTime` for a given frame, the driver returns 0 and the correction is skipped (behaviour matches the pre-correction code path).
+
 ## Latency Testing
 
 Here, I've got a RoboRIO with an LED, an Orange Pi 5, and a network switch on a test bench. The LED is assumed to turn on basically instantly once we apply current, and based on DMA testing, the total time to switch a digital output on is on the order of 10uS. The RoboRIO is running a TimeSync Server, and the Orange Pi is running a TimeSync Client.

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
@@ -85,6 +85,7 @@ public class LibcameraGpuFrameProvider extends FrameProvider {
 
             var now = LibCameraJNI.getLibcameraTimestamp();
             var capture = LibCameraJNI.getFrameCaptureTime(p_ptr);
+            var exposureUs = LibCameraJNI.getFrameExposureTimeUs(p_ptr);
             var latency = (now - capture);
 
             LibCameraJNI.releasePair(p_ptr);
@@ -92,12 +93,19 @@ public class LibcameraGpuFrameProvider extends FrameProvider {
             // Know frame is good -- increment sequence
             ++sequenceID;
 
+            // libcamera's SensorTimestamp marks start-of-exposure. The scene the
+            // detector integrates over spans [SOE, SOE+exposure], so mid-exposure
+            // is the closest single-instant approximation. When the driver
+            // returns 0, ExposureTime metadata was unavailable for this frame
+            // and we leave the timestamp uncorrected.
+            long midExposureCorrectionNs = exposureUs > 0 ? (exposureUs * 1000L) / 2L : 0L;
+
             return new Frame(
                     sequenceID,
                     colorMat,
                     processedMat,
                     type,
-                    MathUtils.wpiNanoTime() - latency,
+                    MathUtils.wpiNanoTime() - latency + midExposureCorrectionNs,
                     settables.getFrameStaticProperties().rotate(settables.getRotation()));
         }
     }


### PR DESCRIPTION
## Why

PhotonVision's libcamera path currently publishes the start-of-exposure timestamp from `libcamera::controls::SensorTimestamp` directly. The scene a detector integrates over spans `[SOE, SOE+exposure]`, so the closest single-instant approximation is the midpoint of that window. The existing [e2e-latency design doc](docs/source/docs/contributing/design-descriptions/e2e-latency.md) already acknowledges this residual ("sensor will remain collecting light for up to the total integration time").

Magnitude at typical FRC exposures (~5–15 ms): a 2.5–7.5 ms earlier-bias is removed, which is ~12–37 mm of pose error at 5 m/s drive speed.

## What

- `LibcameraGpuFrameProvider`: read `getFrameExposureTimeUs` and add `exposure/2` (ns) to the published timestamp.
- When the driver returns `0` (libcamera did not populate `ExposureTime` for the frame), the correction is skipped and behaviour matches today.
- `e2e-latency.md`: documents the new behaviour and the rolling-shutter caveat.

## Dependency

Requires PhotonVision/photon-libcamera-gl-driver#33 (the paired JNI surface). That PR must merge and a driver release that bumps `libcameraDriverVersion` in `build.gradle` must land before this PR compiles against the upstream Maven artifact. Local smoke build was verified with `./gradlew publishToMavenLocal` on the driver branch.

## Scope notes

- libcamera path only. The V4L/USB path has separate caveats around proprietary exposure scales (some Arducam V4L drivers) and unreliable per-frame metadata under auto-exposure, and is explicitly out of scope.
- No feature flag — the `driver-returns-0` fallback already covers the unsupported-sensor case, so a config toggle would be redundant.
- Residual row-dependent bias on rolling-shutter sensors is not corrected here.