### PR TITLE
Don't crash if libcamera fails to load

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/csi/LibcameraGpuSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/csi/LibcameraGpuSettables.java
@@ -63,7 +63,14 @@ public class LibcameraGpuSettables extends VisionSourceSettables {
 
         videoModes = new HashMap<>();
 
-        sensorModel = LibCameraJNI.getSensorModel(configuration.matchedCameraInfo.path());
+        LibCameraJNI.SensorModel tempSensorModel;
+        try {
+            tempSensorModel = LibCameraJNI.getSensorModel(configuration.matchedCameraInfo.path());
+        } catch (UnsatisfiedLinkError e) {
+            logger.error("Unable to load libcamera JNI", e);
+            tempSensorModel = LibCameraJNI.SensorModel.Disconnected;
+        }
+        sensorModel = tempSensorModel;
 
         if (sensorModel == LibCameraJNI.SensorModel.IMX219) {
             // Settings for the IMX219 sensor, which is used on the Pi Camera Module v2

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/LibcameraGpuFrameProvider.java
@@ -146,11 +146,15 @@ public class LibcameraGpuFrameProvider extends FrameProvider {
 
     @Override
     public boolean checkCameraConnected() {
-        String[] cameraNames = LibCameraJNI.getCameraNames();
-        for (String name : cameraNames) {
-            if (name.equals(settables.getConfiguration().getDevicePath())) {
-                return true;
+        try {
+            String[] cameraNames = LibCameraJNI.getCameraNames();
+            for (String name : cameraNames) {
+                if (name.equals(settables.getConfiguration().getDevicePath())) {
+                    return true;
+                }
             }
+        } catch (UnsatisfiedLinkError e) {
+            // libcamera failed to load; ignored
         }
         return false;
     }


### PR DESCRIPTION
## Description

This catches the exceptions thrown if libcamera fails to load while checking camera connection information to prevent PV from crashing. Alternative approach to photonvision/photon-libcamera-gl-driver#36.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added – It doesn't seem feasible to test this
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
