### PR TITLE
Remove OpenCV version check

### DIFF
--- a/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
+++ b/photon-lib/src/main/java/org/photonvision/PhotonCamera.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import org.opencv.core.Core;
 import org.photonvision.common.hardware.VisionLEDMode;
 import org.photonvision.common.networktables.PacketSubscriber;
 import org.photonvision.targeting.PhotonPipelineResult;
@@ -184,61 +183,6 @@ public class PhotonCamera implements AutoCloseable {
 
         // HACK - start a TimeSyncServer, if we haven't yet.
         TimeSyncSingleton.load();
-
-        // HACK - check if things are compatible
-        verifyDependencies();
-    }
-
-    /** This is something we only need to check for java because of the way java packages opencv. */
-    static void verifyDependencies() {
-        // spotless:off
-        // WPILIB names their opencv version in the format YEAR-OPENCVVERSION-PATCH
-        // so we split on '-' and take the middle part to get the version number
-        if (!Core.VERSION.equals(PhotonVersion.opencvTargetVersion.split("-")[1])) {
-            String bfw = """
-
-
-
-
-                    >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\s
-                    >>> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\s
-                    >>>                                          \s
-                    >>> You are running an incompatible version  \s
-                    >>> of PhotonVision !                        \s
-                    >>>                                          \s
-                    >>> PhotonLib """
-                    + PhotonVersion.versionString
-                    + " is built for OpenCV "
-                    + PhotonVersion.opencvTargetVersion
-                    + "\n"
-                    + ">>> but you are using OpenCV "
-                    + Core.VERSION
-                    + """
-                    \n>>>                                          \s
-                    >>> This is neither tested nor supported.    \s
-                    >>> You MUST update WPILib, PhotonLib, or both.
-                    >>> Check `./gradlew dependencies` and ensure\s
-                    >>> all mentions of OpenCV match the version \s
-                    >>> that PhotonLib was built for. If you find a
-                    >>> a mismatched version in a dependency, you\s
-                    >>> must take steps to update the version of \s
-                    >>> OpenCV used in that dependency. If you do\s
-                    >>> not control that dependency and an updated\s
-                    >>> version is not available, contact the    \s
-                    >>> developers of that dependency.           \s
-                    >>>                                          \s
-                    >>> Your code will now crash.                \s
-                    >>> We hope your day gets better.            \s
-                    >>>                                          \s
-                    >>> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\s
-                    >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\s
-                    """;
-            // spotless:on
-
-            DriverStationErrors.reportWarning(bfw, false);
-            DriverStationErrors.reportError(bfw, false);
-            throw new UnsupportedOperationException(bfw);
-        }
     }
 
     /**

--- a/photon-lib/src/test/java/org/photonvision/PhotonVersionTest.java
+++ b/photon-lib/src/test/java/org/photonvision/PhotonVersionTest.java
@@ -24,7 +24,6 @@
 
 package org.photonvision;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,10 +57,5 @@ public class PhotonVersionTest {
         assertTrue(versionMatches("dev-v2021.1.6-5-gca49ea50", "v2021.1.6"));
         assertFalse(versionMatches("", "v2021.1.6"));
         assertFalse(versionMatches("v2021.1.6", ""));
-    }
-
-    @Test
-    public void testNominalDeps() {
-        assertDoesNotThrow(PhotonCamera::verifyDependencies);
     }
 }


### PR DESCRIPTION
## Description

**What changed?**

The OpenCV version check historically used to detect incorrect OpenCV libraries has been removed.

**Why?**

This code and the issue it mitigated is impossible to hit by construction (at least in non-betas due to the OpenCV version being stable, however, if the OpenCV version changes during beta for some reason, you can still hit this), due to there being only one, _year versioned_ Maven OpenCV artifact. There are no longer separate Maven artifacts per year (the year is no longer part of the group ID). This means given multiple dependencies that declare a dependency on OpenCV with differing versions, Gradle will always upgrade OpenCV to the latest version, which should typically be from GradleRIO.

## Testing

- [x] I have tested this change locally
- [x] Test evidence (screenshots, videos, or test results):

<img width="2559" height="1454" alt="image" src="https://github.com/user-attachments/assets/df9d758a-b50e-458d-bf00-9fb29587df14" />

OpenCV 2027-4.13.0-1 manually specified in build.gradle, upgraded to 2027-4.13.0-4 (from GradleRIO).

---

## AI Disclosure

- [x] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:

## Merge Checklist

- [x] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [x] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description
- [ ] **Bug fix?** Regression test is added
- [ ] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
