### PR TITLE
cancel the workflow if build-gradle fails and unblock previously dependent jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,19 @@ jobs:
         run: ./gradlew photon-targeting:build photon-core:build photon-server:build -x check
       - name: Gradle Tests and Coverage
         run: ./gradlew test jacocoTestReport --stacktrace
+      - name: Cancel on failure
+        if: failure()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runId = context.runId;
+
+            await github.rest.actions.cancelWorkflowRun({
+              owner,
+              repo,
+              run_id: runId
+            });
   build-offline-docs:
     name: "Build Offline Docs"
     runs-on: ubuntu-24.04
@@ -317,7 +330,7 @@ jobs:
           path: output/*.zip
 
   build-package-linux:
-    needs: [build-gradle, build-offline-docs]
+    needs: [build-offline-docs]
 
     strategy:
       fail-fast: false
@@ -370,7 +383,7 @@ jobs:
           path: photon-targeting/build/libs
 
   build-package-macos:
-    needs: [build-gradle, build-offline-docs]
+    needs: [build-offline-docs]
 
     strategy:
       fail-fast: false
@@ -389,7 +402,7 @@ jobs:
     steps: *build-package-steps
 
   build-package-windows:
-    needs: [build-gradle, build-offline-docs]
+    needs: [build-offline-docs]
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We don't need to wait for build-gradle to run everything else. Thus also sets it up so that if tests fail, we cancel the entire workflow.

This also cuts roughly six minutes off our CI time.