### PR TITLE
Use test mode during playwright tests

### DIFF
--- a/photon-client/playwright.config.ts
+++ b/photon-client/playwright.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: process.platform === "win32" ? "" : "./gradlew run",
+    command: process.platform === "win32" ? "" : "./gradlew run --args=-t",
     url: "http://localhost:5800",
     timeout: 300 * 1000,
     reuseExistingServer: !process.env.CI,

--- a/photon-client/src/App.vue
+++ b/photon-client/src/App.vue
@@ -27,6 +27,10 @@ if (!is_demo) {
       }
       if (data.cameraSettings !== undefined) {
         useCameraSettingsStore().updateCameraSettingsFromWebsocket(data.cameraSettings);
+        if (navigator.webdriver && useCameraSettingsStore().currentPipelineSettings.cameraGain < 0) {
+          // Manually force the gain slider to be visible for automated browsers by making gain nonnegative
+          useCameraSettingsStore().currentPipelineSettings.cameraGain = 0;
+        }
       }
       if (data.ntConnectionInfo !== undefined) {
         useStateStore().updateNTConnectionStatusFromWebsocket(data.ntConnectionInfo);

--- a/photon-client/src/App.vue
+++ b/photon-client/src/App.vue
@@ -29,6 +29,7 @@ if (!is_demo) {
         useCameraSettingsStore().updateCameraSettingsFromWebsocket(data.cameraSettings);
         if (navigator.webdriver && useCameraSettingsStore().currentPipelineSettings.cameraGain < 0) {
           // Manually force the gain slider to be visible for automated browsers by making gain nonnegative
+          // TODO: Remove this as part of completing #2563
           useCameraSettingsStore().currentPipelineSettings.cameraGain = 0;
         }
       }

--- a/photon-client/tests/input.spec.ts
+++ b/photon-client/tests/input.spec.ts
@@ -5,35 +5,37 @@ test("Camera Gain Slider won't go past max or min", async ({ page }) => {
   await page.goto("http://localhost:5800/#/dashboard");
   await page.locator("div").filter({ hasText: "Set up some cameras to get started!" }).nth(2).press("Escape");
 
+  const cameraGainInput = page.locator("div.d-flex", { has: page.locator("span", { hasText: "Camera Gain" }) }).locator("input[type=\"number\"]");
+
   // Fill in Camera Gain text field with 1000
-  await page.locator("#input-v-44").fill("1000");
-  await page.locator("#input-v-44").press("Enter");
-  await expect(page.locator("#input-v-44")).toHaveValue("100");
+  await cameraGainInput.fill("1000");
+  await cameraGainInput.press("Enter");
+  await expect(cameraGainInput).toHaveValue("100");
 
   // Try using buttons to go past the max
   await page.getByRole("button", { name: "appended action" }).nth(2).click();
-  await expect(page.locator("#input-v-44")).toHaveValue("100");
+  await expect(cameraGainInput).toHaveValue("100");
 
   // Make sure the value is actually properly limited, not just visually
   await page.getByRole("button", { name: "prepended action" }).nth(2).click();
-  await expect(page.locator("#input-v-44")).toHaveValue("99");
+  await expect(cameraGainInput).toHaveValue("99");
 
-  await page.locator("#input-v-44").fill("-10");
-  await page.locator("#input-v-44").press("Enter");
-  await expect(page.locator("#input-v-44")).toHaveValue("0");
+  await cameraGainInput.fill("-10");
+  await cameraGainInput.press("Enter");
+  await expect(cameraGainInput).toHaveValue("0");
 
   await page.getByRole("button", { name: "prepended action" }).nth(2).click();
-  await expect(page.locator("#input-v-44")).toHaveValue("0");
+  await expect(cameraGainInput).toHaveValue("0");
 
   // Make sure the value is actually properly limited, not just visually
   await page.getByRole("button", { name: "appended action" }).nth(2).click();
-  await expect(page.locator("#input-v-44")).toHaveValue("1");
+  await expect(cameraGainInput).toHaveValue("1");
 
   // Make sure that the guard actually prevents value setting, instead of just reverting the value
   // This can be ensured by making sure the Camera Gain field doesn't disappear (disappears when the value is -1)
   await page.getByRole("button", { name: "prepended action" }).nth(2).click();
   await page.getByRole("button", { name: "prepended action" }).nth(2).click();
-  await expect(page.locator("#input-v-44")).toHaveValue("0");
+  await expect(cameraGainInput).toHaveValue("0");
 
   await expect(page.getByText("Camera Gain", { exact: true })).toBeVisible();
 });

--- a/photon-client/tests/input.spec.ts
+++ b/photon-client/tests/input.spec.ts
@@ -3,7 +3,6 @@ import { test } from "./fixtures.ts";
 
 test("Camera Gain Slider won't go past max or min", async ({ page }) => {
   await page.goto("http://localhost:5800/#/dashboard");
-  await page.locator("div").filter({ hasText: "Set up some cameras to get started!" }).nth(2).press("Escape");
 
   const cameraGainInput = page.locator("div.d-flex", { has: page.locator("span", { hasText: "Camera Gain" }) }).locator("input[type=\"number\"]");
 


### PR DESCRIPTION
## Description

Test mode is enabled for playwright tests. This allows the tests to use the test mode cameras, and also has the side advantage of letting them be run on unsupported platforms. The input test was updated to not use generated ids.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
