### PR TITLE
Use generic Java collections when passing data to/from UI

### DIFF
--- a/photon-client/tests/quirks.spec.ts
+++ b/photon-client/tests/quirks.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures.ts";
+
+test("Quirks should be able to be changed", async ({ page }) => {
+  await page.goto("http://localhost:5800/#/cameras");
+
+  await page.locator("div.d-flex", { has: page.locator("span", { hasText: "Arducam Model" }) }).locator("div.v-field").click();
+
+  await page.locator(".v-overlay .v-list .v-list-item", { hasText: "OV9281" }).click();
+
+  await page.locator("button", { has: page.locator("span", { hasText: "Save Changes" }) }).click();
+
+  await expect(page.locator(".v-overlay p").last()).toHaveText("Camera settings updated successfully");
+
+  await page.locator("div.d-flex", { has: page.locator("span", { hasText: "Arducam Model" }) }).locator("div.v-field").click();
+
+  await page.locator(".v-overlay .v-list .v-list-item", { hasText: "None" }).click();
+
+  await page.locator("button", { has: page.locator("span", { hasText: "Save Changes" }) }).click();
+
+  await expect(page.locator(".v-overlay p").last()).toHaveText("Camera settings updated successfully");
+});

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -215,8 +215,8 @@ public class NetworkTablesManager {
     }
 
     private void broadcastConnectedStatusImpl() {
-        HashMap<String, Object> map = new HashMap<>();
-        var subMap = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> subMap = new HashMap<>();
 
         subMap.put("connected", ntInstance.isConnected());
         if (ntInstance.isConnected()) {

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UIDataPublisher.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/websocket/UIDataPublisher.java
@@ -19,6 +19,8 @@ package org.photonvision.common.dataflow.websocket;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.photonvision.common.dataflow.CVPipelineResultConsumer;
 import org.photonvision.common.dataflow.DataChangeService;
 import org.photonvision.common.dataflow.events.OutgoingUIEvent;
@@ -46,11 +48,11 @@ public class UIDataPublisher implements CVPipelineResultConsumer {
         // only update the UI at 10hz
         if (lastUIResultUpdateTime + 1000.0 / 10.0 > now) return;
 
-        var dataMap = new HashMap<String, Object>();
+        Map<String, Object> dataMap = new HashMap<>();
         dataMap.put("sequenceID", result.sequenceID);
         dataMap.put("fps", result.fps);
         dataMap.put("latency", result.getLatencyMillis());
-        var uiTargets = new ArrayList<HashMap<String, Object>>(result.targets.size());
+        List<Map<String, Object>> uiTargets = new ArrayList<>(result.targets.size());
 
         // We don't actually need to send targets during calibration and it can take up a lot (up to
         // 1.2Mbps for 60 snapshots) of target results with no pitch/yaw/etc set
@@ -75,7 +77,7 @@ public class UIDataPublisher implements CVPipelineResultConsumer {
             dataMap.put("multitagResult", multitagData);
         }
 
-        var uiMap = new HashMap<String, HashMap<String, Object>>();
+        Map<String, Map<String, Object>> uiMap = new HashMap<>();
         uiMap.put(uniqueName, dataMap);
 
         if (result instanceof FocusPipelineResult focusResult) {

--- a/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
+++ b/photon-core/src/main/java/org/photonvision/common/logging/Logger.java
@@ -307,10 +307,10 @@ public class Logger {
     private static class UILogAppender implements LogAppender {
         @Override
         public void log(String message, LogLevel level) {
-            var messageMap = new HashMap<String, Object>();
+            Map<String, Object> messageMap = new HashMap<>();
             messageMap.put("logMessage", message);
             messageMap.put("logLevel", level.code);
-            var superMap = new HashMap<String, Object>();
+            Map<String, Object> superMap = new HashMap<>();
             superMap.put("logMessage", messageMap);
             DataChangeService.getInstance().publishEvent(OutgoingUIEvent.wrappedOf("log", superMap));
         }

--- a/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
+++ b/photon-core/src/main/java/org/photonvision/vision/pipeline/Calibrate3dPipeline.java
@@ -20,6 +20,7 @@ package org.photonvision.vision.pipeline;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.opencv.core.Mat;
 import org.opencv.core.Point;
 import org.photonvision.common.dataflow.DataChangeService;
@@ -190,7 +191,7 @@ public class Calibrate3dPipeline
     }
 
     public void broadcastState() {
-        var state =
+        Map<String, Object> state =
                 SerializationUtils.objectToHashMap(
                         new UICalibrationData(
                                 foundCornersList.size(),

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -751,7 +751,7 @@ public class VisionModule {
      *
      * @param quirksToChange map of true/false for quirks we should change
      */
-    public void changeCameraQuirks(HashMap<CameraQuirk, Boolean> quirksToChange) {
+    public void changeCameraQuirks(Map<CameraQuirk, Boolean> quirksToChange) {
         visionSource.getCameraConfiguration().cameraQuirks.updateQuirks(quirksToChange);
         visionSource.remakeSettables();
         saveAndBroadcastAll();

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -544,8 +544,8 @@ public class VisionModule {
         logger.trace("Broadcasting PSC mutation - " + propertyName + ": " + value);
         saveModule();
 
-        HashMap<String, Object> map = new HashMap<>();
-        HashMap<String, Object> subMap = new HashMap<>();
+        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> subMap = new HashMap<>();
         subMap.put(propertyName, value);
         map.put("mutatePipelineSettings", subMap);
 

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -30,6 +30,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Optional;
 import javax.imageio.ImageIO;
 import org.apache.commons.io.FileUtils;
@@ -396,7 +397,7 @@ public class RequestHandler {
 
     @Json
     record CameraSettingsRequest(
-            double fov, HashMap<CameraQuirk, Boolean> quirksToChange, String cameraUniqueName) {}
+            double fov, Map<CameraQuirk, Boolean> quirksToChange, String cameraUniqueName) {}
 
     public static void onCameraSettingsRequest(Context ctx) {
         try {
@@ -404,7 +405,7 @@ public class RequestHandler {
                     Jsonb.instance().type(CameraSettingsRequest.class).fromJson(ctx.body());
             // Extract the settings from the request
             double fov = request.fov;
-            HashMap<CameraQuirk, Boolean> quirksToChange = request.quirksToChange;
+            Map<CameraQuirk, Boolean> quirksToChange = request.quirksToChange;
             String cameraUniqueName = request.cameraUniqueName;
 
             if (cameraUniqueName == null || cameraUniqueName.isEmpty()) {

--- a/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
+++ b/photon-server/src/main/java/org/photonvision/server/RequestHandler.java
@@ -1171,7 +1171,7 @@ public class RequestHandler {
     }
 
     public static void onImageSnapshotsRequest(Context ctx) {
-        var snapshots = new ArrayList<HashMap<String, Object>>();
+        var snapshots = new ArrayList<Map<String, Object>>();
         var cameraDirs = ConfigManager.getInstance().getImageSavePath().toFile().listFiles();
 
         if (cameraDirs != null) {
@@ -1209,19 +1209,18 @@ public class RequestHandler {
 
     public static void onCameraCalibImagesRequest(Context ctx) {
         try {
-            HashMap<String, HashMap<String, ArrayList<HashMap<String, Object>>>> snapshots =
-                    new HashMap<>();
+            Map<String, Map<String, ArrayList<Map<String, Object>>>> snapshots = new HashMap<>();
 
             var cameraDirs = ConfigManager.getInstance().getCalibDir().toFile().listFiles();
             if (cameraDirs != null) {
-                var camData = new HashMap<String, ArrayList<HashMap<String, Object>>>();
+                var camData = new HashMap<String, ArrayList<Map<String, Object>>>();
                 for (var cameraDir : cameraDirs) {
                     var resolutionDirs = cameraDir.listFiles();
                     if (resolutionDirs == null) continue;
                     for (var resolutionDir : resolutionDirs) {
                         var calibImages = resolutionDir.listFiles();
                         if (calibImages == null) continue;
-                        var resolutionImages = new ArrayList<HashMap<String, Object>>();
+                        var resolutionImages = new ArrayList<Map<String, Object>>();
                         for (var calibImg : calibImages) {
                             var snapshotData = new HashMap<String, Object>();
 


### PR DESCRIPTION
## Description

The first commit fixes #2559 by requesting a `Map` instead of `HashMap` from the JSON deserialization. The second commit uses the generic `List` and `Map` types when passing data to JSON serialization, which is probably extraneous for right now, but should help ensure the correct types are used if the functions are converted to use structured data records in the future.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [x] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
