### PR TITLE
fix(photon-core): don't NPE or mutate caller's Mat in MJPGFrameConsumer

### DIFF
--- a/photon-core/src/main/java/org/photonvision/vision/frame/consumer/MJPGFrameConsumer.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/consumer/MJPGFrameConsumer.java
@@ -17,7 +17,6 @@
 
 package org.photonvision.vision.frame.consumer;
 
-import org.photonvision.common.util.math.MathUtils;
 import org.photonvision.vision.frame.StaticFrames;
 import org.photonvision.vision.opencv.CVMat;
 import org.wpilib.util.PixelFormat;
@@ -25,10 +24,6 @@ import org.wpilib.vision.camera.*;
 import org.wpilib.vision.stream.CameraServer;
 
 public class MJPGFrameConsumer implements AutoCloseable {
-    private static final double MAX_FRAMERATE = -1;
-    private static final long MAX_FRAME_PERIOD_NS = Math.round(1e9 / MAX_FRAMERATE);
-
-    private long lastFrameTimeNs;
     private CvSource cvSource;
     private MjpegServer mjpegServer;
 
@@ -46,16 +41,12 @@ public class MJPGFrameConsumer implements AutoCloseable {
     }
 
     public void accept(CVMat image) {
-        long now = MathUtils.wpiNanoTime();
-
         if (image == null || image.getMat() == null || image.getMat().empty()) {
-            image.copyFrom(StaticFrames.LOST_MAT);
+            cvSource.putFrame(StaticFrames.LOST_MAT);
+            return;
         }
 
-        if (now - lastFrameTimeNs > MAX_FRAME_PERIOD_NS) {
-            lastFrameTimeNs = now;
-            cvSource.putFrame(image.getMat());
-        }
+        cvSource.putFrame(image.getMat());
     }
 
     @Override


### PR DESCRIPTION
## Description

`MJPGFrameConsumer.accept()` had a null guard that dereferenced its own subject — `if (image == null || ...) { image.copyFrom(...) }` — and, when the input was merely empty, it overwrote the caller's live pipeline Mat with the LOST card, a surprising side effect on a shared buffer. On null/unusable input it now puts `StaticFrames.LOST_MAT` to the CvSource directly and returns without touching the caller's CVMat.

Also removes the dead rate limiter: `MAX_FRAMERATE = -1` made the frame period negative, so the throttle check always passed and the fields were pure scaffolding.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (MJPGFrameConsumer has no test harness; fix verified by inspection and compile)