### PR TITLE
Use Javalin SPA root config to enable use of HTML5 History

### DIFF
--- a/docs/source/docs/advanced-installation/sw_install/romi.md
+++ b/docs/source/docs/advanced-installation/sw_install/romi.md
@@ -39,5 +39,5 @@ In order for settings, logs, etc. to be saved / take effect, ensure that PhotonV
 :::
 
 :::{attention}
-When using an older version of PhotonVision, the user interface and features may be different than what appears in the online documentation. The [Documentation](http://10.0.0.2:5800/#/docs) link in the User Interface will open a bundled version of the documentation that matches the PhotonVision version running on your coprocessor.
+When using an older version of PhotonVision, the user interface and features may be different than what appears in the online documentation. The [Documentation](http://10.0.0.2:5800/docs) link in the User Interface will open a bundled version of the documentation that matches the PhotonVision version running on your coprocessor.
 :::

--- a/docs/source/docs/quick-start/camera-calibration.md
+++ b/docs/source/docs/quick-start/camera-calibration.md
@@ -8,7 +8,7 @@ If you’re not using cameras in 3D mode, calibration is optional, but it can st
 
 ## Print the Calibration Target
 
-- Downloaded from our [demo site](https://demo.photonvision.org/#/cameras), or directly from your coprocessors cameras tab.
+- Downloaded from our [demo site](https://demo.photonvision.org/cameras), or directly from your coprocessors cameras tab.
 - Use the ChArUco calibration board:
   - Board Type: ChAruCo
   - Tag Family: 4x4

--- a/photon-client/index.html
+++ b/photon-client/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <base href="/"/>
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Photon Client</title>

--- a/photon-client/src/router/index.ts
+++ b/photon-client/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory } from "vue-router";
+import { createRouter, createWebHistory } from "vue-router";
 
 import DashboardView from "@/views/DashboardView.vue";
 import CameraSettingsView from "@/views/CameraSettingsView.vue";
@@ -8,9 +8,7 @@ import NotFoundView from "@/views/NotFoundView.vue";
 import CameraMatchingView from "@/views/CameraMatchingView.vue";
 
 const router = createRouter({
-  // Using HTML5 History Mode is problematic with Javalin because each route is treated as a server endpoint which causes Javalin to return a 404 error before being redirected to the UI.
-  // mode: "history",
-  history: createWebHashHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: "/",

--- a/photon-client/tests/input.spec.ts
+++ b/photon-client/tests/input.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "./fixtures.ts";
 
 test("Camera Gain Slider won't go past max or min", async ({ page }) => {
-  await page.goto("http://localhost:5800/#/dashboard");
+  await page.goto("http://localhost:5800/dashboard");
 
   const cameraGainInput = page.locator("div.d-flex", { has: page.locator("span", { hasText: "Camera Gain" }) }).locator("input[type=\"number\"]");
 

--- a/photon-client/tests/platformDependent/od.spec.ts
+++ b/photon-client/tests/platformDependent/od.spec.ts
@@ -11,7 +11,7 @@ const platforms = ["LINUX_RK3588_64", "LINUX_QCS6490"];
 for (const platform of platforms) {
   test.describe(`Platform: ${platform}`, () => {
     test.beforeEach(async ({ page }) => {
-      await page.goto("/#/settings");
+      await page.goto("/settings");
       await axios.post("/override/platform", { platform: platform });
       await page.reload();
     });
@@ -45,7 +45,7 @@ for (const platform of platforms) {
 
       await page.getByRole("button", { name: "Import Object Detection Model" }).click();
 
-      await page.goto("/#/settings");
+      await page.goto("/settings");
       const tableRow = page.getByTestId("model-table").locator("tr", { hasText: fakeModelName });
 
       await expect(tableRow).toBeVisible();

--- a/photon-client/tests/quirks.spec.ts
+++ b/photon-client/tests/quirks.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "./fixtures.ts";
 
 test("Quirks should be able to be changed", async ({ page }) => {
-  await page.goto("http://localhost:5800/#/cameras");
+  await page.goto("http://localhost:5800/cameras");
 
   await page.locator("div.d-flex", { has: page.locator("span", { hasText: "Arducam Model" }) }).locator("div.v-field").click();
 

--- a/photon-server/src/main/java/org/photonvision/server/Server.java
+++ b/photon-server/src/main/java/org/photonvision/server/Server.java
@@ -62,6 +62,7 @@ public class Server {
                         javalinConfig -> {
                             javalinConfig.showJavalinBanner = false;
                             javalinConfig.staticFiles.add("web");
+                            javalinConfig.spaRoot.addFile("/", "web/index.html");
                             javalinConfig.registerPlugin(new CorsPlugin(cors -> cors.addRule(CorsRule::anyHost)));
                             javalinConfig.requestLogger.http(
                                     (ctx, ms) -> {


### PR DESCRIPTION
## Description

**What changed?**

Javalin supports SPAs like photon-client, and maps certain endpoints to an HTML page (and the router takes care of the rest).

**Why?**

This makes the URLs cleaner by removing the intermediate hash.

## Testing

- [x] I have tested this change locally
- [x] Test evidence (screenshots, videos, or test results):

Tested using #2566 to fix ICEs with MSVC.

Old:
https://github.com/user-attachments/assets/37f6df59-8fe8-45ef-94ce-a132cfa5fce2

New:
https://github.com/user-attachments/assets/05e539e0-47d8-4789-ad2f-042316bc845c

I'll note that some of the behavior has changed, like the recursive 404 page you see if docs are missing. All 404s now route to the same page, which might be undesirable in some cases, but really it only matters if you're missing the docs.

Also not shown was the behavior of using older hash-based URLs. Those are just ignored and the router just appends the hash to the end of the URL.

## Related Issues

Closes #877.

---

## AI Disclosure

- [x] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:

---

## Merge Checklist

- [x] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [x] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description
- [ ] **Bug fix?** Regression test is added
- [ ] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
