### PR TITLE
move typechecking to lint-format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,27 +91,6 @@ jobs:
   #           ./gradlew build
   #           ./gradlew clean
 
-  typecheck-client:
-    name: "Typecheck Client"
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 11
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: photon-client/pnpm-lock.yaml
-      - name: Typecheck Client
-        working-directory: photon-client
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm type-check
   playwright-tests:
     name: "Playwright E2E tests"
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -109,3 +109,12 @@ jobs:
             echo "::error ::Linting failed. See https://docs.photonvision.org/en/latest/docs/contributing/linting.html"
             exit $exit_code
           fi
+      - name: Run Typechecking
+        run: |
+          set +e
+          pnpm run type-check
+          exit_code=$?
+          if test "$exit_code" -ne "0"; then
+            echo "::error ::Linting failed. See https://docs.photonvision.org/en/latest/docs/contributing/linting.html"
+            exit $exit_code
+          fi


### PR DESCRIPTION
We already set up PNPM/install packages in the lint workflow -- move out of build and off of the critical path