### PR TITLE
Update images to v2027.2.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_VERSION: v2027.1.1
+  IMAGE_VERSION: v2027.2.1
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,38 +510,43 @@ jobs:
             plat_override: LINUX_RK3588_64
             image_name: photonvision_opi5.img.xz
             minimum_free_mb: 1024
-          - os: ubuntu-24.04-arm
-            image_suffix: orangepi5_armbian
-            plat_override: LINUX_RK3588_64
-            image_name: photonvision_opi5_armbian.img.xz
             root_location: 'partition=1'
-            minimum_free_mb: 1024
             shrink_image: 'no'
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5b
             plat_override: LINUX_RK3588_64
             image_name: photonvision_opi5b.img.xz
             minimum_free_mb: 1024
+            root_location: 'partition=1'
+            shrink_image: 'no'
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5plus
             plat_override: LINUX_RK3588_64
             image_name: photonvision_opi5plus.img.xz
             minimum_free_mb: 1024
+            root_location: 'partition=1'
+            shrink_image: 'no'
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5pro
             plat_override: LINUX_RK3588_64
             image_name: photonvision_opi5pro.img.xz
             minimum_free_mb: 1024
+            root_location: 'partition=1'
+            shrink_image: 'no'
           - os: ubuntu-24.04-arm
             image_suffix: orangepi5max
             plat_override: LINUX_RK3588_64
             image_name: photonvision_opi5max.img.xz
             minimum_free_mb: 1024
+            root_location: 'partition=1'
+            shrink_image: 'no'
           - os: ubuntu-24.04-arm
             image_suffix: rock5c
             plat_override: LINUX_RK3588_64
             image_name: photonvision_rock5c.img.xz
             minimum_free_mb: 1024
+            root_location: 'partition=1'
+            shrink_image: 'no'
           - os: ubuntu-24.04-arm
             image_suffix: rubikpi3
             cache: 'yes'


### PR DESCRIPTION
## Description

**What changed?**
This PR updates `build.yml` to use the v2027.2.1 custom images.

**Why?**

v2027.2.1 of the custom images includes Ubuntu 26.04 on RubikPi3 and Debian Trixie on the RK3588 (OrangePi5 & Rock-5c). These are the images that we hope to provide for 2027 season and this update supports testing them during the beta phase.

## Testing

- [ ] I have tested this change locally
- [ ] Test evidence (screenshots, videos, or test results):

Paste screenshots or video links here

## Related Issues

Closes #<!-- issue number -->

---

## AI Disclosure

- [X] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:

Describe AI involvement here if applicable

---

## Merge Checklist

- [X] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [X] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description and migrations are marked with `// MIGRATION: <dataYear>` where `<dataYear>` is the last season the pre-migration data was used in
- [ ] **Bug fix?** Regression test is added
- [ ] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
