### PR TITLE
Don't include SQLite native libraries that we don't use

### DIFF
--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -44,6 +44,25 @@ shadowJar {
         project.configurations.runtimeClasspath
     ]
     mergeServiceFiles()
+    // SQLite natives that we don't use
+    exclude 'org/sqlite/native/*/x86/**'
+    exclude 'org/sqlite/native/*/armv7/**'
+    exclude 'org/sqlite/native/Linux/arm/**'
+    exclude 'org/sqlite/native/Linux/armv6/**'
+    exclude 'org/sqlite/native/Linux/ppc64/**'
+    exclude 'org/sqlite/native/Linux-Android/**'
+    exclude 'org/sqlite/native/Linux-Musl/**'
+    exclude 'org/sqlite/native/FreeBSD/**'
+    // JNA natives that we don't use
+    exclude 'com/sun/jna/*bsd*/**'
+    exclude 'com/sun/jna/*ppc*/**'
+    exclude 'com/sun/jna/*-x86/**'
+    exclude 'com/sun/jna/linux-arm*/**' // Non-aarch64 platforms only
+    exclude 'com/sun/jna/linux-loongarch64/**'
+    exclude 'com/sun/jna/linux-mips64el/**'
+    exclude 'com/sun/jna/linux-riscv64/**'
+    exclude 'com/sun/jna/linux-s390x/**'
+    exclude 'com/sun/jna/sunos*/**'
 }
 
 node {


### PR DESCRIPTION
## Description

**What changed?**

When creating the shaded server JAR, several folders for platforms supported by SQLite and JNA (used by oshi) but not PV are excluded.

**Why?**

This keeps JAR size down. This PR reduces JAR size by a little over 10 MB.

## Testing

- [x] I have tested this change locally
- [ ] Test evidence (screenshots, videos, or test results):

It started up on Windows with no errors. Not sure what else to record. I believe CI smoke tests should cover everything.

---

## AI Disclosure

- [x] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:

---

## Merge Checklist

- [x] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [x] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description
- [ ] **Bug fix?** Regression test is added
- [ ] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
