### PR TITLE
fix(photon-core): correct swapped VID/PID on three Logitech quirk entries

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/QuirkyCamera.java
@@ -31,9 +31,9 @@ public class QuirkyCamera {
                     new QuirkyCamera(
                             0x2560, 0xc128, "See3Cam_24CUG", CameraQuirk.Gain, CameraQuirk.See3Cam_24CUG),
                     // Chris's older generic "Logitech HD Webcam"
-                    new QuirkyCamera(0x9331, 0x5A3, CameraQuirk.CompletelyBroken),
+                    new QuirkyCamera(0x5A3, 0x9331, CameraQuirk.CompletelyBroken),
                     // Logitech C270
-                    new QuirkyCamera(0x825, 0x46D, CameraQuirk.CompletelyBroken),
+                    new QuirkyCamera(0x46D, 0x825, CameraQuirk.CompletelyBroken),
                     // A laptop internal camera someone found broken
                     new QuirkyCamera(0x0bda, 0x5510, CameraQuirk.CompletelyBroken),
                     // SnapCamera on Windows
@@ -48,7 +48,7 @@ public class QuirkyCamera {
                     new QuirkyCamera(
                             0x1415, 0x2000, CameraQuirk.Gain, CameraQuirk.FPSCap100, CameraQuirk.PsEyeControls),
                     // Logitech C925-e
-                    new QuirkyCamera(0x85B, 0x46D, CameraQuirk.AdjustableFocus),
+                    new QuirkyCamera(0x46D, 0x85B, CameraQuirk.AdjustableFocus),
                     // Generic arducam. Since OV2311 can't be differentiated
                     // at first boot, apply stickyFPS to the generic case, too
                     new QuirkyCamera(

--- a/photon-core/src/test/java/org/photonvision/vision/QuirkyCameraTest.java
+++ b/photon-core/src/test/java/org/photonvision/vision/QuirkyCameraTest.java
@@ -18,6 +18,8 @@
 package org.photonvision.vision;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
@@ -48,5 +50,45 @@ public class QuirkyCameraTest {
 
         QuirkyCamera quirkless = QuirkyCamera.getQuirkyCamera(1234, 8888);
         assertEquals(quirkless.quirks, noQuirks);
+    }
+
+    @Test
+    public void logitechC270Test() {
+        // Logitech's USB VID is 0x046D; the C270's PID is 0x0825. Matching is VID-first.
+        QuirkyCamera c270 = QuirkyCamera.getQuirkyCamera(0x046D, 0x0825);
+        assertTrue(c270.hasQuirk(CameraQuirk.CompletelyBroken));
+
+        // The swapped (PID-first) order must NOT match
+        QuirkyCamera swapped = QuirkyCamera.getQuirkyCamera(0x0825, 0x046D);
+        assertFalse(swapped.hasQuirks());
+    }
+
+    @Test
+    public void logitechC925eTest() {
+        // Logitech's USB VID is 0x046D; the C925-e's PID is 0x085B
+        QuirkyCamera c925e = QuirkyCamera.getQuirkyCamera(0x046D, 0x085B);
+        assertTrue(c925e.hasQuirk(CameraQuirk.AdjustableFocus));
+
+        QuirkyCamera swapped = QuirkyCamera.getQuirkyCamera(0x085B, 0x046D);
+        assertFalse(swapped.hasQuirks());
+    }
+
+    @Test
+    public void genericLogitechHdWebcamTest() {
+        // ARC International's USB VID is 0x05A3; this webcam's PID is 0x9331
+        QuirkyCamera hdWebcam = QuirkyCamera.getQuirkyCamera(0x05A3, 0x9331);
+        assertTrue(hdWebcam.hasQuirk(CameraQuirk.CompletelyBroken));
+
+        QuirkyCamera swapped = QuirkyCamera.getQuirkyCamera(0x9331, 0x05A3);
+        assertFalse(swapped.hasQuirks());
+    }
+
+    @Test
+    public void see3CamTest() {
+        // e-con Systems' USB VID is 0x2560; the See3CAM_24CUG's PID is 0xC128.
+        // This entry was already VID-first; pin it so it stays that way.
+        QuirkyCamera see3Cam = QuirkyCamera.getQuirkyCamera(0x2560, 0xC128, "See3Cam_24CUG");
+        assertTrue(see3Cam.hasQuirk(CameraQuirk.Gain));
+        assertTrue(see3Cam.hasQuirk(CameraQuirk.See3Cam_24CUG));
     }
 }


### PR DESCRIPTION
## Description

Three Logitech/ARC entries in the camera quirk table were written product-ID-first, but `QuirkyCamera` matches on `(usbVid, usbPid)`. As a result the quirks never fired for the real hardware — the C270's `CompletelyBroken` flag and the C925-e's `AdjustableFocus` support were silently dead.

Corrected to VID-first (C270 `0x046D`/`0x0825`, C925-e `0x046D`/`0x085B`, generic ARC "Logitech HD Webcam" `0x05A3`/`0x9331`), with `QuirkyCameraTest` pinning each VID/PID pair and asserting the swapped order does not match.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR addresses a bug, a regression test for it is added
