### PR TITLE
cache rubik image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,7 +415,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             artifact-name: Win
             arch-override: winx86-64
 
@@ -434,7 +434,7 @@ jobs:
           - os: ubuntu-24.04
             artifact-name: photonvision-*-linuxx86-64.jar
             extraOpts: -Djdk.lang.Process.launchMechanism=vfork
-          - os: windows-latest
+          - os: windows-2022
             artifact-name: photonvision-*-winx86-64.jar
           - os: macos-latest
             artifact-name: photonvision-*-macarm64.jar
@@ -474,11 +474,11 @@ jobs:
           fi
           echo "=== Second run ==="
           java -jar ${{ matrix.extraOpts }} *.jar --smoketest
-        if: ${{ (matrix.os) != 'windows-latest' }}
+        if: ${{ (matrix.os) != 'windows-2022' }}
       - run: |
           ls *.jar | %{ Write-Host "Running $($_.Name)"; Start-Process "java" -ArgumentList "-jar `"$($_.FullName)`" --smoketest" -NoNewWindow -Wait; break }
           ls *.jar | %{ Write-Host "Running $($_.Name)"; Start-Process "java" -ArgumentList "-jar `"$($_.FullName)`" --smoketest" -NoNewWindow -Wait; break }
-        if: ${{ (matrix.os) == 'windows-latest' }}
+        if: ${{ (matrix.os) == 'windows-2022' }}
 
   build-image:
     needs: [build-package-linux]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -125,7 +125,7 @@ jobs:
           distribution: temurin
       - uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
       - uses: actions/setup-node@v6
         with:
           cache: pnpm
@@ -164,7 +164,7 @@ jobs:
           distribution: temurin
       - uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
       - uses: actions/setup-node@v6
         with:
           cache: pnpm
@@ -363,7 +363,7 @@ jobs:
           distribution: temurin
       - uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -549,6 +549,7 @@ jobs:
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             image_suffix: rubikpi3
+            cache: 'yes'
             plat_override: LINUX_QCS6490
             image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_rubikpi3.tar.xz
             minimum_free_mb: 1024
@@ -566,11 +567,12 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           pattern: photonvision-*-linuxarm64.jar
-      - uses: photonvision/photon-image-runner@HEAD
+      - uses: photonvision/photon-image-runner@v2.0.0
         name: Generate image
         id: generate_image
         with:
           image_url: ${{ matrix.image_url }}
+          use_cache: ${{ matrix.cache || 'no' }}
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}
           shrink_image: ${{ matrix.shrink_image || 'yes' }}


### PR DESCRIPTION
Pursuant to caching being added in https://github.com/photonvision/photonvision/photon-image-runner, we can now cache images for our action. We're only caching the rubik image as we need to wait for all of them to finish anyways, and caching the other ones as well won't gain time.

Also, downgrade to windows 2022 cause MSVC ICE bugs. Also also, bump pnpm to 11 in actions cause windows using the version as part of the path for caches (why? WHY??)
