### PR TITLE
fix(photon-server): don't apply default network config on malformed settings POST

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -378,12 +378,10 @@ public class RequestHandler {
             ctx.result("Successfully saved general settings");
             logger.info("Successfully saved general settings");
         } catch (IllegalStateException | JsonException e) {
-            // If the settings can't be parsed, use the default network settings
-            config = new NetworkConfig();
-
             ctx.status(400);
             ctx.result("The provided general settings were malformed");
             logger.error("The provided general settings were malformed", e);
+            return;
         }
 
         ConfigManager.getInstance().setNetworkSettings(config);


### PR DESCRIPTION
## Description

If the JSON body of a POST to `/api/settings/general` failed to parse, `onGeneralSettingsRequest` built a default `NetworkConfig` and then fell through to apply it, persist it, and reinitialize networking — so a single malformed request (or a UI/backend schema mismatch) silently reset team number, static IP, hostname, and NT mode. On a competition robot this presents as random, catastrophic config loss.

The handler now returns immediately after responding 400; network settings are only applied and saved on a successful parse.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (photon-server has no test suite; verified by inspection — the fix is a two-line control-flow change)