### PR TITLE
fix(photon-core): normalize null cameraQuirks before caching it in VisionModule

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -107,10 +107,10 @@ public class VisionModule {
 
         mismatch = false;
 
-        cameraQuirks = visionSource.getCameraConfiguration().cameraQuirks;
-
         if (visionSource.getCameraConfiguration().cameraQuirks == null)
             visionSource.getCameraConfiguration().cameraQuirks = QuirkyCamera.DefaultCamera;
+
+        cameraQuirks = visionSource.getCameraConfiguration().cameraQuirks;
 
         // We don't show gain if the config says it's -1. So check here to make sure
         // it's non-negative if it _is_ supported


### PR DESCRIPTION
## Description

`VisionModule`'s constructor cached `cameraQuirks` from the camera configuration *before* the null-repair that assigns `QuirkyCamera.DefaultCamera`, so when a configuration arrived with null quirks the cached field stayed null and `cameraQuirks.hasQuirk(...)` threw an NPE a few lines later — the guard could never protect the class it lives in. The configuration is now normalized first, then cached.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (constructor ordering fix; VisionModule has no isolated test harness)