### PR TITLE
fix(photon-client): show correct camera name in delete confirmation

### DIFF
--- a/photon-client/src/views/CameraMatchingView.vue
+++ b/photon-client/src/views/CameraMatchingView.vue
@@ -427,7 +427,7 @@ const getMatchedDevice = (info: PVCameraInfo | undefined): PVCameraInfo => {
     <pv-delete-modal
       v-model="confirmDeleteDialog.show"
       title="Delete Camera"
-      :description="`Are you sure you want to delete the camera '${useCameraSettingsStore().currentCameraSettings.nickname}'? This action cannot be undone.`"
+      :description="`Are you sure you want to delete the camera '${confirmDeleteDialog.nickname}'? This action cannot be undone.`"
       :expected-confirmation-text="confirmDeleteDialog.nickname"
       :on-confirm="() => deleteThisCamera(confirmDeleteDialog.cameraUniqueName)"
     />


### PR DESCRIPTION
## Description

The delete-camera confirmation modal in `CameraMatchingView` interpolated `currentCameraSettings.nickname` into its description, but the dialog is opened for (and deletes) `confirmDeleteDialog.cameraUniqueName`. The dialog could therefore say "delete camera A?" while actually deleting camera B — on a destructive, unrecoverable action. The typed-confirmation input already used the correct name; the description now uses `confirmDeleteDialog.nickname` to match.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (one-line template fix; verified with vue-tsc + eslint)