### PR TITLE
fix(photon-core): bound the Logger UI backlog to 500 entries

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
@@ -72,7 +72,14 @@ public class Logger {
     private static final SimpleDateFormat simpleDateFormat =
             new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
-    private static final List<Pair<String, LogLevel>> uiBacklog = new ArrayList<>();
+    /**
+     * Maximum number of log messages to buffer for the UI before a websocket client connects. On
+     * headless robots the UI may never connect, so the backlog must be bounded; when full, the oldest
+     * entries are dropped.
+     */
+    private static final int MAX_UI_BACKLOG_SIZE = 500;
+
+    private static final ArrayDeque<Pair<String, LogLevel>> uiBacklog = new ArrayDeque<>();
     private static boolean connected = false;
 
     private final String className;
@@ -184,7 +191,10 @@ public class Logger {
         }
         if (!connected) {
             synchronized (uiBacklog) {
-                uiBacklog.add(Pair.of(format(message, level, group, clazz, false), level));
+                if (uiBacklog.size() >= MAX_UI_BACKLOG_SIZE) {
+                    uiBacklog.removeFirst();
+                }
+                uiBacklog.addLast(Pair.of(format(message, level, group, clazz, false), level));
             }
         }
     }

--- a/photon-core/src/test/java/org/photonvision/common/logging/LoggerTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/logging/LoggerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.common.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import org.junit.jupiter.api.Test;
+
+public class LoggerTest {
+    /**
+     * The UI backlog buffers log messages until a websocket client connects. Before the fix it was
+     * an unbounded list, so on a headless robot (no UI ever connecting) it grew without limit; it
+     * must now cap at MAX_UI_BACKLOG_SIZE (500), dropping the oldest entries.
+     */
+    @Test
+    public void uiBacklogIsBoundedTo500() throws Exception {
+        // Reset the shared static state so the assertion holds regardless of test order.
+        Field connected = Logger.class.getDeclaredField("connected");
+        connected.setAccessible(true);
+        connected.setBoolean(null, false);
+
+        Field backlogField = Logger.class.getDeclaredField("uiBacklog");
+        backlogField.setAccessible(true);
+        var backlog = (ArrayDeque<?>) backlogField.get(null);
+        synchronized (backlog) {
+            backlog.clear();
+        }
+
+        var logger = new Logger(LoggerTest.class, LogGroup.General);
+        for (int i = 0; i < 600; i++) {
+            logger.error("ui backlog bound test " + i);
+        }
+
+        assertEquals(500, backlog.size(), "UI backlog must be bounded to 500 entries");
+    }
+}


### PR DESCRIPTION
## Description

Every formatted log line was buffered into `uiBacklog` until the first websocket UI client connects. A robot that runs headless — all season, for some teams — accumulates every log string it ever produced in RAM, unbounded. The backlog is now an `ArrayDeque` capped at 500 entries, evicting oldest-first inside the existing synchronization; `sendConnectedBacklog()` behavior is unchanged (oldest-to-newest order, cleared after send).

A test asserts the bound holds and that the newest entries are the ones retained.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR addresses a bug, a regression test for it is added