### PR TITLE
fix(photon-client): stop treating zero-valued metrics as missing

### DIFF
--- a/photon-client/src/stores/settings/GeneralSettingsStore.ts
+++ b/photon-client/src/stores/settings/GeneralSettingsStore.ts
@@ -134,22 +134,22 @@ export const useSettingsStore = defineStore("settings", {
     }
   },
   actions: {
-    updateMetricsFromWebsocket(data: Required<MetricData>) {
+    updateMetricsFromWebsocket(data: MetricData) {
       this.metrics = {
-        cpuTemp: data.cpuTemp || undefined,
-        cpuUtil: data.cpuUtil || undefined,
-        cpuThr: data.cpuThr || undefined,
-        ramMem: data.ramMem || undefined,
-        ramUtil: data.ramUtil || undefined,
-        gpuMem: data.gpuMem || undefined,
-        gpuMemUtil: data.gpuMemUtil || undefined,
-        diskUtilPct: data.diskUtilPct || undefined,
-        diskUsableSpace: data.diskUsableSpace || undefined,
-        npuUsage: data.npuUsage || undefined,
-        ipAddress: data.ipAddress || undefined,
-        uptime: data.uptime || undefined,
-        sentBitRate: data.sentBitRate || undefined,
-        recvBitRate: data.recvBitRate || undefined
+        cpuTemp: data.cpuTemp ?? undefined,
+        cpuUtil: data.cpuUtil ?? undefined,
+        cpuThr: data.cpuThr ?? undefined,
+        ramMem: data.ramMem ?? undefined,
+        ramUtil: data.ramUtil ?? undefined,
+        gpuMem: data.gpuMem ?? undefined,
+        gpuMemUtil: data.gpuMemUtil ?? undefined,
+        diskUtilPct: data.diskUtilPct ?? undefined,
+        diskUsableSpace: data.diskUsableSpace ?? undefined,
+        npuUsage: data.npuUsage ?? undefined,
+        ipAddress: data.ipAddress ?? undefined,
+        uptime: data.uptime ?? undefined,
+        sentBitRate: data.sentBitRate ?? undefined,
+        recvBitRate: data.recvBitRate ?? undefined
       };
       if (metricsHistoryBuffer.update({ time: Date.now(), metrics: this.metrics })) {
         metricsHistorySnapshot.value = metricsHistoryBuffer.getHistory();


### PR DESCRIPTION
## Description

Every numeric device metric was coerced with `|| undefined` on ingestion, so a legitimate reading of `0` (0% CPU, 0 Mb/s network) rendered as "Unknown" in the device cards. The coercions now use `??`, which still normalizes msgpack-decoded Java nulls to `undefined` but passes real zeros through. The parameter type is also corrected from `Required<MetricData>` to `MetricData` since the backend omits fields.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (verified with vue-tsc + eslint)