### PR TITLE
fix(photon-core): un-invert setVideoMode success check

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/USBCameras/GenericUSBCameraSettables.java
@@ -278,7 +278,7 @@ public class GenericUSBCameraSettables extends VisionSourceSettables {
                 logger.error("Got a null video mode! Doing nothing...");
                 return;
             }
-            if (camera.setVideoMode(videoMode)) logger.debug("Failed to set video mode!");
+            if (!camera.setVideoMode(videoMode)) logger.warn("Failed to set video mode!");
         } catch (Exception e) {
             logger.error("Failed to set video mode!", e);
         }


### PR DESCRIPTION
## Description

cscore's `setVideoMode` returns `true` on success, but `GenericUSBCameraSettables` logged "Failed to set video mode!" when it returned true — so it reported failure on every success and stayed silent on actual failures. The condition is negated and the message promoted from debug to warn so real failures are visible.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (one-line logging condition against live cscore hardware)