### PR TITLE
fix(photon-lib): close heartbeatSubscriber instead of double-closing pipelineIndexRequest

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -93,7 +93,7 @@ public class PhotonCamera implements AutoCloseable {
         pipelineIndexState.close();
         ledModeRequest.close();
         ledModeState.close();
-        pipelineIndexRequest.close();
+        heartbeatSubscriber.close();
         cameraIntrinsicsSubscriber.close();
         cameraDistortionSubscriber.close();
         topicNameSubscriber.close();


### PR DESCRIPTION
## Description

`PhotonCamera.close()` listed `pipelineIndexRequest.close()` twice and never closed `heartbeatSubscriber`, leaking an NT handle per camera instance in unit tests and multi-camera robot code. The duplicate close is replaced with the missing one; the close list now covers every NT handle field declared in the class, each exactly once.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (one-line close-list correction, verified against the field declarations)