### PR TITLE
change to a switch statement to avoid object comparison

### DIFF
--- a/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
@@ -150,14 +150,15 @@ public enum Platform {
     public static String getNativePlatform() {
         String platPath = CombinedRuntimeLoader.getPlatformPath();
 
-        if (platPath == "/linux/x86-64/") {
-            return "linuxx64";
-        } else if (platPath == "/windows/x86-64/") {
-            return "winx64";
-        } else if (platPath == "/linux/arm64/") {
-            return "linuxarm64";
-        } else {
-            return "";
+        switch (platPath) {
+            case "/linux/x86-64/":
+                return "linuxx64";
+            case "/windows/x86-64/":
+                return "winx64";
+            case "/linux/arm64/":
+                return "linuxarm64";
+            default:
+                return "";
         }
     }
 


### PR DESCRIPTION
With Java, `==` checks the equality of an object, i.e. same loc in mem. We want to check for equality of the string, i.e. same chars. A switch statement uses `.equals()` and is less verbose.
