### PR TITLE
fix(photon-server): correct error handling and per-camera data in snapshot endpoints

### DIFF
--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -1199,6 +1199,7 @@ public class RequestHandler {
             } catch (IOException e) {
                 ctx.status(500);
                 ctx.result("Unable to read saved images");
+                return;
             }
         }
 
@@ -1213,8 +1214,8 @@ public class RequestHandler {
 
             var cameraDirs = ConfigManager.getInstance().getCalibDir().toFile().listFiles();
             if (cameraDirs != null) {
-                var camData = new HashMap<String, ArrayList<HashMap<String, Object>>>();
                 for (var cameraDir : cameraDirs) {
+                    var camData = new HashMap<String, ArrayList<HashMap<String, Object>>>();
                     var resolutionDirs = cameraDir.listFiles();
                     if (resolutionDirs == null) continue;
                     for (var resolutionDir : resolutionDirs) {


### PR DESCRIPTION
## Description

Two fixes in the snapshot REST handlers:

- `onImageSnapshotsRequest`: the IOException catch set status 500 but execution fell through to an unconditional `ctx.status(200)`, masking the failure from the client. It now returns after the 500.
- `onCameraCalibImagesRequest`: the `camData` map was allocated outside the per-camera loop, so every camera's response key pointed at the merged data of all cameras. The allocation now lives inside the loop.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (photon-server has no test suite; both fixes are mechanical control-flow/scoping corrections)