### PR TITLE
Fix tag size for c++ on-rio

### DIFF
--- a/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
@@ -246,10 +246,10 @@ PhotonPoseEstimator::EstimateClosestToReferencePose(
 std::optional<std::array<cv::Point3d, 4>> detail::CalcTagCorners(
     int tagID, const wpi::apriltag::AprilTagFieldLayout& aprilTags) {
   if (auto tagPose = aprilTags.GetTagPose(tagID); tagPose.has_value()) {
-    return std::array{TagCornerToObjectPoint(-3.5_in, -3.5_in, *tagPose),
-                      TagCornerToObjectPoint(+3.5_in, -3.5_in, *tagPose),
-                      TagCornerToObjectPoint(+3.5_in, +3.5_in, *tagPose),
-                      TagCornerToObjectPoint(-3.5_in, +3.5_in, *tagPose)};
+    return std::array{TagCornerToObjectPoint(-3.25_in, -3.25_in, *tagPose),
+                      TagCornerToObjectPoint(+3.25_in, -3.25_in, *tagPose),
+                      TagCornerToObjectPoint(+3.25_in, +3.25_in, *tagPose),
+                      TagCornerToObjectPoint(-3.25_in, +3.25_in, *tagPose)};
   } else {
     return std::nullopt;
   }

--- a/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
+++ b/photon-lib/src/main/native/cpp/photon/PhotonPoseEstimator.cpp
@@ -246,10 +246,10 @@ PhotonPoseEstimator::EstimateClosestToReferencePose(
 std::optional<std::array<cv::Point3d, 4>> detail::CalcTagCorners(
     int tagID, const wpi::apriltag::AprilTagFieldLayout& aprilTags) {
   if (auto tagPose = aprilTags.GetTagPose(tagID); tagPose.has_value()) {
-    return std::array{TagCornerToObjectPoint(-3_in, -3_in, *tagPose),
-                      TagCornerToObjectPoint(+3_in, -3_in, *tagPose),
-                      TagCornerToObjectPoint(+3_in, +3_in, *tagPose),
-                      TagCornerToObjectPoint(-3_in, +3_in, *tagPose)};
+    return std::array{TagCornerToObjectPoint(-3.5_in, -3.5_in, *tagPose),
+                      TagCornerToObjectPoint(+3.5_in, -3.5_in, *tagPose),
+                      TagCornerToObjectPoint(+3.5_in, +3.5_in, *tagPose),
+                      TagCornerToObjectPoint(-3.5_in, +3.5_in, *tagPose)};
   } else {
     return std::nullopt;
   }


### PR DESCRIPTION
Worth noting that it would be nice to have a way to grab this from the config, but alas WPILib doesn't really have any support for that.

**Why?**

When tags went from 16h5 to 36h11, this never got updated.

## Related Issues

Closes #2583

---

## AI Disclosure

- [x] This PR was authored entirely by me
- [ ] This PR includes AI-generated code (e.g., from GitHub Copilot, ChatGPT)
  - [ ] If yes, I have reviewed all AI-generated code for correctness
  - [ ] If yes, please describe which parts were AI-assisted:


---

## Merge Checklist

- [x] PR title is a [short, imperative summary](https://cbea.ms/git-commit/) of changes
- [x] PR description documents the *what* and *why*


### Additional Checks (if applicable)

- [ ] **User-facing changes?** User documentation is updated
- [ ] **Breaking changes?** Migration guide is included in description and migrations are marked with `// MIGRATION: <dataYear>` where `<dataYear>` is the last season the pre-migration data was used in
- [ ] **Bug fix?** Regression test is added
- [ ] **New dependency?** License compatibility is verified and steps have been taken to follow it
- [ ] **Serde changes?** All messages are regenerated with no unexpected hash changes
- [ ] **Configuration changes?** Changes are backwards compatible with previous season's last release
- [ ] **Pipeline/data exchange changes?** Frontend types are updated in `./photon-client/src/types`
