### PR TITLE
ci: make matrix-checker gate all terminal jobs, treating skips as failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -599,19 +599,11 @@ jobs:
           commands: java -jar *.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
-    # This job is the single required status check for branch protection and the
-    # overall pass/fail signal for a run. It needs every terminal job in the
-    # workflow graph, so a failure anywhere fails this check:
-    #   - Intermediate jobs (validation, build-offline-docs, build-photonlib-host,
-    #     build-photonlib-docker, build-package-*) are covered transitively: when
-    #     one of them fails, GitHub marks its dependents as 'skipped', so any
-    #     needed job that is 'skipped' (or 'cancelled') must be treated as a
-    #     failure here, not ignored.
-    #   - 'release' is the one exception: its own `if:` only lets it run on
-    #     pushes to main or v* tags of PhotonVision/photonvision, so a skipped
-    #     'release' is only an error when that condition holds (handled in the
-    #     check script below).
-    # The job name is referenced by branch protection - do not rename it.
+    # Single required status check for branch protection: it needs every terminal
+    # job, so any non-success -- including a 'skipped' caused by an upstream failure
+    # -- fails the gate. Exception: 'release' only runs on main/v* tags upstream, so
+    # a skipped 'release' off those refs is expected (handled in the script below).
+    # Do not rename this job -- branch protection references it by name.
     runs-on: ubuntu-latest
     needs:
       - build-gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,19 +154,6 @@ jobs:
         run: ./gradlew photon-targeting:build photon-core:build photon-server:build -x check
       - name: Gradle Tests and Coverage
         run: ./gradlew test jacocoTestReport --stacktrace
-      - name: Cancel on failure
-        if: failure()
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const runId = context.runId;
-
-            await github.rest.actions.cancelWorkflowRun({
-              owner,
-              repo,
-              run_id: runId
-            });
   build-offline-docs:
     name: "Build Offline Docs"
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -612,13 +612,58 @@ jobs:
           commands: java -jar *.jar --smoketest --platform=${{ matrix.plat_override }}
 
   matrix-checker:
-    # This job always runs last to set the overall result based on the matrix jobs. If any matrix job failed, this job will fail.
-    # This makes it so that we don't need to add each matrix job individually to CI checks.
+    # This job is the single required status check for branch protection and the
+    # overall pass/fail signal for a run. It needs every terminal job in the
+    # workflow graph, so a failure anywhere fails this check:
+    #   - Intermediate jobs (validation, build-offline-docs, build-photonlib-host,
+    #     build-photonlib-docker, build-package-*) are covered transitively: when
+    #     one of them fails, GitHub marks its dependents as 'skipped', so any
+    #     needed job that is 'skipped' (or 'cancelled') must be treated as a
+    #     failure here, not ignored.
+    #   - 'release' is the one exception: its own `if:` only lets it run on
+    #     pushes to main or v* tags of PhotonVision/photonvision, so a skipped
+    #     'release' is only an error when that condition holds (handled in the
+    #     check script below).
+    # The job name is referenced by branch protection - do not rename it.
     runs-on: ubuntu-latest
-    needs: [build-image]
+    needs:
+      - build-gradle
+      - playwright-tests
+      - build-photonlib-vendorjson
+      - combine
+      - build-image
+      - run-smoketest-native
+      - release
     if: always()
     steps:
-      - run: ${{!contains(needs.*.result, 'failure')}}
+      - name: Check required job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          # 'release' only runs on pushes to main or v* tags in the upstream
+          # repo (mirrors the release job's own `if:`); everywhere else a
+          # skipped 'release' is expected and must not fail the gate.
+          release_required=false
+          if [ "$GITHUB_REPOSITORY" = "PhotonVision/photonvision" ]; then
+            case "$GITHUB_REF" in
+              refs/heads/main|refs/tags/v*) release_required=true ;;
+            esac
+          fi
+
+          echo "Needed job results:"
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+
+          failed=0
+          while IFS=$'\t' read -r job result; do
+            if [ "$job" = "release" ] && [ "$result" = "skipped" ] && [ "$release_required" = "false" ]; then
+              continue
+            fi
+            if [ "$result" != "success" ]; then
+              echo "::error::Required job '$job' did not succeed (result: $result)"
+              failed=1
+            fi
+          done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | [.key, .value.result] | @tsv')
+          exit "$failed"
 
   release:
     # Require smoketest-native so that if those fail, we don't release broken artifacts


### PR DESCRIPTION
## Description

`matrix-checker` is the branch-protection gate, but it only `needs: [build-image]` and only checks for `failure` results. When an upstream job fails (e.g. `build-package-linux`), `build-image` is *skipped*, not failed — so the gate **passes while the build is broken**. It also ignored the photonlib builds, smoke tests, and combine entirely.

The gate now:
- `needs:` every terminal job (`build-gradle`, `playwright-tests`, `build-photonlib-vendorjson`, `combine`, `build-image`, `run-smoketest-native`, `release`) — intermediate jobs are covered transitively, since their failure skips a gated dependent;
- runs with `if: always()` and fails on `failure`, `cancelled`, **or** `skipped`;
- tolerates `release: skipped` only when release's own job-level condition is false (non-tag/non-main ref or fork), mirroring that condition via `$GITHUB_REF`/`$GITHUB_REPOSITORY`;
- reads `${{ toJSON(needs) }}` from an env var and iterates with jq — no expression interpolation inside shell logic.

The second commit removes the cancel-on-failure workaround from #2525: its purpose was to stop dependent jobs from reporting green-by-skip when build-gradle failed, which the gate now catches directly — and run-cancellation had the downside of marking unrelated in-flight jobs cancelled.

Scenarios walked through against the check script with mocked `needs` payloads (8/8 as expected): PR with a failed package build → gate fails (previously passed); all-green main push and fork pushes → pass; tag build with failed or failure-skipped release → fails.

## Meta

Merge checklist:
- [x] Pull Request title is a short, imperative summary of proposed changes
- [x] The description documents the _what_ and _why_
- [ ] If this PR addresses a bug, a regression test for it is added (GHA workflow logic; scenario-tested against mocked needs JSON as described)