### PR TITLE
Use Sync instead of Copy task for copying client assets

### DIFF
--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -51,7 +51,7 @@ node {
     pnpmVersion = "11.0.9"
 }
 
-tasks.register('copyClientUIToResources', Copy) {
+tasks.register('copyClientUIToResources', Sync) {
     from "${projectDir}/../photon-client/dist/"
     into "${projectDir}/src/main/resources/web/"
 }


### PR DESCRIPTION
## Description

**What changed?**

The `copyClientUIToResources` task is now a `Sync` task instead of a `Copy` task.

**Why?**

`Sync` will remove any outdated files, preventing a slow build up of outdated client assets that are then copied into locally built JARs.

## Testing

- [x] I have tested this change locally
- [x] Test evidence (screenshots, videos, or test results):

https://github.com/user-attachments/assets/dac2e7bc-60ac-48ce-bc3b-7a5f1be1e970

---

## AI Disclosure

- [x] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:

---

## Merge Checklist

- [x] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [x] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description
- [ ] **Bug fix?** Regression test is added
- [ ] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
