### PR TITLE
Added frcYear to the photonlib.json.in file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ ext {
     rknnVersion = "dev-v2026.0.1-3-g14c3ecb"
     tfliteVersion = "v2027.0.2-alpha-1"
     wpilibYear = "2027_alpha5"
+    frcYear = "2027_alpha1"
     mrcalVersion = "v2027.0.2";
 
     pubVersion = versionString

--- a/photon-lib/build.gradle
+++ b/photon-lib/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'org.photonvision.tools.WpilibTools'
 
-import java.nio.file.Path
-
 ext {
     nativeName = "photonlib"
     includePhotonTargeting = true
@@ -158,6 +156,7 @@ task generateVendorJson() {
     def read = photonlibFileInput.text
             .replace('${photon_version}', pubVersion)
             .replace('${wpilib_year}', wpilibYear)
+            .replace('${frcYear}', frcYear)
     photonlibFileOutput.text = read
 
     outputs.upToDateWhen { false }

--- a/photon-lib/src/generate/photonlib.json.in
+++ b/photon-lib/src/generate/photonlib.json.in
@@ -4,6 +4,7 @@
   "version": "${photon_version}",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
   "wpilibYear": "${wpilib_year}",
+  "frcYear": "${frc_year}"
   "mavenUrls": [
     "https://maven.photonvision.org/repository/internal",
     "https://maven.photonvision.org/repository/snapshots"


### PR DESCRIPTION
Before this change, when you added a photonvision venderdep using the url provided on the docs here: https://docs.photonvision.org/en/v2025.1.1/docs/programming/photonlib/adding-vendordep.html it gave the following error on build:

> Failed to apply plugin class 'edu.wpi.first.gradlerio.wpi.WPIPlugin'.
   > Could not create an instance of type edu.wpi.first.gradlerio.wpi.WPIExtension.
      > Vendor Dependency photonlib has invalid year null. Expected to be 2027_alpha1. Reach out to the vendor to get a new version of the dependency. Attempting to modify an existing dependency will break at runtime, and will result in loss of support from the WPILib team.

I fixed this problem by adding the year number line: "frcYear": "2027_alpha1"
The other changes I made were to get this to work.

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
