### PR TITLE
docs(photon-targeting): correct PhotonPipelineMetadata timestamp Javadocs

### DIFF
--- a/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
+++ b/photon-lib/py/photonlibpy/targeting/photonPipelineResult.py
@@ -11,8 +11,9 @@ if TYPE_CHECKING:
 
 @dataclass
 class PhotonPipelineMetadata:
-    # Image capture and NT publish timestamp, in microseconds and in the coprocessor timebase. As
-    # reported by WPIUtilJNI::now.
+    # Image capture and NT publish timestamp, in microseconds and in the Time Sync Server's
+    # timebase (wpi::nt::Now). The robot shall run a server, so this is FPGA-relative on a real
+    # robot. NTDataPublisher applies the time-sync offset before publishing.
     captureTimestampMicros: int = -1
     publishTimestampMicros: int = -1
 

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineMetadata.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineMetadata.java
@@ -58,9 +58,9 @@ public class PhotonPipelineMetadata implements PhotonStructSerializable<PhotonPi
     }
 
     /**
-     * The time that this image was captured, in microseconds and in the Time Sync Server's time
-     * base ({@code wpi::nt::Now}). The robot shall run a server, so this is FPGA-relative on a real
-     * robot. NTDataPublisher applies the time-sync offset before publishing.
+     * The time that this image was captured, in microseconds and in the Time Sync Server's time base
+     * ({@code wpi::nt::Now}). The robot shall run a server, so this is FPGA-relative on a real robot.
+     * NTDataPublisher applies the time-sync offset before publishing.
      *
      * @return The time in microseconds
      */

--- a/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineMetadata.java
+++ b/photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineMetadata.java
@@ -58,7 +58,9 @@ public class PhotonPipelineMetadata implements PhotonStructSerializable<PhotonPi
     }
 
     /**
-     * The time that this image was captured, in the coprocessor's time base.
+     * The time that this image was captured, in microseconds and in the Time Sync Server's time
+     * base ({@code wpi::nt::Now}). The robot shall run a server, so this is FPGA-relative on a real
+     * robot. NTDataPublisher applies the time-sync offset before publishing.
      *
      * @return The time in microseconds
      */
@@ -67,7 +69,9 @@ public class PhotonPipelineMetadata implements PhotonStructSerializable<PhotonPi
     }
 
     /**
-     * The time that this result was published to NT, in the coprocessor's time base.
+     * The time that this result was published to NT, in microseconds and in the Time Sync Server's
+     * time base ({@code wpi::nt::Now}). The robot shall run a server, so this is FPGA-relative on a
+     * real robot. NTDataPublisher applies the time-sync offset before publishing.
      *
      * @return The time in microseconds
      */


### PR DESCRIPTION
## Summary

The getter Javadocs on `PhotonPipelineMetadata` claim the timestamp fields are in **the coprocessor's time base**, but that's not what's on the wire:

- [PhotonPipelineMetadata.java:60-66](photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineMetadata.java#L60-L66): *"The time that this image was captured, in the coprocessor's time base."*
- [PhotonPipelineMetadata.java:68-74](photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineMetadata.java#L68-L74): *"The time that this result was published to NT, in the coprocessor's time base."*

[NTDataPublisher.java:200-211](photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java#L200-L211) adds the `TimeSyncClient` offset to both values before publishing, with the in-line comment *"Transform the metadata timestamps from the local wpi::nt::Now timebase to the Time Sync Server's timebase"*. The field-level comment at [PhotonPipelineMetadata.java:25-26](photon-targeting/src/main/java/org/photonvision/targeting/PhotonPipelineMetadata.java#L25-L26) already correctly says *"The timebase is `wpi::nt::Now` on the time sync server."*

So the field-level prose is right; the getter Javadocs (which users actually see in IDE autocomplete + online API docs) are stale. A user trusting the getter docs would build the wrong FPGA conversion on the robot side.

## Fix

Aligns the two getter Javadocs with the field-level truth. Same fix for the equivalent per-field comment in the Python port ([photonPipelineResult.py:13-15](photon-lib/py/photonlibpy/targeting/photonPipelineResult.py#L13-L15)).

No code, behavior, or test changes.

## Test plan

- [x] Documentation-only — no build risk

## Related

- #2496 (in-flight) rewrote the `getTimestampSeconds()` Javadocs to say *"Time Sync Server's time base"* — this PR makes the field-level getter Javadocs match. Either PR can land first; they're independent.