### PR TITLE
Update rknn to a 2027 tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
 
     javalinVersion = "6.7.0"
     libcameraDriverVersion = "v2027.0.0-alpha-1"
-    rknnVersion = "dev-v2026.0.1-3-g14c3ecb"
+    rknnVersion = "v2027.0.0"
     tfliteVersion = "v2027.0.2-alpha-1"
     wpilibYear = "2027_alpha5"
     mrcalVersion = "v2027.0.2";


### PR DESCRIPTION
## Description

`rknn_jni` was on a 2026 snapshot tag. This updates it to a 2027 tag. (No code changes.)

## Meta

Merge checklist:
- [x] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [x] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
