### PR TITLE
Fix references to older JDK versions in documenation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -182,4 +182,3 @@ if token:
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence", "substitution", "attrs_inline"]
-myst_heading_anchors = 3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -182,3 +182,4 @@ if token:
 
 # MyST configuration (https://myst-parser.readthedocs.io/en/latest/configuration.html)
 myst_enable_extensions = ["colon_fence", "substitution", "attrs_inline"]
+myst_heading_anchors = 3

--- a/docs/source/docs/advanced-installation/sw_install/linux-pc.md
+++ b/docs/source/docs/advanced-installation/sw_install/linux-pc.md
@@ -8,14 +8,14 @@ You do not need to install PhotonVision on a Windows PC in order to access the w
 
 ## Installing Java
 
-PhotonVision requires a JDK installed and on the system path. JDK 17 is needed (different versions will not work). If you don't have JDK 17 already, run the following to install it:
+PhotonVision requires a JDK installed and on the system path. JDK 25 is needed (different versions will not work). If you don't have JDK 25 already, run the following to install it:
 
 ```
-$ sudo apt-get install openjdk-17-jdk
+$ sudo apt-get install openjdk-25-jdk
 ```
 
 :::{warning}
-Using a JDK other than JDK17 will cause issues when running PhotonVision and is not supported.
+Using a JDK other than JDK 25 will cause issues when running PhotonVision and is not supported.
 :::
 
 ## Downloading the Latest Stable Release of PhotonVision
@@ -23,9 +23,9 @@ Using a JDK other than JDK17 will cause issues when running PhotonVision and is 
 Go to the [GitHub releases page](https://github.com/PhotonVision/photonvision/releases) and download the relevant .jar file for your coprocessor.
 
 :::{note}
-If your coprocessor has a 64 bit ARM based CPU architecture (OrangePi, Raspberry Pi, etc.), download the LinuxArm64.jar file.
+If your coprocessor has a 64 bit ARM based CPU architecture (OrangePi, Raspberry Pi, etc.), download the linuxarm64.jar file.
 
-If your coprocessor has an 64 bit x86 based CPU architecture (Mini PC, laptop, etc.), download the Linuxx86-64.jar file.
+If your coprocessor has an 64 bit x86 based CPU architecture (Mini PC, laptop, etc.), download the linuxx86-64.jar file.
 :::
 
 :::{warning}

--- a/docs/source/docs/advanced-installation/sw_install/windows-pc.md
+++ b/docs/source/docs/advanced-installation/sw_install/windows-pc.md
@@ -12,7 +12,7 @@ Bonjour provides more stable networking when using Windows PCs. Install [Bonjour
 
 ## Installing Java
 
-PhotonVision requires a JDK installed and on the system path. **JDK 17 is needed.** You may already have it if you installed WPILib, but ensure that running `java -version` shows JDK 17. You will likely have to add WPILib's JDK to JAVA_HOME and the JDK's `bin` directory to PATH. If you do not have a JDK 17 install, [download and install it from here.](https://adoptium.net/temurin/releases?version=17)
+PhotonVision requires a JDK installed and on the system path. **Windows Users must use the JDK that ships with WPILib.** After installing WPILib, the JDK will be located in the directory where WPILib is installed. Typically this is `C:\Users\Public\wpilib\YYYY\jdk\bin` wheere YYYY is the year. Copy the full path to the JDK `\bin` directory and add it to the beginning of your PATH.
 
 ## Downloading the Latest Stable Release of PhotonVision
 
@@ -23,7 +23,7 @@ Go to the [GitHub releases page](https://github.com/PhotonVision/photonvision/re
 To run PhotonVision, open a terminal window of your choice and run the following command:
 
 ```
-> java -jar C:\path\to\photonvision\NAME OF JAR FILE GOES HERE.jar
+> java -jar C:\path\to\photonvision\photonvision-XXX.jar
 ```
 
 If your computer has a compatible webcam connected, PhotonVision should startup without any error messages. If there are error messages, your webcam isn't supported or another issue has occurred. If it is the latter, please open an issue on the [PhotonVision issues page](https://github.com/PhotonVision/photonvision/issues).

--- a/docs/source/docs/advanced-installation/sw_install/windows-pc.md
+++ b/docs/source/docs/advanced-installation/sw_install/windows-pc.md
@@ -10,6 +10,7 @@ You do not need to install PhotonVision on a Windows PC in order to access the w
 
 Bonjour provides more stable networking when using Windows PCs. Install [Bonjour here](https://support.apple.com/downloads/DL999/en_US/BonjourPSSetup.exe) before continuing to ensure a stable experience while using PhotonVision.
 
+(java-on-windows)=
 ## Installing Java
 
 PhotonVision requires a JDK installed and on the system path. **Windows Users must use the JDK that ships with WPILib.** After installing WPILib, the JDK will be located in the directory where WPILib is installed. Typically this is `C:\Users\Public\wpilib\YYYY\jdk\bin` wheere YYYY is the year. Copy the full path to the JDK `\bin` directory and add it to the beginning of your PATH.

--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -8,7 +8,7 @@ This section contains the build instructions from the source code available at [
 
 **Java Development Kit:**
 
- Building PhotonVision requires Java Development Kit (JDK) 25. *Windows Users must use the JDK that ships with WPILib.* See the [Installing Java](../advanced-installation/sw_install/windows-pc.md#installing-java) section of the Windows PC installation instructions for configuring Windows to use the WPILib JDK.
+ Building PhotonVision requires Java Development Kit (JDK) 25. *Windows Users must use the JDK that ships with WPILib.* See the {ref}`Installing Java <java-on-windows>` section of the Windows PC installation instructions for configuring Windows to use the WPILib JDK.
 
  For other platforms, you can follow the instructions to install JDK 25 for your platform [here](https://adoptium.net/temurin/releases?version=25).
 

--- a/docs/source/docs/contributing/building-photon.md
+++ b/docs/source/docs/contributing/building-photon.md
@@ -8,7 +8,9 @@ This section contains the build instructions from the source code available at [
 
 **Java Development Kit:**
 
- This project requires Java Development Kit (JDK) 25 to be compiled. This is the same Java version that comes with WPILib for 2027. **Windows Users must use the JDK that ships with WPILib.** For other platforms, you can follow the instructions to install JDK 25 for your platform [here](https://bell-sw.com/pages/downloads/#jdk-25-lts).
+ Building PhotonVision requires Java Development Kit (JDK) 25. *Windows Users must use the JDK that ships with WPILib.* See the [Installing Java](../advanced-installation/sw_install/windows-pc.md#installing-java) section of the Windows PC installation instructions for configuring Windows to use the WPILib JDK.
+
+ For other platforms, you can follow the instructions to install JDK 25 for your platform [here](https://adoptium.net/temurin/releases?version=25).
 
 **Node JS:**
 


### PR DESCRIPTION
## Description

This PR fixes references to the JDK version that weren't already updated to JDK 25. It also adds guidance for Windows users on using the WPILib-supplied JDK.


## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [x] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
