### PR TITLE
Remove gradle build failfast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,20 +159,6 @@ jobs:
         run: ./gradlew photon-targeting:build photon-core:build photon-server:build -x check
       - name: Gradle Tests and Coverage
         run: ./gradlew test jacocoTestReport --stacktrace
-      - name: Cancel on failure
-        if: failure()
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.CI_CANCELLATION_TOKEN }}
-          script: |
-            const { owner, repo } = context.repo;
-            const runId = context.runId;
-
-            await github.rest.actions.cancelWorkflowRun({
-              owner,
-              repo,
-              run_id: runId
-            });
   build-offline-docs:
     name: "Build Offline Docs"
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  actions: write
-  contents: read
-
 env:
   IMAGE_VERSION: v2027.1.0
 
@@ -142,7 +138,6 @@ jobs:
           fetch-depth: 0
       - name: Fetch tags
         run: git fetch --tags --force
-      - run: exit 1
       - uses: actions/setup-java@v5
         with:
           java-version: 25

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: write
+  contents: read
+
 env:
   IMAGE_VERSION: v2027.1.0
 
@@ -156,8 +160,9 @@ jobs:
         run: ./gradlew test jacocoTestReport --stacktrace
       - name: Cancel on failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
+          github-token: ${{ secrets.CI_CANCELLATION_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const runId = context.runId;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,7 @@ jobs:
           fetch-depth: 0
       - name: Fetch tags
         run: git fetch --tags --force
+      - run: exit 1
       - uses: actions/setup-java@v5
         with:
           java-version: 25


### PR DESCRIPTION
The previous solution only works when a PR comes from the same repo. It worked in testing, because it got PRed from the same repo. From my investigation, there's no way to do it with a PR from another repo. You could provision a token and cancel that way, but that's a huge security risk.