### PR TITLE
fix(photon-core): repair custom GPIO config detection and adapter wiring

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/configuration/HardwareConfig.java
+++ b/photon-core/src/main/java/org/photonvision/common/configuration/HardwareConfig.java
@@ -114,11 +114,15 @@ public class HardwareConfig {
      * @return True if any gpio command has been configured to be non-empty, false otherwise
      */
     public final boolean hasGPIOCommandsConfigured() {
-        return getGPIOCommand != ""
-                || setGPIOCommand != ""
-                || setPWMCommand != ""
-                || setPWMFrequencyCommand != ""
-                || releaseGPIOCommand != "";
+        return isNonEmpty(getGPIOCommand)
+                || isNonEmpty(setGPIOCommand)
+                || isNonEmpty(setPWMCommand)
+                || isNonEmpty(setPWMFrequencyCommand)
+                || isNonEmpty(releaseGPIOCommand);
+    }
+
+    private static boolean isNonEmpty(String s) {
+        return s != null && !s.isEmpty();
     }
 
     @Override

--- a/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/hardware/HardwareManager.java
@@ -152,7 +152,7 @@ public class HardwareManager {
                         hardwareConfig.setGPIOCommand,
                         hardwareConfig.setPWMCommand,
                         hardwareConfig.setPWMFrequencyCommand,
-                        hardwareConfig.setPWMFrequencyCommand);
+                        hardwareConfig.releaseGPIOCommand);
         CustomDeviceFactory deviceFactory = new CustomDeviceFactory(adapter);
         BoardPinInfo pinInfo = deviceFactory.getBoardPinInfo();
 


### PR DESCRIPTION
## Description

Two related bugs in custom-GPIO hardware configuration:

- `HardwareConfig.hasGPIOCommandsConfigured()` compared strings with `!=` (reference equality). Strings deserialized from JSON are not interned, so a config whose command strings were all empty still reported "configured" after a JSON round-trip — silently selecting the custom GPIO factory over the native diozero one and breaking LED control on stock hardware. The check now tests content (null-safe non-empty).
- `HardwareManager` passed `setPWMFrequencyCommand` twice when constructing `CustomAdapter`; the fifth parameter is `releaseGPIOCommand`, so the configured release command never ran (the PWM-frequency command ran in its place). The correct field is now passed.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (existing `HardwareConfigTest` passes; the adapter wiring is constructor plumbing exercised on real hardware)