### PR TITLE
fix(photon-lib): do not crash constrained solvepnp when heading-free with empty buffer

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -371,8 +371,6 @@ public class PhotonPoseEstimator {
         if (!headingFree && headingSampleOpt.isEmpty()) {
             return Optional.empty();
         }
-        // The solver's heading-free cost function never reads the provided heading, so any
-        // placeholder value works when the buffer is empty
         var headingSample = headingSampleOpt.orElse(Rotation2d.kZero);
         if (!headingFree) {
             // If heading fixed, force rotation component

--- a/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonPoseEstimator.java
@@ -366,17 +366,17 @@ public class PhotonPoseEstimator {
         if (!shouldEstimate(cameraResult)) {
             return Optional.empty();
         }
+        var headingSampleOpt = headingBuffer.getSample(cameraResult.getTimestampSeconds());
         // Need heading if heading fixed
+        if (!headingFree && headingSampleOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        // The solver's heading-free cost function never reads the provided heading, so any
+        // placeholder value works when the buffer is empty
+        var headingSample = headingSampleOpt.orElse(Rotation2d.kZero);
         if (!headingFree) {
-            if (headingBuffer.getSample(cameraResult.getTimestampSeconds()).isEmpty()) {
-                return Optional.empty();
-            } else {
-                // If heading fixed, force rotation component
-                seedPose =
-                        new Pose3d(
-                                seedPose.getTranslation(),
-                                new Rotation3d(headingBuffer.getSample(cameraResult.getTimestampSeconds()).get()));
-            }
+            // If heading fixed, force rotation component
+            seedPose = new Pose3d(seedPose.getTranslation(), new Rotation3d(headingSample));
         }
         var pnpResult =
                 VisionEstimation.estimateRobotPoseConstrainedSolvepnp(
@@ -388,7 +388,7 @@ public class PhotonPoseEstimator {
                         fieldTags,
                         tagModel,
                         headingFree,
-                        headingBuffer.getSample(cameraResult.getTimestampSeconds()).get(),
+                        headingSample,
                         headingScaleFactor);
         if (!pnpResult.isPresent()) return Optional.empty();
         var best = Pose3d.kZero.plus(pnpResult.get().best); // field-to-robot

--- a/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
@@ -489,8 +489,6 @@ PhotonPoseEstimator::EstimateConstrainedSolvepnpPose(
   if (!headingFree && !headingSampleOpt) {
     return std::nullopt;
   }
-  // The solver's heading-free cost function never reads the provided heading,
-  // so any placeholder value works when the buffer is empty
   wpi::math::Rotation2d headingSample =
       headingSampleOpt.value_or(wpi::math::Rotation2d{});
   if (!headingFree) {

--- a/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
@@ -483,17 +483,20 @@ PhotonPoseEstimator::EstimateConstrainedSolvepnpPose(
   if (!ShouldEstimate(cameraResult)) {
     return std::nullopt;
   }
+  std::optional<wpi::math::Rotation2d> headingSampleOpt =
+      headingBuffer.Sample(cameraResult.GetTimestamp());
   // Need heading if heading fixed
+  if (!headingFree && !headingSampleOpt) {
+    return std::nullopt;
+  }
+  // The solver's heading-free cost function never reads the provided heading,
+  // so any placeholder value works when the buffer is empty
+  wpi::math::Rotation2d headingSample =
+      headingSampleOpt.value_or(wpi::math::Rotation2d{});
   if (!headingFree) {
-    if (!headingBuffer.Sample(cameraResult.GetTimestamp())) {
-      return std::nullopt;
-    } else {
-      // If heading fixed, force rotation component
-      seedPose = wpi::math::Pose3d{
-          seedPose.Translation(),
-          wpi::math::Rotation3d{
-              headingBuffer.Sample(cameraResult.GetTimestamp()).value()}};
-    }
+    // If heading fixed, force rotation component
+    seedPose = wpi::math::Pose3d{seedPose.Translation(),
+                                 wpi::math::Rotation3d{headingSample}};
   }
   std::vector<photon::PhotonTrackedTarget> targets{
       cameraResult.GetTargets().begin(), cameraResult.GetTargets().end()};
@@ -501,9 +504,7 @@ PhotonPoseEstimator::EstimateConstrainedSolvepnpPose(
   std::optional<photon::PnpResult> pnpResult =
       VisionEstimation::EstimateRobotPoseConstrainedSolvePNP(
           cameraMatrix, distCoeffs, targets, m_robotToCamera, seedPose,
-          aprilTags, photon::kAprilTag36h11, headingFree,
-          wpi::math::Rotation2d{
-              headingBuffer.Sample(cameraResult.GetTimestamp()).value()},
+          aprilTags, photon::kAprilTag36h11, headingFree, headingSample,
           headingScaleFactor);
 
   if (!pnpResult) {

--- a/photon-lib/src/test/java/org/photonvision/PhotonPoseEstimatorTest.java
+++ b/photon-lib/src/test/java/org/photonvision/PhotonPoseEstimatorTest.java
@@ -24,6 +24,7 @@
 
 package org.photonvision;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -939,6 +940,53 @@ class PhotonPoseEstimatorTest {
                         result, cameraMat, distortion, multiTagEstimate.get().estimatedPose, true, 0);
         Pose3d pose = estimatedPose.get().estimatedPose;
         System.out.println(pose);
+    }
+
+    @Test
+    public void testConstrainedPnpHeadingFreeEmptyHeadingBuffer() {
+        var distortion = VecBuilder.fill(0, 0, 0, 0, 0, 0, 0, 0);
+        var cameraMat =
+                MatBuilder.fill(
+                        Nat.N3(),
+                        Nat.N3(),
+                        399.37500000000006,
+                        0,
+                        319.5,
+                        0,
+                        399.16666666666674,
+                        239.5,
+                        0,
+                        0,
+                        1);
+
+        List<TargetCorner> corners8 =
+                List.of(
+                        new TargetCorner(98.09875447066685, 331.0093220119495),
+                        new TargetCorner(122.20226758624413, 335.50083894738486),
+                        new TargetCorner(127.17118732489361, 313.81406314178633),
+                        new TargetCorner(104.28543773760417, 309.6516557438994));
+
+        var result =
+                new PhotonPipelineResult(
+                        new PhotonPipelineMetadata(10000, 2000, 1, 100),
+                        List.of(
+                                new PhotonTrackedTarget(0, 0, 0, 0, 8, 0, 0, null, null, 0, corners8, corners8)),
+                        Optional.empty());
+
+        final double camPitch = Units.degreesToRadians(30.0);
+        final Transform3d kRobotToCam =
+                new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, -camPitch, 0));
+
+        PhotonPoseEstimator estimator =
+                new PhotonPoseEstimator(
+                        AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo), kRobotToCam);
+
+        // No addHeadingData calls -- in heading-free mode an empty heading buffer must
+        // not throw (the estimate may still be empty for other reasons)
+        assertDoesNotThrow(
+                () ->
+                        estimator.estimateConstrainedSolvepnpPose(
+                                result, cameraMat, distortion, new Pose3d(), true, 0));
     }
 
     private static class PhotonCameraInjector extends PhotonCamera {


### PR DESCRIPTION
## Description

Constrained solvePnP unconditionally unwrapped the heading-buffer sample (`Optional.get()` in Java, `std::optional::value()` in C++), so running heading-free with an empty heading buffer crashed (`NoSuchElementException` / `bad_optional_access`).

Both implementations now early-return only when a heading is actually required, and pass a safe placeholder otherwise — the solver's heading-free cost function never reads the provided heading. A regression test (`PhotonPoseEstimatorTest`) exercises the heading-free + empty-buffer path.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR addresses a bug, a regression test for it is added
