### PR TITLE
Switch from Commons CLI to picocli

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ PhotonVision uses the following additional out-of-source repositories for buildi
 PhotonVision was forked from [Chameleon Vision](https://github.com/Chameleon-Vision/chameleon-vision/). Thank you to everyone who worked on the original project.
 
 * [WPILib](https://github.com/wpilibsuite) - Specifically [allwpilib](https://github.com/wpilibsuite/allwpilib) and [their build of OpenCV](https://github.com/wpilibsuite/thirdparty-opencv).
-* [Apache Commons](https://commons.apache.org/) - Specifically [Commons IO](https://commons.apache.org/proper/commons-io/), and [Commons CLI](https://commons.apache.org/proper/commons-cli/)
+* [Apache Commons](https://commons.apache.org/) - Specifically [Commons IO](https://commons.apache.org/proper/commons-io/)
+* [picocli](https://picocli.info)
 * [diozero](https://www.diozero.com/)
 * [EJML](https://github.com/lessthanoptimal/ejml)
 * [Javalin](https://javalin.io/)

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -332,7 +332,7 @@ public class Main implements Callable<Integer> {
                     .registerLoadedConfigs(
                             ConfigManager.getInstance().getConfig().getCameraConfigurations().values());
         } else {
-            if (testModeFolder == null) {
+            if (!testModeFolder.isPresent()) {
                 addTestModeSources();
             }
         }

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-
 import org.opencv.core.Size;
 import org.photonvision.common.LoadJNI;
 import org.photonvision.common.LoadJNI.JNITypes;
@@ -58,51 +57,69 @@ import org.photonvision.vision.processes.VisionSourceManager;
 import org.photonvision.vision.target.TargetModel;
 import org.wpilib.hardware.hal.HAL;
 import org.wpilib.math.geometry.Rotation2d;
-
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-@Command(name="java -jar photonvision.jar", mixinStandardHelpOptions = true, version = PhotonVersion.versionString)
+@Command(
+        name = "java -jar photonvision.jar",
+        mixinStandardHelpOptions = true,
+        version = PhotonVersion.versionString)
 public class Main implements Callable<Integer> {
     public static final int DEFAULT_WEBPORT = 5800;
 
     private static final Logger logger = new Logger(Main.class, LogGroup.General);
 
-    @Option(names = { "-d", "--debug" }, description = "Enable debug logging prints")
+    @Option(
+            names = {"-d", "--debug"},
+            description = "Enable debug logging prints")
     private boolean debugMode;
 
-    @Option(names = { "-t", "--test-mode"}, description = "Run in test mode with 2019 and 2020 WPI field images in place of cameras")
+    @Option(
+            names = {"-t", "--test-mode"},
+            description = "Run in test mode with 2019 and 2020 WPI field images in place of cameras")
     private boolean testMode;
 
-    @Option(names = { "-f", "--folder"}, description = "Point test mode to a specific folder")
+    @Option(
+            names = {"-f", "--folder"},
+            description = "Point test mode to a specific folder")
     private Optional<Path> testModeFolder;
 
-    @Option(names = { "-n", "--disable-networking"}, description = "Disables control device network settings")
+    @Option(
+            names = {"-n", "--disable-networking"},
+            description = "Disables control device network settings")
     private boolean disableNetworking;
 
-    @Option(names = { "-c", "--clear-config"}, description = "Clears PhotonVision pipeline and networking settings. Preserves log files")
+    @Option(
+            names = {"-c", "--clear-config"},
+            description = "Clears PhotonVision pipeline and networking settings. Preserves log files")
     private boolean clearConfig;
 
-    @Option(names = { "-s", "--smoketest"}, description = "Exit Photon after loading native libraries and camera configs, but before starting up camera runners")
+    @Option(
+            names = {"-s", "--smoketest"},
+            description =
+                    "Exit Photon after loading native libraries and camera configs, but before starting up camera runners")
     private boolean smoketest;
 
-    @Option(names = { "-p", "--platform"}, description = "Specify platform override, based on Platform enum")
+    @Option(
+            names = {"-p", "--platform"},
+            description = "Specify platform override, based on Platform enum")
     private Optional<Platform> platform;
 
     private static void addTestModeSources() {
         ConfigManager.getInstance().load();
 
-        CameraConfiguration camConf2026 = ConfigManager.getInstance().getConfig().getCameraConfigurations()
-                .get("WPI2026");
+        CameraConfiguration camConf2026 =
+                ConfigManager.getInstance().getConfig().getCameraConfigurations().get("WPI2026");
         if (camConf2026 == null) {
-            camConf2026 = new CameraConfiguration(
-                    PVCameraInfo.fromFileInfo(
-                            TestUtils.getResourcesFolderPath(true)
-                                    .resolve("testimages")
-                                    .resolve(TestUtils.WPI2026Images.kBlueOutpostFuelSpread.path)
-                                    .toString(),
-                            "WPI2026"));
+            camConf2026 =
+                    new CameraConfiguration(
+                            PVCameraInfo.fromFileInfo(
+                                    TestUtils.getResourcesFolderPath(true)
+                                            .resolve("testimages")
+                                            .resolve(TestUtils.WPI2026Images.kBlueOutpostFuelSpread.path)
+                                            .toString(),
+                                    "WPI2026"));
 
             camConf2026.FOV = TestUtils.WPI2026Images.FOV.getDegrees();
 
@@ -120,9 +137,9 @@ public class Main implements Callable<Integer> {
             double fx = cx / Math.tan(fovWidth.getRadians() / 2.0);
             double fy = cy / Math.tan(fovHeight.getRadians() / 2.0);
 
-            JsonMatOfDouble testCameraMatrix = new JsonMatOfDouble(3, 3,
-                    new double[] { fx, 0, cx, 0, fy, cy, 0, 0, 1 });
-            JsonMatOfDouble testDistortion = new JsonMatOfDouble(1, 5, new double[] { 0, 0, 0, 0, 0 });
+            JsonMatOfDouble testCameraMatrix =
+                    new JsonMatOfDouble(3, 3, new double[] {fx, 0, cx, 0, fy, cy, 0, 0, 1});
+            JsonMatOfDouble testDistortion = new JsonMatOfDouble(1, 5, new double[] {0, 0, 0, 0, 0});
 
             camConf2026.calibrations.add(
                     new CameraCalibrationCoefficients(

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -81,11 +81,6 @@ public class Main implements Callable<Integer> {
     private boolean testMode;
 
     @Option(
-            names = {"-f", "--folder"},
-            description = "Point test mode to a specific folder")
-    private Optional<Path> testModeFolder;
-
-    @Option(
             names = {"-n", "--disable-networking"},
             description = "Disables control device network settings")
     private boolean disableNetworking;
@@ -220,10 +215,6 @@ public class Main implements Callable<Integer> {
 
         if (testMode) {
             logger.info("Running in test mode - Cameras will not be used");
-
-            if (testModeFolder.isPresent()) {
-                logger.info("Loading from Path " + testModeFolder.get().toAbsolutePath().toString());
-            }
         }
 
         if (disableNetworking) {
@@ -332,9 +323,7 @@ public class Main implements Callable<Integer> {
                     .registerLoadedConfigs(
                             ConfigManager.getInstance().getConfig().getCameraConfigurations().values());
         } else {
-            if (!testModeFolder.isPresent()) {
-                addTestModeSources();
-            }
+            addTestModeSources();
         }
 
         VisionSourceManager.getInstance().registerTimedTasks();

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -184,7 +184,7 @@ public class Main implements Callable<Integer> {
     }
 
     @Override
-    public Integer call() throws Exception {
+    public Integer call() {
         var logLevel = debugMode ? LogLevel.TRACE : LogLevel.DEBUG;
         Logger.setLevel(LogGroup.Camera, logLevel);
         Logger.setLevel(LogGroup.WebServer, logLevel);
@@ -252,7 +252,7 @@ public class Main implements Callable<Integer> {
 
         if (!HAL.initialize(500, 0)) {
             logger.error("Failed to initialize the HAL! Giving up :(");
-            System.exit(1);
+            return 1;
         }
 
         if (Platform.isRaspberryPi()) {
@@ -307,7 +307,7 @@ public class Main implements Callable<Integer> {
 
         if (smoketest) {
             logger.info("PhotonVision base functionality loaded -- smoketest complete");
-            System.exit(0);
+            return 0;
         }
 
         logger.debug("Loading SystemMonitor...");
@@ -315,8 +315,7 @@ public class Main implements Callable<Integer> {
         SystemMonitor.getInstance().startMonitor(500, 1000);
 
         // todo - should test mode just add test mode sources, but still allow local usb
-        // cameras to be
-        // added?
+        // cameras to be added?
         if (!testMode) {
             logger.debug("Loading VisionSourceManager...");
             VisionSourceManager.getInstance()

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -22,7 +22,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.commons.cli.*;
+import java.util.concurrent.Callable;
+
 import org.opencv.core.Size;
 import org.photonvision.common.LoadJNI;
 import org.photonvision.common.LoadJNI.JNITypes;
@@ -58,105 +59,50 @@ import org.photonvision.vision.target.TargetModel;
 import org.wpilib.hardware.hal.HAL;
 import org.wpilib.math.geometry.Rotation2d;
 
-public class Main {
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name="java -jar photonvision.jar", mixinStandardHelpOptions = true, version = PhotonVersion.versionString)
+public class Main implements Callable<Integer> {
     public static final int DEFAULT_WEBPORT = 5800;
 
     private static final Logger logger = new Logger(Main.class, LogGroup.General);
 
-    private static boolean isTestMode = false;
-    private static boolean isSmoketest = false;
-    private static Path testModeFolder = null;
-    private static boolean printDebugLogs;
+    @Option(names = { "-d", "--debug" }, description = "Enable debug logging prints")
+    private boolean debugMode;
 
-    private static boolean handleArgs(String[] args) throws ParseException {
-        final var options = new Options();
-        options.addOption("d", "debug", false, "Enable debug logging prints");
-        options.addOption("h", "help", false, "Show this help text and exit");
-        options.addOption(
-                "t",
-                "test-mode",
-                false,
-                "Run in test mode with 2019 and 2020 WPI field images in place of cameras");
+    @Option(names = { "-t", "--test-mode"}, description = "Run in test mode with 2019 and 2020 WPI field images in place of cameras")
+    private boolean testMode;
 
-        options.addOption("f", "folder", true, "Point test mode to a specific folder");
-        options.addOption("n", "disable-networking", false, "Disables control device network settings");
-        options.addOption(
-                "c",
-                "clear-config",
-                false,
-                "Clears PhotonVision pipeline and networking settings. Preserves log files");
-        options.addOption(
-                "s",
-                "smoketest",
-                false,
-                "Exit Photon after loading native libraries and camera configs, but before starting up camera runners");
-        options.addOption("p", "platform", true, "Specify platform override, based on Platform enum");
+    @Option(names = { "-f", "--folder"}, description = "Point test mode to a specific folder")
+    private Optional<Path> testModeFolder;
 
-        CommandLineParser parser = new DefaultParser();
-        CommandLine cmd = parser.parse(options, args);
+    @Option(names = { "-n", "--disable-networking"}, description = "Disables control device network settings")
+    private boolean disableNetworking;
 
-        if (cmd.hasOption("help")) {
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp("java -jar photonvision.jar [options]", options);
-            return false; // exit program
-        } else {
-            if (cmd.hasOption("debug")) {
-                printDebugLogs = true;
-                logger.info("Enabled debug logging");
-            }
+    @Option(names = { "-c", "--clear-config"}, description = "Clears PhotonVision pipeline and networking settings. Preserves log files")
+    private boolean clearConfig;
 
-            if (cmd.hasOption("test-mode")) {
-                isTestMode = true;
-                logger.info("Running in test mode - Cameras will not be used");
+    @Option(names = { "-s", "--smoketest"}, description = "Exit Photon after loading native libraries and camera configs, but before starting up camera runners")
+    private boolean smoketest;
 
-                if (cmd.hasOption("path")) {
-                    Path p = Path.of(System.getProperty("PATH_PREFIX", "") + cmd.getOptionValue("path"));
-                    logger.info("Loading from Path " + p.toAbsolutePath().toString());
-                    testModeFolder = p;
-                }
-            }
-
-            if (cmd.hasOption("disable-networking")) {
-                NetworkManager.getInstance().networkingIsDisabled = true;
-            }
-
-            if (cmd.hasOption("clear-config")) {
-                ConfigManager.getInstance().clearConfig();
-            }
-
-            if (cmd.hasOption("smoketest")) {
-                isSmoketest = true;
-            }
-
-            if (cmd.hasOption("platform")) {
-                String platStr = cmd.getOptionValue("platform");
-                try {
-                    Platform plat = Platform.valueOf(platStr);
-                    Platform.overridePlatform(plat);
-                    logger.info("Overrode platform to: " + plat);
-                } catch (IllegalArgumentException e) {
-                    logger.error("Invalid platform override: " + platStr);
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
+    @Option(names = { "-p", "--platform"}, description = "Specify platform override, based on Platform enum")
+    private Optional<Platform> platform;
 
     private static void addTestModeSources() {
         ConfigManager.getInstance().load();
 
-        CameraConfiguration camConf2026 =
-                ConfigManager.getInstance().getConfig().getCameraConfigurations().get("WPI2026");
+        CameraConfiguration camConf2026 = ConfigManager.getInstance().getConfig().getCameraConfigurations()
+                .get("WPI2026");
         if (camConf2026 == null) {
-            camConf2026 =
-                    new CameraConfiguration(
-                            PVCameraInfo.fromFileInfo(
-                                    TestUtils.getResourcesFolderPath(true)
-                                            .resolve("testimages")
-                                            .resolve(TestUtils.WPI2026Images.kBlueOutpostFuelSpread.path)
-                                            .toString(),
-                                    "WPI2026"));
+            camConf2026 = new CameraConfiguration(
+                    PVCameraInfo.fromFileInfo(
+                            TestUtils.getResourcesFolderPath(true)
+                                    .resolve("testimages")
+                                    .resolve(TestUtils.WPI2026Images.kBlueOutpostFuelSpread.path)
+                                    .toString(),
+                            "WPI2026"));
 
             camConf2026.FOV = TestUtils.WPI2026Images.FOV.getDegrees();
 
@@ -174,9 +120,9 @@ public class Main {
             double fx = cx / Math.tan(fovWidth.getRadians() / 2.0);
             double fy = cy / Math.tan(fovHeight.getRadians() / 2.0);
 
-            JsonMatOfDouble testCameraMatrix =
-                    new JsonMatOfDouble(3, 3, new double[] {fx, 0, cx, 0, fy, cy, 0, 0, 1});
-            JsonMatOfDouble testDistortion = new JsonMatOfDouble(1, 5, new double[] {0, 0, 0, 0, 0});
+            JsonMatOfDouble testCameraMatrix = new JsonMatOfDouble(3, 3,
+                    new double[] { fx, 0, cx, 0, fy, cy, 0, 0, 1 });
+            JsonMatOfDouble testDistortion = new JsonMatOfDouble(1, 5, new double[] { 0, 0, 0, 0, 0 });
 
             camConf2026.calibrations.add(
                     new CameraCalibrationCoefficients(
@@ -213,20 +159,21 @@ public class Main {
         VisionSourceManager.getInstance().registerLoadedConfigs(cameraConfigs);
     }
 
-    private static void tryLoadJNI(JNITypes type) {
+    private void tryLoadJNI(JNITypes type) {
         try {
             LoadJNI.forceLoad(type);
             logger.info("Loaded " + type.name() + "-JNI");
         } catch (IOException e) {
             logger.error("Failed to load " + type.name() + "-JNI!", e);
-            if (isSmoketest) {
+            if (smoketest) {
                 System.exit(1);
             }
         }
     }
 
-    public static void main(String[] args) {
-        var logLevel = printDebugLogs ? LogLevel.TRACE : LogLevel.DEBUG;
+    @Override
+    public Integer call() throws Exception {
+        var logLevel = debugMode ? LogLevel.TRACE : LogLevel.DEBUG;
         Logger.setLevel(LogGroup.Camera, logLevel);
         Logger.setLevel(LogGroup.WebServer, logLevel);
         Logger.setLevel(LogGroup.VisionModule, logLevel);
@@ -250,19 +197,36 @@ public class Main {
             logger.info("PhotonVision image version: unknown");
         }
 
-        try {
-            if (!handleArgs(args)) {
-                System.exit(1);
+        if (debugMode) {
+            logger.info("Enabled debug logging");
+        }
+
+        if (testMode) {
+            logger.info("Running in test mode - Cameras will not be used");
+
+            if (testModeFolder.isPresent()) {
+                logger.info("Loading from Path " + testModeFolder.get().toAbsolutePath().toString());
             }
-        } catch (ParseException e) {
-            logger.error("Failed to parse command-line options!", e);
+        }
+
+        if (disableNetworking) {
+            NetworkManager.getInstance().networkingIsDisabled = true;
+        }
+
+        if (clearConfig) {
+            ConfigManager.getInstance().clearConfig();
+        }
+
+        if (platform.isPresent()) {
+            Platform.overridePlatform(platform.get());
+            logger.info("Overrode platform to: " + platform);
         }
 
         // We don't want to trigger an exit in test mode or smoke test. This is
         // specifically for MacOS.
-        if (!(Platform.isSupported() || isSmoketest || isTestMode)) {
+        if (!(Platform.isSupported() || smoketest || testMode)) {
             logger.error("This platform is unsupported!");
-            System.exit(1);
+            return 1;
         }
 
         try {
@@ -270,11 +234,11 @@ public class Main {
 
             if (!success) {
                 logger.error("Failed to load native libraries! Giving up :(");
-                System.exit(1);
+                return 1;
             }
         } catch (Exception e) {
             logger.error("Failed to load native libraries!", e);
-            System.exit(1);
+            return 1;
         }
         logger.info("WPILib and photon-targeting JNI libraries loaded.");
 
@@ -333,7 +297,7 @@ public class Main {
         // Force load the hardware manager
         HardwareManager.getInstance();
 
-        if (isSmoketest) {
+        if (smoketest) {
             logger.info("PhotonVision base functionality loaded -- smoketest complete");
             System.exit(0);
         }
@@ -342,9 +306,10 @@ public class Main {
         SystemMonitor.getInstance().logSystemInformation();
         SystemMonitor.getInstance().startMonitor(500, 1000);
 
-        // todo - should test mode just add test mode sources, but still allow local usb cameras to be
+        // todo - should test mode just add test mode sources, but still allow local usb
+        // cameras to be
         // added?
-        if (!isTestMode) {
+        if (!testMode) {
             logger.debug("Loading VisionSourceManager...");
             VisionSourceManager.getInstance()
                     .registerLoadedConfigs(
@@ -360,5 +325,13 @@ public class Main {
         logger.info("Starting server...");
         HardwareManager.getInstance().setError(Optional.empty());
         Server.initialize(DEFAULT_WEBPORT);
+        return -1; // Don't exit, the server is running
+    }
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new Main()).execute(args);
+        if (exitCode >= 0) {
+            System.exit(exitCode);
+        }
     }
 }

--- a/shared/common.gradle
+++ b/shared/common.gradle
@@ -43,7 +43,8 @@ dependencies {
     implementation group: "us.hebi.quickbuf", name: "quickbuf-runtime", version: quickbufVersion;
 
     implementation "commons-io:commons-io:2.11.0"
-    implementation "commons-cli:commons-cli:1.5.0"
+
+    implementation "info.picocli:picocli:4.7.7"
 
     testImplementation(platform('org.junit:junit-bom:5.11.4'))
     testImplementation 'org.junit.jupiter:junit-jupiter-api'


### PR DESCRIPTION
## Description

**What changed?**

This replaces the server's argument parser from Apache Commons CLI to picocli. As a side effect, there is also now a `--version` flag that operates similarly to `--help`.

Main still behaves the same way -- it will return early, since javalin app:start [does not block](https://javalin.io/documentation#server-setup), and the JVM will not exit until all non-daemon threads have terminated. 

**Why?**

Picocli has better type safety and supports subcommands. Also annotations are cool

## Testing

- [x] I have tested this change locally
- [ ] Test evidence (screenshots, videos, or test results):

## Related Issues

N/A

---

## AI Disclosure

- [x] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:

Describe AI involvement here if applicable

---

## Merge Checklist

- [x] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [x] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description
- [ ] **Bug fix?** Regression test is added
- [x] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
