### PR TITLE
move image-metadata def to config manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,7 +611,7 @@ jobs:
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}
           shrink_image: ${{ matrix.shrink_image || 'yes' }}
-          commands: pwd && ls /opt/photonvision && java -jar /opt/photonvision/photonvision.jar --smoketest --platform=${{ matrix.plat_override }}
+          commands: pwd && ls /opt/photonvision/photonvision_config && java -jar /opt/photonvision/photonvision.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
     # This job always runs last to set the overall result based on the matrix jobs. If any matrix job failed, this job will fail.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,7 +611,7 @@ jobs:
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}
           shrink_image: ${{ matrix.shrink_image || 'yes' }}
-          commands: java -jar *.jar --smoketest --platform=${{ matrix.plat_override }}
+          commands: java -jar /opt/photonvision/*.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
     # This job always runs last to set the overall result based on the matrix jobs. If any matrix job failed, this job will fail.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,7 +611,7 @@ jobs:
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}
           shrink_image: ${{ matrix.shrink_image || 'yes' }}
-          commands: pwd && java -jar /opt/photonvision/*.jar --smoketest --platform=${{ matrix.plat_override }}
+          commands: pwd && ls /opt/photonvision && java -jar /opt/photonvision/photonvision.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
     # This job always runs last to set the overall result based on the matrix jobs. If any matrix job failed, this job will fail.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,7 +611,7 @@ jobs:
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}
           shrink_image: ${{ matrix.shrink_image || 'yes' }}
-          commands: pwd && ls /opt/photonvision/photonvision_config && java -jar /opt/photonvision/photonvision.jar --smoketest --platform=${{ matrix.plat_override }}
+          commands: cd /opt/photonvision && pwd && find . && java -Xmx512m -jar /opt/photonvision/photonvision.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
     # This job always runs last to set the overall result based on the matrix jobs. If any matrix job failed, this job will fail.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,7 +611,7 @@ jobs:
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}
           shrink_image: ${{ matrix.shrink_image || 'yes' }}
-          commands: java -jar /opt/photonvision/*.jar --smoketest --platform=${{ matrix.plat_override }}
+          commands: pwd && java -jar /opt/photonvision/*.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
     # This job always runs last to set the overall result based on the matrix jobs. If any matrix job failed, this job will fail.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,7 +611,7 @@ jobs:
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}
           shrink_image: ${{ matrix.shrink_image || 'yes' }}
-          commands: cd /opt/photonvision && pwd && find . && java -Xmx512m -jar /opt/photonvision/photonvision.jar --smoketest --platform=${{ matrix.plat_override }}
+          commands: java -jar *.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
     # This job always runs last to set the overall result based on the matrix jobs. If any matrix job failed, this job will fail.

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -187,6 +187,10 @@ public class ConfigManager {
         return PathManager.getInstance().getRootFolder();
     }
 
+    public static Path getImageMetadataPath() {
+        return Path.of(getRootFolder().toString(), "image_metadata.json");
+    }
+
     ConfigManager(Path configDirectory, ConfigProvider provider) {
         this.configDirectoryFile = new File(configDirectory.toUri());
         m_provider = provider;

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -188,7 +188,7 @@ public class ConfigManager {
     }
 
     public static Path getImageMetadataPath() {
-        return Path.of(getRootFolder().toString(), "image_metadata.json");
+        return Path.of(getRootFolder().toString(), "image-version.json");
     }
 
     ConfigManager(Path configDirectory, ConfigProvider provider) {

--- a/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/ConfigManager.java
@@ -188,7 +188,7 @@ public class ConfigManager {
     }
 
     public static Path getImageMetadataPath() {
-        return Path.of(getRootFolder().toString(), "image-version.json");
+        return Path.of(getRootFolder().toString(), "image-metadata.json");
     }
 
     ConfigManager(Path configDirectory, ConfigProvider provider) {

--- a/photon-core/src/main/java/org/photonvision/common/hardware/OsImageData.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/OsImageData.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
 import java.util.Optional;
+import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.logging.LogGroup;
 import org.photonvision.common.logging.Logger;
 
@@ -37,7 +37,8 @@ import org.photonvision.common.logging.Logger;
 public class OsImageData {
     private static final Logger logger = new Logger(OsImageData.class, LogGroup.General);
 
-    private static File imageMetadataFile = Path.of("/opt/photonvision/image-metadata.json").toFile();
+    private static File imageMetadataFile =
+            ConfigManager.getInstance().getImageMetadataPath().toFile();
 
     public static final Optional<ImageMetadata> IMAGE_METADATA = getImageMetadata();
 


### PR DESCRIPTION
This PR adjusts the definition of the image-metadata file to live in the ConfigManager, instead of being hardcoded in the OsImageMetadata file.