### PR TITLE
fix(photon-lib): apply field layout origin in C++ coproc multitag pose

### DIFF
--- a/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
@@ -302,7 +302,9 @@ PhotonPoseEstimator::EstimateCoprocMultiTagPose(
   const auto field2camera = cameraResult.MultiTagResult()->estimatedPose.best;
 
   const auto fieldToRobot =
-      wpi::math::Pose3d() + field2camera + m_robotToCamera.Inverse();
+      (wpi::math::Pose3d() + field2camera)  // field-to-camera
+          .RelativeTo(aprilTags.GetOrigin())
+          .TransformBy(m_robotToCamera.Inverse());  // field-to-robot
   return photon::EstimatedRobotPose(fieldToRobot, cameraResult.GetTimestamp(),
                                     cameraResult.GetTargets(),
                                     MULTI_TAG_PNP_ON_COPROCESSOR);


### PR DESCRIPTION
## Description

Java's `estimateCoprocMultiTagPose` applies `.relativeTo(fieldTags.getOrigin())` to the multitag-derived pose, and Python matches — but the C++ implementation omitted it. Teams calling `SetOrigin(kRedAllianceWallRightSide)` got correct poses in Java/Python and mirrored poses in C++ from the same coprocessor result: a silent, alliance-dependent wrong answer.

The C++ composition now mirrors Java's exactly: `(Pose3d() + field2camera).RelativeTo(aprilTags.GetOrigin()).TransformBy(m_robotToCamera.Inverse())`. The default origin is the zero pose, so behavior is unchanged for teams that never call `SetOrigin`.

No other strategy needs this: the remaining strategies obtain tag poses via `getTagPose()`, which applies the origin internally — Java and C++ already agree there.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (existing C++ pose-estimator tests run with the default origin and are unaffected)