### PR TITLE
Fix typos in log message and comment (occured, seperately)

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/TimeSyncManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/TimeSyncManager.java
@@ -58,7 +58,7 @@ public class TimeSyncManager {
         m_client = new TimeSyncClient("127.0.0.1", 5810, 1.0);
     }
 
-    // Since we're spinning off tasks in a new thread, be careful and start it seperately
+    // Since we're spinning off tasks in a new thread, be careful and start it separately
     public void start() {
         TimedTaskManager.getInstance().addTask("TimeSyncManager::tick", this::tick, 1000);
     }

--- a/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
+++ b/photon-core/src/main/java/org/photonvision/common/networking/NetworkUtils.java
@@ -123,7 +123,7 @@ public class NetworkUtils {
                 }
 
             } catch (IOException e) {
-                logger.error("IO Exception occured when calling nmcli to get network interfaces!", e);
+                logger.error("IO Exception occurred when calling nmcli to get network interfaces!", e);
             } catch (InterruptedException e) {
                 logger.error("Interrupted while waiting for NetworkManager", e);
             }


### PR DESCRIPTION
Two spelling fixes:

- `NetworkUtils.java`: log message "IO Exception occured" -> "occurred"
- `TimeSyncManager.java`: comment "start it seperately" -> "separately"

No behaviour change - comments and log text only.