### PR TITLE
Fix setting stream res

### DIFF
--- a/photon-client/src/components/dashboard/tabs/InputTab.vue
+++ b/photon-client/src/components/dashboard/tabs/InputTab.vue
@@ -61,10 +61,9 @@ const currentStreamResolutionIndex = computed<number>({
     return stored - skipped;
   },
   set: (index) => {
-    useCameraSettingsStore().changeCurrentPipelineSetting(
-      { streamingFrameDivisor: index + getNumberOfSkippedDivisors() },
-      false
-    );
+    useCameraSettingsStore().changeCurrentPipelineSetting({
+      streamingFrameDivisor: index + getNumberOfSkippedDivisors()
+    });
   }
 });
 const { mdAndDown } = useDisplay();


### PR DESCRIPTION
In the PR to add typechecking, I switched the v-model for updating the stream resolution to something local instead of the store. However, I forgot to remove the param that keeps the store from updating. This PR updates the store.
