### PR TITLE
fix(photon-server): make -d/--debug and -f/--folder CLI flags take effect

### DIFF
--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -109,8 +109,8 @@ public class Main {
                 isTestMode = true;
                 logger.info("Running in test mode - Cameras will not be used");
 
-                if (cmd.hasOption("path")) {
-                    Path p = Path.of(System.getProperty("PATH_PREFIX", "") + cmd.getOptionValue("path"));
+                if (cmd.hasOption("folder")) {
+                    Path p = Path.of(System.getProperty("PATH_PREFIX", "") + cmd.getOptionValue("folder"));
                     logger.info("Loading from Path " + p.toAbsolutePath().toString());
                     testModeFolder = p;
                 }
@@ -226,15 +226,6 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        var logLevel = printDebugLogs ? LogLevel.TRACE : LogLevel.DEBUG;
-        Logger.setLevel(LogGroup.Camera, logLevel);
-        Logger.setLevel(LogGroup.WebServer, logLevel);
-        Logger.setLevel(LogGroup.VisionModule, logLevel);
-        Logger.setLevel(LogGroup.Data, logLevel);
-        Logger.setLevel(LogGroup.Config, logLevel);
-        Logger.setLevel(LogGroup.General, logLevel);
-        logger.info("Logging initialized in debug mode.");
-
         System.setProperty("jsonb.disableAdapterSpi", "true");
 
         logger.info(
@@ -257,6 +248,16 @@ public class Main {
         } catch (ParseException e) {
             logger.error("Failed to parse command-line options!", e);
         }
+
+        // Level must be set after handleArgs so that -d/--debug is honored
+        var logLevel = printDebugLogs ? LogLevel.TRACE : LogLevel.DEBUG;
+        Logger.setLevel(LogGroup.Camera, logLevel);
+        Logger.setLevel(LogGroup.WebServer, logLevel);
+        Logger.setLevel(LogGroup.VisionModule, logLevel);
+        Logger.setLevel(LogGroup.Data, logLevel);
+        Logger.setLevel(LogGroup.Config, logLevel);
+        Logger.setLevel(LogGroup.General, logLevel);
+        logger.info("Logging initialized in debug mode.");
 
         // We don't want to trigger an exit in test mode or smoke test. This is
         // specifically for MacOS.
@@ -352,6 +353,10 @@ public class Main {
         } else {
             if (testModeFolder == null) {
                 addTestModeSources();
+            } else {
+                logger.warn(
+                        "Folder-based test mode (-f/--folder) currently registers no camera sources; ignoring "
+                                + testModeFolder);
             }
         }
 


### PR DESCRIPTION
## Description

Two CLI flags in `Main` were dead:

- Log levels were computed from `printDebugLogs` *before* `handleArgs()` parsed the command line, so `-d/--debug` could never enable debug logging. Levels are now set after argument parsing (startup and arg-parsing logs still print — the groups involved default to INFO).
- The option was registered as `"f", "folder"` but read via `cmd.hasOption("path")`, which is never registered, so `testModeFolder` could never be set. The reads now use `"folder"`. Note the folder branch registers no camera sources even when set (pre-existing gap) — this now logs an explicit warning instead of failing silently.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (CLI wiring in `main()`; not practical to unit test in the current structure)