### PR TITLE
fix(photon-core): return empty list from TFLite detect() when uninitialized

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/objects/TFLiteObjectDetector.java
+++ b/photon-core/src/main/java/org/photonvision/vision/objects/TFLiteObjectDetector.java
@@ -118,10 +118,8 @@ public class TFLiteObjectDetector implements ObjectDetector {
     @Override
     public List<NeuralNetworkPipeResult> detect(Mat in, double nmsThresh, double boxThresh) {
         if (!isValid()) {
-            logger.error(
-                    "Detector is not initialized, and so it can't be released! Model: "
-                            + model.modelFile.getName());
-            return null;
+            logger.error("Detector is not initialized! Model: " + model.modelFile.getName());
+            return List.of();
         }
 
         // Resize the frame to the input size of the model


### PR DESCRIPTION
## Description

`TFLiteObjectDetector.detect()` returned `null` when the native detector pointer was invalid, but the `ObjectDetector` interface contract (and `RknnObjectDetector`) promise an empty list. The null flowed unchecked through `ObjectDetectionPipe` into `FilterObjectDetectionsPipe` and NPE'd. It now returns `List.of()`, and the error message — copy-pasted from a release path ("...and so it can't be released!") — is corrected to describe the detect path.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (guard-path fix; the invalid-pointer state requires a failed native model load to reach)