### PR TITLE
fix(photon-client): persist output-stream visibility from Cameras page

### DIFF
--- a/photon-client/src/views/CameraSettingsView.vue
+++ b/photon-client/src/views/CameraSettingsView.vue
@@ -33,9 +33,13 @@ const cameraViewType = computed<number[]>({
     return ret;
   },
   set: (v) => {
-    useCameraSettingsStore().currentPipelineSettings.inputShouldShow = v.includes(0);
-    useCameraSettingsStore().currentPipelineSettings.outputShouldShow = v.includes(1);
-    useCameraSettingsStore().changeCurrentPipelineSetting({ inputShouldShow: v.includes(0) }, false);
+    useCameraSettingsStore().changeCurrentPipelineSetting(
+      {
+        inputShouldShow: v.includes(0),
+        outputShouldShow: v.includes(1)
+      },
+      true
+    );
   }
 });
 </script>


### PR DESCRIPTION
## Description

`CameraSettingsView`'s stream-selector setter mutated the store directly and only sent `{ inputShouldShow }` to the backend, while the equivalent setter in `DashboardView` sends both flags. Toggling output-stream visibility from the Cameras page therefore never persisted — it silently reset on the next full-settings broadcast. The setter now sends both flags through `changeCurrentPipelineSetting`, matching the Dashboard behavior.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (verified with vue-tsc + eslint; the two views' setters are now byte-identical)