### PR TITLE
Use Avaje Jsonb for Javalin JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     wpilibVersion = "2027.0.0-alpha-6"
     openCVversion = "2027-4.13.0-3"
     ejmlVersion = "0.43.1";
-    avajeJsonbVersion = "3.14-RC4";
+    avajeJsonbVersion = "3.14";
     msgpackVersion = "0.9.0";
     quickbufVersion = "1.3.3";
     jacocoVersion = "0.8.14";

--- a/photon-server/src/main/java/org/photonvision/server/Server.java
+++ b/photon-server/src/main/java/org/photonvision/server/Server.java
@@ -17,6 +17,7 @@
 
 package org.photonvision.server;
 
+import io.avaje.jsonb.javalin.JavalinJsonb;
 import io.javalin.Javalin;
 import io.javalin.plugin.bundled.CorsPlugin;
 import java.net.InetSocketAddress;
@@ -103,6 +104,7 @@ public class Server {
                                                                     return "Got WebSockets binary message from host: " + host;
                                                                 }));
                                     });
+                            javalinConfig.jsonMapper(new JavalinJsonb());
                         });
 
         /* Web Socket Events for Data Exchange */

--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation group: "io.avaje", name: "avaje-jsonb", version: avajeJsonbVersion
     annotationProcessor group: "io.avaje", name: "avaje-jsonb-generator", version: avajeJsonbVersion
     implementation group: "io.avaje", name: "avaje-jsonb-jackson", version: avajeJsonbVersion
+    implementation group: "io.avaje", name: "avaje-jsonb-javalin-mapper", version: avajeJsonbVersion
 
     implementation group: "org.ejml", name: "ejml-simple", version: ejmlVersion
     implementation group: "us.hebi.quickbuf", name: "quickbuf-runtime", version: quickbufVersion;


### PR DESCRIPTION
## Description

This updates to the release version of Avaje Jsonb and switches Javalin to use Avaje Jsonb as its backend to fix some serialization bugs. No tests are written since no tests are set up for `photon-server`, but there probably should be to catch problems like this.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
