### PR TITLE
Evaluate IMAGE_VERSION when passing into image-runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -490,68 +490,68 @@ jobs:
           - os: ubuntu-24.04-arm
             image_suffix: RaspberryPi
             plat_override: LINUX_RASPBIAN64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_raspi.img.xz
+            image_name: photonvision_raspi.img.xz
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             image_suffix: limelight2
             plat_override: LINUX_RASPBIAN64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight.img.xz
+            image_name: photonvision_limelight.img.xz
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             image_suffix: limelight3
             plat_override: LINUX_RASPBIAN64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight3.img.xz
+            image_name: photonvision_limelight3.img.xz
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             image_suffix: limelight3G
             plat_override: LINUX_RASPBIAN64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight3g.img.xz
+            image_name: photonvision_limelight3g.img.xz
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             image_suffix: limelight4
             plat_override: LINUX_RASPBIAN64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_limelight4.img.xz
+            image_name: photonvision_limelight4.img.xz
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             image_suffix: luma_p1
             plat_override: LINUX_RASPBIAN64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_luma_p1.img.xz
+            image_name: photonvision_luma_p1.img.xz
             minimum_free_mb: 100
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5
             plat_override: LINUX_RK3588_64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5.img.xz
+            image_name: photonvision_opi5.img.xz
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5b
             plat_override: LINUX_RK3588_64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5b.img.xz
+            image_name: photonvision_opi5b.img.xz
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5plus
             plat_override: LINUX_RK3588_64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5plus.img.xz
+            image_name: photonvision_opi5plus.img.xz
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5pro
             plat_override: LINUX_RK3588_64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5pro.img.xz
+            image_name: photonvision_opi5pro.img.xz
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5max
             plat_override: LINUX_RK3588_64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_opi5max.img.xz
+            image_name: photonvision_opi5max.img.xz
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             image_suffix: rock5c
             plat_override: LINUX_RK3588_64
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_rock5c.img.xz
+            image_name: photonvision_rock5c.img.xz
             minimum_free_mb: 1024
           - os: ubuntu-24.04-arm
             image_suffix: rubikpi3
             cache: 'yes'
             plat_override: LINUX_QCS6490
-            image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/$IMAGE_VERSION/photonvision_rubikpi3.tar.xz
+            image_name: photonvision_rubikpi3.tar.xz
             minimum_free_mb: 1024
             root_location: 'offset=569376768'
             shrink_image: 'no'
@@ -571,7 +571,7 @@ jobs:
         name: Generate image
         id: generate_image
         with:
-          image_url: ${{ matrix.image_url }}
+          image_url: "https://github.com/PhotonVision/photon-image-modifier/releases/download/${{ env.IMAGE_VERSION }}/${{ matrix.image_name }}"
           use_cache: ${{ matrix.cache || 'no' }}
           minimum_free_mb: ${{ matrix.minimum_free_mb }}
           root_location: ${{ matrix.root_location || 'partition=2' }}


### PR DESCRIPTION
If we don't evaluate IMAGE_VERSION when passing it into the image-runner action, cache gets the variable name instead of the actual value. This PR also cleans up the really long URLs in the matrix entries since it's always the same.