### PR TITLE
Move client assets to separate build subdirectory

### DIFF
--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -72,8 +72,9 @@ node {
 
 tasks.register('copyClientUIToResources', Sync) {
     from "${projectDir}/../photon-client/dist/"
-    into "${projectDir}/src/main/resources/web/"
+    into "${buildDir}/ui/web/"
 }
+sourceSets.main.resources.srcDir "${buildDir}/ui/"
 
 tasks.register('buildClient', PnpmTask) {
     inputs.dir fileTree(dir: "${projectDir}/../photon-client", exclude: "dist/")

--- a/photon-server/build.gradle
+++ b/photon-server/build.gradle
@@ -53,8 +53,9 @@ node {
 
 tasks.register('copyClientUIToResources', Sync) {
     from "${projectDir}/../photon-client/dist/"
-    into "${projectDir}/src/main/resources/web/"
+    into "${buildDir}/ui/web/"
 }
+sourceSets.main.resources.srcDir "${buildDir}/ui/"
 
 tasks.register('buildClient', PnpmTask) {
     inputs.dir fileTree(dir: "${projectDir}/../photon-client", exclude: "dist/")


### PR DESCRIPTION
## Description

**What changed?**

Client assets are now copied to a subdirectory under the build directory.

**Why?**

This makes it so cleans properly wipe away old client assets, and fixes an issue where the copy task overwrites the docs.

## Testing

- [x] I have tested this change locally
- [ ] Test evidence (screenshots, videos, or test results):

I have verified the CI built JAR has both docs and the client assets.

---

## AI Disclosure

- [x] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:

---

## Merge Checklist

- [x] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [x] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description
- [ ] **Bug fix?** Regression test is added
- [ ] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
