### PR TITLE
fix(photon-core): remove DataChangeService subscribers by identity instead of index

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/dataflow/DataChangeService.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/DataChangeService.java
@@ -17,6 +17,8 @@
 
 package org.photonvision.common.dataflow;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -30,20 +32,15 @@ public class DataChangeService {
     private static final Logger logger = new Logger(DataChangeService.class, LogGroup.WebServer);
 
     public static class SubscriberHandle {
-        private final int[] idxs;
+        private final List<DataChangeSubscriber> subs;
 
-        private SubscriberHandle(int[] idxs) {
-            this.idxs = idxs;
-        }
-
-        private SubscriberHandle(int idx) {
-            this.idxs = new int[] {idx};
+        private SubscriberHandle(List<DataChangeSubscriber> subs) {
+            this.subs = subs;
         }
 
         public void stop() {
-            for (int idx : idxs) {
-                if (idx < 0) continue;
-                getInstance().subscribers.set(idx, null);
+            for (var sub : subs) {
+                getInstance().subscribers.remove(sub);
             }
         }
     }
@@ -79,7 +76,6 @@ public class DataChangeService {
             try {
                 var taken = eventQueue.take();
                 for (var sub : subscribers) {
-                    if (sub == null) continue;
                     if (sub.wantedSources.contains(taken.sourceType)
                             && sub.wantedDestinations.contains(taken.destType)) {
                         sub.onDataChangeEvent(taken);
@@ -95,7 +91,7 @@ public class DataChangeService {
     public SubscriberHandle addSubscriber(DataChangeSubscriber subscriber) {
         if (!subscribers.addIfAbsent(subscriber)) {
             logger.warn("Attempted to add already added subscriber!");
-            return new SubscriberHandle(-1);
+            return new SubscriberHandle(List.of());
         } else {
             logger.debug(
                     () -> {
@@ -110,16 +106,16 @@ public class DataChangeService {
 
                         return "Added subscriber - " + "Sources: " + sources + ", Destinations: " + dests;
                     });
-            return new SubscriberHandle(subscribers.size() - 1);
+            return new SubscriberHandle(List.of(subscriber));
         }
     }
 
     public SubscriberHandle addSubscribers(DataChangeSubscriber... subs) {
-        int[] idxs = new int[subs.length];
-        for (int i = 0; i < subs.length; i++) {
-            idxs[i] = addSubscriber(subs[i]).idxs[0];
+        var added = new ArrayList<DataChangeSubscriber>();
+        for (var sub : subs) {
+            added.addAll(addSubscriber(sub).subs);
         }
-        return new SubscriberHandle(idxs);
+        return new SubscriberHandle(added);
     }
 
     public void publishEvent(DataChangeEvent event) {

--- a/photon-core/src/test/java/org/photonvision/common/dataflow/DataChangeServiceTest.java
+++ b/photon-core/src/test/java/org/photonvision/common/dataflow/DataChangeServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.photonvision.common.dataflow;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.photonvision.common.dataflow.events.DataChangeEvent;
+
+public class DataChangeServiceTest {
+    private static DataChangeSubscriber noopSubscriber() {
+        return new DataChangeSubscriber() {
+            @Override
+            public <T> void onDataChangeEvent(DataChangeEvent<T> event) {}
+        };
+    }
+
+    /**
+     * Stopping a handle must remove exactly its own subscriber. The old handle stored a list index
+     * and nulled that slot; once any earlier subscriber was removed the stored index went stale and
+     * could detach the wrong subscriber. Removal is now by object identity.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void stopRemovesSubscriberByIdentityNotIndex() throws Exception {
+        var service = DataChangeService.getInstance();
+
+        Field field = DataChangeService.class.getDeclaredField("subscribers");
+        field.setAccessible(true);
+        var subscribers = (List<DataChangeSubscriber>) field.get(service);
+
+        var first = noopSubscriber();
+        var second = noopSubscriber();
+        var firstHandle = service.addSubscriber(first);
+        var secondHandle = service.addSubscriber(second);
+        try {
+            assertTrue(subscribers.contains(first));
+            assertTrue(subscribers.contains(second));
+
+            firstHandle.stop();
+
+            assertFalse(subscribers.contains(first), "the stopped subscriber should be removed");
+            assertTrue(subscribers.contains(second), "other subscribers should stay registered");
+        } finally {
+            // Don't leak our subscribers into the process-wide singleton for later tests.
+            firstHandle.stop();
+            secondHandle.stop();
+        }
+    }
+}


### PR DESCRIPTION
## Description

`addSubscriber` returned `subscribers.size() - 1` as a handle — wrong under concurrent adds from different threads — and `SubscriberHandle.stop()` nulled the slot rather than removing it, so the `CopyOnWriteArrayList` grew monotonically: every camera add/remove leaked a slot for the life of the process.

`SubscriberHandle` now holds references to its subscribers and `stop()` removes them by identity (`DataChangeSubscriber` doesn't override `equals`, so removal is reference-based). The index mechanism and the dispatch-loop null-check for tombstoned slots are gone. Duplicate adds return an inert handle, preserving the old sentinel semantics. All call sites (`VisionModule`, `Server`, `DataSocketHandler`) checked for compatibility; a test asserts remove-by-identity works and the list no longer grows after stop().

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [x] If this PR addresses a bug, a regression test for it is added